### PR TITLE
feat(deploy): widget story deploy

### DIFF
--- a/.github/workflows/widgetbook-deploy.yml
+++ b/.github/workflows/widgetbook-deploy.yml
@@ -4,15 +4,13 @@
 name: 📚 Deploy Widgetbook to GitHub Pages
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - develop
     paths:
       - 'widgetbook_kit/**'
-      - 'packages/**'
+      - 'packages/**'      
       - '.github/workflows/widgetbook-deploy.yml'
-  workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -29,7 +27,7 @@ concurrency:
 jobs:
   # Build job
   build:
-    name: Build Widgetbook
+    name: Build Widgetbook (hexaMobileShare)
     runs-on: ubuntu-latest
     # Only run on merged PRs or manual workflow dispatch
     if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true)
@@ -37,6 +35,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: develop
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -65,7 +65,7 @@ jobs:
 
   # Deployment job
   deploy:
-    name: Deploy to GitHub Pages
+    name: Deploy to GitHub Pages (hexaMobileShare)
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Widgetbook story deployment with pr push to develop branch

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [ ] Packages (packages/*)
- [ ] Widgetbook Kit (widgetbook_kit/)
- [x] Documentation (docs/)
- [x] CI / Infra (.github/)

---

This pull request updates the deployment workflow for Widgetbook, changing how and when the GitHub Pages deployment is triggered and clarifying job naming conventions. The main theme is improving the automation and clarity of the deployment process.

**Workflow trigger and job naming changes:**

* The workflow is now triggered by pushes to the `develop` branch that affect relevant files, instead of only running on closed pull requests or manual dispatch. This ensures deployments happen automatically when changes are merged to develop.
* The build and deploy job names have been updated to include `(hexaMobileShare)`, making it clear which project the workflow is for. [[1]](diffhunk://#diff-e3eb2b8b1394abda0f3b971c81129d7d46a5e2dee87336e367bc6d2fd0cb1d8cL32-R39) [[2]](diffhunk://#diff-e3eb2b8b1394abda0f3b971c81129d7d46a5e2dee87336e367bc6d2fd0cb1d8cL68-R68)
* The build job now explicitly checks out the `develop` branch, ensuring the correct code is built and deployed.
