### PR TITLE
feat(deploy): widget story deploy

### DIFF
--- a/.github/workflows/widgetbook-deploy.yml
+++ b/.github/workflows/widgetbook-deploy.yml
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 
 name: 📚 Deploy Widgetbook to GitHub Pages
-
 on:
   push:
     branches:
@@ -11,58 +10,45 @@ on:
       - 'widgetbook_kit/**'
       - 'packages/**'      
       - '.github/workflows/widgetbook-deploy.yml'
-
+  workflow_dispatch:
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
-
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
-
 jobs:
   # Build job
   build:
     name: Build Widgetbook (hexaMobileShare)
     runs-on: ubuntu-latest
-    # Only run on merged PRs or manual workflow dispatch
-    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true)
     timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: develop
-
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.x'
           channel: 'stable'
           cache: true
-
       - name: Install Melos
         run: dart pub global activate melos
-
       - name: Bootstrap packages
         run: melos bootstrap
-
       - name: Build Widgetbook for web
         working-directory: widgetbook_kit
         run: flutter build web --release --base-href "/hexaMobileShare/"
-
       - name: Setup Pages
         uses: actions/configure-pages@v5
-
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: widgetbook_kit/build/web
-
   # Deployment job
   deploy:
     name: Deploy to GitHub Pages (hexaMobileShare)
@@ -75,7 +61,6 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-
       - name: Deployment summary
         run: |
           echo "### 🎉 Widgetbook Deployment Successful!" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Widgetbook story deployment with pr push to develop branch with fix

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [ ] Packages (packages/*)
- [ ] Widgetbook Kit (widgetbook_kit/)
- [ ] Documentation (docs/)
- [x] CI / Infra (.github/)

---

This pull request updates the GitHub Actions workflow for deploying Widgetbook to GitHub Pages. The main change is enabling manual workflow dispatch, allowing the deployment to be triggered manually in addition to the existing automatic triggers. Several workflow steps and conditions have also been cleaned up for clarity and maintainability.

**Workflow improvements:**

* Added `workflow_dispatch` to the `on:` section, allowing manual triggering of the deployment workflow.
* Removed the conditional check for merged pull requests, simplifying the job trigger logic.

**Workflow step cleanup:**

* Removed unnecessary `ref: develop` from the checkout step and other redundant step configurations for a cleaner workflow.
* Cleaned up extra newlines and comments throughout the workflow file for improved readability. [[1]](diffhunk://#diff-e3eb2b8b1394abda0f3b971c81129d7d46a5e2dee87336e367bc6d2fd0cb1d8cL5) [[2]](diffhunk://#diff-e3eb2b8b1394abda0f3b971c81129d7d46a5e2dee87336e367bc6d2fd0cb1d8cL78)