### PR TITLE
feat(core-kit): add AppOutlinedButton wrapper and Widgetbook stories

### DIFF
--- a/packages/core_kit/lib/widgets/buttons/app_outlined_button.dart
+++ b/packages/core_kit/lib/widgets/buttons/app_outlined_button.dart
@@ -1,6 +1,35 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppOutlinedButton {
-  const AppOutlinedButton();
+import 'package:flutter/material.dart';
+import 'package:core_kit/widgets/buttons/app_button.dart';
+
+/// A convenience wrapper that delegates to AppButton.outlined().
+/// Use for secondary actions requiring an outlined style.
+class AppOutlinedButton extends StatelessWidget {
+  final String label;
+  final VoidCallback? onPressed;
+  final IconData? icon;
+  final bool fullWidth;
+  final bool isLoading;
+
+  const AppOutlinedButton({
+    required this.label,
+    this.onPressed,
+    this.icon,
+    this.fullWidth = false,
+    this.isLoading = false,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AppButton.outlined(
+      label: label,
+      onPressed: onPressed,
+      icon: icon,
+      fullWidth: fullWidth,
+      isLoading: isLoading,
+    );
+  }
 }

--- a/widgetbook_kit/lib/stories/core_kit/widgets/buttons/app_outlined_button_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/buttons/app_outlined_button_stories.dart
@@ -1,2 +1,116 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/widgets/buttons/app_outlined_button.dart';
+import 'package:core_kit/widgets/buttons/app_button.dart';
+
+// ...existing code...
+@widgetbook.UseCase(name: 'Default', type: AppOutlinedButton)
+Widget appOutlinedButtonDefault(BuildContext context) {
+  return Center(
+    child: AppOutlinedButton(
+      label: context.knobs.string(label: 'Label', initialValue: 'Button'),
+      onPressed: () {},
+    ),
+  );
+}
+
+// ...existing code...
+@widgetbook.UseCase(name: 'With Icon', type: AppOutlinedButton)
+Widget appOutlinedButtonWithIcon(BuildContext context) {
+  return Center(
+    child: AppOutlinedButton(
+      icon: Icons.download,
+      label: context.knobs.string(label: 'Label', initialValue: 'Download'),
+      onPressed: () {},
+    ),
+  );
+}
+
+// ...existing code...
+@widgetbook.UseCase(name: 'States', type: AppOutlinedButton)
+Widget appOutlinedButtonStates(BuildContext context) {
+  final label = context.knobs.string(label: 'Label', initialValue: 'Submit');
+  return Column(
+    mainAxisAlignment: MainAxisAlignment.center,
+    children: [
+      AppOutlinedButton(label: '$label (enabled)', onPressed: () {}),
+      const SizedBox(height: 12),
+      const AppOutlinedButton(label: 'Disabled'),
+      const SizedBox(height: 12),
+      const AppOutlinedButton(label: 'Loading', isLoading: true),
+      const SizedBox(height: 12),
+      AppOutlinedButton(label: 'Hover/Pressed demo', onPressed: () {}),
+    ],
+  );
+}
+
+// ...existing code...
+@widgetbook.UseCase(name: 'Sizes', type: AppOutlinedButton)
+Widget appOutlinedButtonSizes(BuildContext context) {
+  final longText = context.knobs.boolean(
+    label: 'Use long text',
+    initialValue: true,
+  );
+  return Padding(
+    padding: const EdgeInsets.all(16),
+    child: Column(
+      children: [
+        AppOutlinedButton(
+          label: longText
+              ? 'This is a very long button label to test wrapping and overflow'
+              : 'Normal',
+          onPressed: () {},
+        ),
+        const SizedBox(height: 12),
+        const AppOutlinedButton(label: 'Full width', fullWidth: true),
+      ],
+    ),
+  );
+}
+
+// ...existing code...
+@widgetbook.UseCase(name: 'Theme Variations', type: AppOutlinedButton)
+Widget appOutlinedButtonTheme(BuildContext context) {
+  final dark = context.knobs.boolean(label: 'Dark mode', initialValue: false);
+  final toggledTheme = dark
+      ? ThemeData.from(colorScheme: const ColorScheme.dark())
+      : ThemeData.from(colorScheme: const ColorScheme.light());
+
+  return Theme(
+    data: toggledTheme,
+    child: Center(
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: const [
+          AppOutlinedButton(label: 'Outlined'),
+          SizedBox(width: 12),
+          AppButton.filled(label: 'Filled'),
+        ],
+      ),
+    ),
+  );
+}
+
+// ...existing code...
+@widgetbook.UseCase(name: 'Comparison', type: AppOutlinedButton)
+Widget appOutlinedButtonComparison(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16),
+    child: Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: const [
+        AppButton.text(label: 'Text'),
+        SizedBox(width: 12),
+        AppOutlinedButton(label: 'Outlined'),
+        SizedBox(width: 12),
+        AppButton.filled(label: 'Filled'),
+      ],
+    ),
+  );
+}
+
+// ...existing code...


### PR DESCRIPTION
# Pull Request


---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Packages (packages/*)
- [x] Widgetbook Kit (widgetbook_kit/)
- [ ] Documentation (docs/)
- [ ] CI / Infra (.github/)

---


- [✅] My branch name follows format: <type>/<short-description> (e.g., feat/login-screen)
- [✅] My PR title starts with one of the approved types listed above
- [✅] My Dart code is formatted (dart format . or flutter format .)
- [✅] I ran static analysis (flutter analyze) and resolved warnings
- [✅] I ran tests successfully (flutter test)
- [✅] I updated / checked pubspec.yaml and pubspec.lock for dependency changes
- [✅] For UI changes, I added screenshots and/or updated golden tests (if applicable)
- [✅] I linked related issues using keywords like Closes #42
- [✅] I ensured this PR has no unrelated changes
- [✅] This PR is ready for review and does not include unfinished work

---

Closes #14 

---

This pull request introduces a new reusable widget, `AppOutlinedButton`, for the core UI kit and adds comprehensive Widgetbook stories to showcase its usage, states, and variations. The changes enhance both the UI component library and its documentation, making it easier for developers to implement and test outlined buttons in various scenarios.

**New UI component:**
* Added a new `AppOutlinedButton` widget as a convenience wrapper around `AppButton.outlined`, supporting label, icon, loading state, full width, and disabled state. (`packages/core_kit/lib/widgets/buttons/app_outlined_button.dart`)

**Widgetbook stories and documentation:**
* Added multiple Widgetbook use cases for `AppOutlinedButton`, demonstrating default usage, icon support, different states (enabled, disabled, loading), size variations, theme variations (light/dark), and direct comparison with other button styles. (`widgetbook_kit/lib/stories/core_kit/widgets/buttons/app_outlined_button_stories.dart`)