### PR TITLE
feat(core_kit): implement AppIconButton and add Widgetbook stories

### DIFF
--- a/packages/core_kit/lib/widgets/buttons/app_icon_button.dart
+++ b/packages/core_kit/lib/widgets/buttons/app_icon_button.dart
@@ -1,6 +1,189 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppIconButton {
-  const AppIconButton();
+import 'package:flutter/material.dart';
+
+/// AppIconButton: MD3-compliant icon-only button with variants and accessibility.
+class AppIconButton extends StatelessWidget {
+  /// Standard icon button (no background).
+  const AppIconButton({
+    super.key,
+    required this.icon,
+    required this.tooltip,
+    this.onPressed,
+    this.iconSize = 24.0,
+    this.color,
+    this.padding,
+    this.style,
+    this.isSelected = false,
+  }) : _variant = _AppIconButtonVariant.standard;
+
+  /// Filled icon button (primary emphasis).
+  const AppIconButton.filled({
+    super.key,
+    required this.icon,
+    required this.tooltip,
+    this.onPressed,
+    this.iconSize = 24.0,
+    this.color,
+    this.padding,
+    this.style,
+    this.isSelected = false,
+  }) : _variant = _AppIconButtonVariant.filled;
+
+  /// Filled tonal icon button (secondary/tonal emphasis).
+  const AppIconButton.filledTonal({
+    super.key,
+    required this.icon,
+    required this.tooltip,
+    this.onPressed,
+    this.iconSize = 24.0,
+    this.color,
+    this.padding,
+    this.style,
+    this.isSelected = false,
+  }) : _variant = _AppIconButtonVariant.filledTonal;
+
+  /// Outlined icon button (medium emphasis, with border).
+  const AppIconButton.outlined({
+    super.key,
+    required this.icon,
+    required this.tooltip,
+    this.onPressed,
+    this.iconSize = 24.0,
+    this.color,
+    this.padding,
+    this.style,
+    this.isSelected = false,
+  }) : _variant = _AppIconButtonVariant.outlined;
+
+  final IconData icon;
+  final VoidCallback? onPressed;
+  final String tooltip;
+  final double? iconSize;
+  final Color? color;
+  final EdgeInsetsGeometry? padding;
+  final ButtonStyle? style;
+  final bool isSelected;
+
+  final _AppIconButtonVariant _variant;
+
+  @override
+  Widget build(BuildContext context) {
+    // MD3: minimum 48x48dp touch target even if visually smaller.
+    final Widget child = _buildVariantButton(context);
+
+    return Semantics(
+      button: true,
+      selected: isSelected,
+      enabled: onPressed != null,
+      label: tooltip,
+      child: SizedBox(
+        width: 48,
+        height: 48,
+        child: child,
+      ),
+    );
+  }
+
+  Widget _buildVariantButton(BuildContext context) {
+    final ColorScheme cs = Theme.of(context).colorScheme;
+
+    // Icon color defaults per variant using MD3 tokens.
+    final Color? defaultIconColor = switch (_variant) {
+      _AppIconButtonVariant.standard => cs.onSurfaceVariant,
+      _AppIconButtonVariant.filled => cs.onPrimary,
+      _AppIconButtonVariant.filledTonal => cs.onSecondaryContainer,
+      _AppIconButtonVariant.outlined => cs.onSurfaceVariant,
+    };
+
+    final ButtonStyle baseStyle = switch (_variant) {
+      _AppIconButtonVariant.standard => const ButtonStyle(),
+      _AppIconButtonVariant.filled => ButtonStyle(
+          backgroundColor: WidgetStateProperty.resolveWith((states) {
+            if (states.contains(WidgetState.disabled)) {
+              return cs.onSurface.withOpacity(0.12);
+            }
+            return cs.primary;
+          }),
+        ),
+      _AppIconButtonVariant.filledTonal => ButtonStyle(
+          backgroundColor: WidgetStateProperty.resolveWith((states) {
+            if (states.contains(WidgetState.disabled)) {
+              return cs.onSurface.withOpacity(0.12);
+            }
+            return cs.secondaryContainer;
+          }),
+        ),
+      _AppIconButtonVariant.outlined => ButtonStyle(
+          side: WidgetStateProperty.resolveWith((states) {
+            final Color outline = cs.outline;
+            final Color disabledOutline = outline.withOpacity(0.12);
+            return BorderSide(
+              color: states.contains(WidgetState.disabled)
+                  ? disabledOutline
+                  : outline,
+            );
+          }),
+        ),
+    };
+
+    final ButtonStyle mergedStyle = baseStyle.merge(style);
+
+    final EdgeInsetsGeometry effectivePadding =
+        padding ?? const EdgeInsets.all(12); // 48 container with 24 icon
+
+    final Icon iconWidget = Icon(
+      icon,
+      size: iconSize ?? 24.0,
+      color: color ?? defaultIconColor,
+    );
+
+    // Toggle visual hint.
+    final Icon effectiveIcon = isSelected
+        ? Icon(
+            iconWidget.icon,
+            size: iconWidget.size,
+            color: (color ?? defaultIconColor)?.withOpacity(1.0),
+          )
+        : iconWidget;
+
+    // Choose base IconButton class by variant for MD3 behavior.
+    return switch (_variant) {
+      _AppIconButtonVariant.standard => IconButton(
+          icon: effectiveIcon,
+          tooltip: tooltip,
+          isSelected: isSelected,
+          onPressed: onPressed,
+          style: mergedStyle,
+          padding: effectivePadding,
+        ),
+      _AppIconButtonVariant.filled => IconButton.filled(
+          icon: effectiveIcon,
+          tooltip: tooltip,
+          isSelected: isSelected,
+          onPressed: onPressed,
+          style: mergedStyle,
+          padding: effectivePadding,
+        ),
+      _AppIconButtonVariant.filledTonal => IconButton.filledTonal(
+          icon: effectiveIcon,
+          tooltip: tooltip,
+          isSelected: isSelected,
+          onPressed: onPressed,
+          style: mergedStyle,
+          padding: effectivePadding,
+        ),
+      _AppIconButtonVariant.outlined => IconButton.outlined(
+          icon: effectiveIcon,
+          tooltip: tooltip,
+          isSelected: isSelected,
+          onPressed: onPressed,
+          style: mergedStyle,
+          padding: effectivePadding,
+        ),
+    };
+  }
 }
+
+enum _AppIconButtonVariant { standard, filled, filledTonal, outlined }

--- a/packages/core_kit/lib/widgets/buttons/app_icon_button.dart
+++ b/packages/core_kit/lib/widgets/buttons/app_icon_button.dart
@@ -60,7 +60,7 @@ class AppIconButton extends StatelessWidget {
   final IconData icon;
   final VoidCallback? onPressed;
   final String tooltip;
-  final double? iconSize;
+  final double iconSize;
   final Color? color;
   final EdgeInsetsGeometry? padding;
   final ButtonStyle? style;
@@ -78,11 +78,7 @@ class AppIconButton extends StatelessWidget {
       selected: isSelected,
       enabled: onPressed != null,
       label: tooltip,
-      child: SizedBox(
-        width: 48,
-        height: 48,
-        child: child,
-      ),
+      child: SizedBox(width: 48, height: 48, child: child),
     );
   }
 
@@ -90,7 +86,7 @@ class AppIconButton extends StatelessWidget {
     final ColorScheme cs = Theme.of(context).colorScheme;
 
     // Icon color defaults per variant using MD3 tokens.
-    final Color? defaultIconColor = switch (_variant) {
+    final Color defaultIconColor = switch (_variant) {
       _AppIconButtonVariant.standard => cs.onSurfaceVariant,
       _AppIconButtonVariant.filled => cs.onPrimary,
       _AppIconButtonVariant.filledTonal => cs.onSecondaryContainer,
@@ -100,32 +96,32 @@ class AppIconButton extends StatelessWidget {
     final ButtonStyle baseStyle = switch (_variant) {
       _AppIconButtonVariant.standard => const ButtonStyle(),
       _AppIconButtonVariant.filled => ButtonStyle(
-          backgroundColor: WidgetStateProperty.resolveWith((states) {
-            if (states.contains(WidgetState.disabled)) {
-              return cs.onSurface.withOpacity(0.12);
-            }
-            return cs.primary;
-          }),
-        ),
+        backgroundColor: WidgetStateProperty.resolveWith((states) {
+          if (states.contains(WidgetState.disabled)) {
+            return cs.onSurface.withValues(alpha: 0.12);
+          }
+          return cs.primary;
+        }),
+      ),
       _AppIconButtonVariant.filledTonal => ButtonStyle(
-          backgroundColor: WidgetStateProperty.resolveWith((states) {
-            if (states.contains(WidgetState.disabled)) {
-              return cs.onSurface.withOpacity(0.12);
-            }
-            return cs.secondaryContainer;
-          }),
-        ),
+        backgroundColor: WidgetStateProperty.resolveWith((states) {
+          if (states.contains(WidgetState.disabled)) {
+            return cs.onSurface.withValues(alpha: 0.12);
+          }
+          return cs.secondaryContainer;
+        }),
+      ),
       _AppIconButtonVariant.outlined => ButtonStyle(
-          side: WidgetStateProperty.resolveWith((states) {
-            final Color outline = cs.outline;
-            final Color disabledOutline = outline.withOpacity(0.12);
-            return BorderSide(
-              color: states.contains(WidgetState.disabled)
-                  ? disabledOutline
-                  : outline,
-            );
-          }),
-        ),
+        side: WidgetStateProperty.resolveWith((states) {
+          final Color outline = cs.outline;
+          final Color disabledOutline = outline.withValues(alpha: 0.12);
+          return BorderSide(
+            color: states.contains(WidgetState.disabled)
+                ? disabledOutline
+                : outline,
+          );
+        }),
+      ),
     };
 
     final ButtonStyle mergedStyle = baseStyle.merge(style);
@@ -135,7 +131,7 @@ class AppIconButton extends StatelessWidget {
 
     final Icon iconWidget = Icon(
       icon,
-      size: iconSize ?? 24.0,
+      size: iconSize,
       color: color ?? defaultIconColor,
     );
 
@@ -144,44 +140,44 @@ class AppIconButton extends StatelessWidget {
         ? Icon(
             iconWidget.icon,
             size: iconWidget.size,
-            color: (color ?? defaultIconColor)?.withOpacity(1.0),
+            color: (color ?? defaultIconColor).withValues(alpha: 1.0),
           )
         : iconWidget;
 
     // Choose base IconButton class by variant for MD3 behavior.
     return switch (_variant) {
       _AppIconButtonVariant.standard => IconButton(
-          icon: effectiveIcon,
-          tooltip: tooltip,
-          isSelected: isSelected,
-          onPressed: onPressed,
-          style: mergedStyle,
-          padding: effectivePadding,
-        ),
+        icon: effectiveIcon,
+        tooltip: tooltip,
+        isSelected: isSelected,
+        onPressed: onPressed,
+        style: mergedStyle,
+        padding: effectivePadding,
+      ),
       _AppIconButtonVariant.filled => IconButton.filled(
-          icon: effectiveIcon,
-          tooltip: tooltip,
-          isSelected: isSelected,
-          onPressed: onPressed,
-          style: mergedStyle,
-          padding: effectivePadding,
-        ),
+        icon: effectiveIcon,
+        tooltip: tooltip,
+        isSelected: isSelected,
+        onPressed: onPressed,
+        style: mergedStyle,
+        padding: effectivePadding,
+      ),
       _AppIconButtonVariant.filledTonal => IconButton.filledTonal(
-          icon: effectiveIcon,
-          tooltip: tooltip,
-          isSelected: isSelected,
-          onPressed: onPressed,
-          style: mergedStyle,
-          padding: effectivePadding,
-        ),
+        icon: effectiveIcon,
+        tooltip: tooltip,
+        isSelected: isSelected,
+        onPressed: onPressed,
+        style: mergedStyle,
+        padding: effectivePadding,
+      ),
       _AppIconButtonVariant.outlined => IconButton.outlined(
-          icon: effectiveIcon,
-          tooltip: tooltip,
-          isSelected: isSelected,
-          onPressed: onPressed,
-          style: mergedStyle,
-          padding: effectivePadding,
-        ),
+        icon: effectiveIcon,
+        tooltip: tooltip,
+        isSelected: isSelected,
+        onPressed: onPressed,
+        style: mergedStyle,
+        padding: effectivePadding,
+      ),
     };
   }
 }

--- a/widgetbook_kit/lib/stories/core_kit/widgets/buttons/app_icon_button_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/buttons/app_icon_button_stories.dart
@@ -7,201 +7,295 @@ import 'package:core_kit/widgets/buttons/app_icon_button.dart';
 
 @widgetbook.UseCase(name: 'Default', type: AppIconButton)
 Widget appIconButtonDefault(BuildContext context) {
-	return Center(
-		child: AppIconButton(
-			icon: context.knobs.list(
-				label: 'Icon',
-				options: const [Icons.search, Icons.menu, Icons.favorite, Icons.share],
-				labelBuilder: (icon) => icon.toString(),
-			),
-			onPressed: () {},
-			tooltip: context.knobs.string(label: 'Tooltip', initialValue: 'Action'),
-		),
-	);
+  return Center(
+    child: AppIconButton(
+      icon: context.knobs.object.dropdown(
+        label: 'Icon',
+        options: const [Icons.search, Icons.menu, Icons.favorite, Icons.share],
+        labelBuilder: (icon) => icon.toString(),
+      ),
+      onPressed: () {},
+      tooltip: context.knobs.string(label: 'Tooltip', initialValue: 'Action'),
+    ),
+  );
 }
 
 @widgetbook.UseCase(name: 'All Variants', type: AppIconButton)
 Widget appIconButtonAllVariants(BuildContext context) {
-	const icon = Icons.search;
-	return Row(
-		mainAxisAlignment: MainAxisAlignment.center,
-		children: [
-			AppIconButton(icon: icon, tooltip: 'Standard', onPressed: () {}),
-			const SizedBox(width: 16),
-			AppIconButton.filled(icon: icon, tooltip: 'Filled', onPressed: () {}),
-			const SizedBox(width: 16),
-			AppIconButton.filledTonal(icon: icon, tooltip: 'Filled Tonal', onPressed: () {}),
-			const SizedBox(width: 16),
-			AppIconButton.outlined(icon: icon, tooltip: 'Outlined', onPressed: () {}),
-		],
-	);
+  const icon = Icons.search;
+  return Row(
+    mainAxisAlignment: MainAxisAlignment.center,
+    children: [
+      AppIconButton(icon: icon, tooltip: 'Standard', onPressed: () {}),
+      const SizedBox(width: 16),
+      AppIconButton.filled(icon: icon, tooltip: 'Filled', onPressed: () {}),
+      const SizedBox(width: 16),
+      AppIconButton.filledTonal(
+        icon: icon,
+        tooltip: 'Filled Tonal',
+        onPressed: () {},
+      ),
+      const SizedBox(width: 16),
+      AppIconButton.outlined(icon: icon, tooltip: 'Outlined', onPressed: () {}),
+    ],
+  );
 }
 
 @widgetbook.UseCase(name: 'Common Icons', type: AppIconButton)
 Widget appIconButtonCommonIcons(BuildContext context) {
-	Widget group(String title, List<IconData> icons) => Column(
-				crossAxisAlignment: CrossAxisAlignment.start,
-				children: [
-					Text(title),
-					const SizedBox(height: 8),
-					Wrap(
-						spacing: 12,
-						runSpacing: 12,
-						children: icons
-								.map((i) => AppIconButton(icon: i, tooltip: title, onPressed: () {}))
-								.toList(),
-					),
-				],
-			);
+  Widget group(String title, List<IconData> icons) => Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Text(title),
+      const SizedBox(height: 8),
+      Wrap(
+        spacing: 12,
+        runSpacing: 12,
+        children: icons
+            .map(
+              (i) => AppIconButton(icon: i, tooltip: title, onPressed: () {}),
+            )
+            .toList(),
+      ),
+    ],
+  );
 
-	return SingleChildScrollView(
-		padding: const EdgeInsets.all(16),
-		child: Column(
-			children: [
-				group('Navigation', const [Icons.arrow_back, Icons.close, Icons.menu, Icons.more_vert]),
-				const SizedBox(height: 16),
-				group('Actions', const [Icons.search, Icons.filter_list, Icons.settings, Icons.refresh]),
-				const SizedBox(height: 16),
-				group('Content', const [Icons.favorite_border, Icons.share, Icons.bookmark_border, Icons.edit]),
-				const SizedBox(height: 16),
-				group('Media', const [Icons.play_arrow, Icons.pause, Icons.skip_next, Icons.volume_up]),
-			],
-		),
-	);
+  return SingleChildScrollView(
+    padding: const EdgeInsets.all(16),
+    child: Column(
+      children: [
+        group('Navigation', const [
+          Icons.arrow_back,
+          Icons.close,
+          Icons.menu,
+          Icons.more_vert,
+        ]),
+        const SizedBox(height: 16),
+        group('Actions', const [
+          Icons.search,
+          Icons.filter_list,
+          Icons.settings,
+          Icons.refresh,
+        ]),
+        const SizedBox(height: 16),
+        group('Content', const [
+          Icons.favorite_border,
+          Icons.share,
+          Icons.bookmark_border,
+          Icons.edit,
+        ]),
+        const SizedBox(height: 16),
+        group('Media', const [
+          Icons.play_arrow,
+          Icons.pause,
+          Icons.skip_next,
+          Icons.volume_up,
+        ]),
+      ],
+    ),
+  );
 }
 
 @widgetbook.UseCase(name: 'States', type: AppIconButton)
 Widget appIconButtonStates(BuildContext context) {
-	return Row(
-		mainAxisAlignment: MainAxisAlignment.center,
-		children: [
-			AppIconButton(icon: Icons.favorite_border, tooltip: 'Enabled', onPressed: () {}),
-			const SizedBox(width: 16),
-			const AppIconButton(icon: Icons.delete, tooltip: 'Disabled', onPressed: null),
-			const SizedBox(width: 16),
-			AppIconButton(icon: Icons.favorite, tooltip: 'Selected', onPressed: () {}, isSelected: true),
-		],
-	);
+  return Row(
+    mainAxisAlignment: MainAxisAlignment.center,
+    children: [
+      AppIconButton(
+        icon: Icons.favorite_border,
+        tooltip: 'Enabled',
+        onPressed: () {},
+      ),
+      const SizedBox(width: 16),
+      const AppIconButton(
+        icon: Icons.delete,
+        tooltip: 'Disabled',
+        onPressed: null,
+      ),
+      const SizedBox(width: 16),
+      AppIconButton(
+        icon: Icons.favorite,
+        tooltip: 'Selected',
+        onPressed: () {},
+        isSelected: true,
+      ),
+    ],
+  );
 }
 
 @widgetbook.UseCase(name: 'Sizes', type: AppIconButton)
 Widget appIconButtonSizes(BuildContext context) {
-	return Row(
-		mainAxisAlignment: MainAxisAlignment.center,
-		children: [
-			AppIconButton(icon: Icons.search, tooltip: 'Small', onPressed: () {}, iconSize: 20),
-			const SizedBox(width: 16),
-			AppIconButton(icon: Icons.search, tooltip: 'Default', onPressed: () {}, iconSize: 24),
-			const SizedBox(width: 16),
-			AppIconButton(icon: Icons.search, tooltip: 'Large', onPressed: () {}, iconSize: 32),
-		],
-	);
+  return Row(
+    mainAxisAlignment: MainAxisAlignment.center,
+    children: [
+      AppIconButton(
+        icon: Icons.search,
+        tooltip: 'Small',
+        onPressed: () {},
+        iconSize: 20,
+      ),
+      const SizedBox(width: 16),
+      AppIconButton(
+        icon: Icons.search,
+        tooltip: 'Default',
+        onPressed: () {},
+        iconSize: 24,
+      ),
+      const SizedBox(width: 16),
+      AppIconButton(
+        icon: Icons.search,
+        tooltip: 'Large',
+        onPressed: () {},
+        iconSize: 32,
+      ),
+    ],
+  );
 }
 
 @widgetbook.UseCase(name: 'Toggle Button', type: AppIconButton)
 Widget appIconButtonToggle(BuildContext context) {
-	final selected = context.knobs.boolean(label: 'Selected', initialValue: false);
-	return Row(
-		mainAxisAlignment: MainAxisAlignment.center,
-		children: [
-			AppIconButton(
-				icon: selected ? Icons.favorite : Icons.favorite_border,
-				tooltip: 'Favorite',
-				isSelected: selected,
-				onPressed: () {},
-			),
-			const SizedBox(width: 16),
-			AppIconButton(
-				icon: selected ? Icons.bookmark : Icons.bookmark_border,
-				tooltip: 'Bookmark',
-				isSelected: selected,
-				onPressed: () {},
-			),
-			const SizedBox(width: 16),
-			AppIconButton(
-				icon: selected ? Icons.visibility : Icons.visibility_off,
-				tooltip: 'Visibility',
-				isSelected: selected,
-				onPressed: () {},
-			),
-		],
-	);
+  final selected = context.knobs.boolean(
+    label: 'Selected',
+    initialValue: false,
+  );
+  return Row(
+    mainAxisAlignment: MainAxisAlignment.center,
+    children: [
+      AppIconButton(
+        icon: selected ? Icons.favorite : Icons.favorite_border,
+        tooltip: 'Favorite',
+        isSelected: selected,
+        onPressed: () {},
+      ),
+      const SizedBox(width: 16),
+      AppIconButton(
+        icon: selected ? Icons.bookmark : Icons.bookmark_border,
+        tooltip: 'Bookmark',
+        isSelected: selected,
+        onPressed: () {},
+      ),
+      const SizedBox(width: 16),
+      AppIconButton(
+        icon: selected ? Icons.visibility : Icons.visibility_off,
+        tooltip: 'Visibility',
+        isSelected: selected,
+        onPressed: () {},
+      ),
+    ],
+  );
 }
 
 @widgetbook.UseCase(name: 'Theme Variations', type: AppIconButton)
 Widget appIconButtonTheme(BuildContext context) {
-	final dark = context.knobs.boolean(label: 'Dark mode', initialValue: false);
-	final colorOverride = context.knobs.color(label: 'Custom icon color');
-	final ThemeData theme = dark ? ThemeData.dark(useMaterial3: true) : ThemeData.light(useMaterial3: true);
+  final dark = context.knobs.boolean(label: 'Dark mode', initialValue: false);
+  final colorOverride = context.knobs.color(label: 'Custom icon color');
+  final ThemeData theme = dark
+      ? ThemeData.dark(useMaterial3: true)
+      : ThemeData.light(useMaterial3: true);
 
-	return Theme(
-		data: theme,
-		child: Row(
-			mainAxisAlignment: MainAxisAlignment.center,
-			children: [
-				AppIconButton(icon: Icons.settings, tooltip: 'Standard', onPressed: () {}, color: colorOverride),
-				const SizedBox(width: 16),
-				AppIconButton.filled(icon: Icons.toggle_on, tooltip: 'Filled', onPressed: () {}, color: colorOverride),
-				const SizedBox(width: 16),
-				AppIconButton.filledTonal(icon: Icons.toggle_on, tooltip: 'Tonal', onPressed: () {}, color: colorOverride),
-				const SizedBox(width: 16),
-				AppIconButton.outlined(icon: Icons.tune, tooltip: 'Outlined', onPressed: () {}, color: colorOverride),
-			],
-		),
-	);
+  return Theme(
+    data: theme,
+    child: Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        AppIconButton(
+          icon: Icons.settings,
+          tooltip: 'Standard',
+          onPressed: () {},
+          color: colorOverride,
+        ),
+        const SizedBox(width: 16),
+        AppIconButton.filled(
+          icon: Icons.toggle_on,
+          tooltip: 'Filled',
+          onPressed: () {},
+          color: colorOverride,
+        ),
+        const SizedBox(width: 16),
+        AppIconButton.filledTonal(
+          icon: Icons.toggle_on,
+          tooltip: 'Tonal',
+          onPressed: () {},
+          color: colorOverride,
+        ),
+        const SizedBox(width: 16),
+        AppIconButton.outlined(
+          icon: Icons.tune,
+          tooltip: 'Outlined',
+          onPressed: () {},
+          color: colorOverride,
+        ),
+      ],
+    ),
+  );
 }
 
 @widgetbook.UseCase(name: 'Interactive Playground', type: AppIconButton)
 Widget appIconButtonPlayground(BuildContext context) {
-		final variant = context.knobs.list(
-			label: 'Variant',
-			options: const ['standard', 'filled', 'filledTonal', 'outlined'],
-			labelBuilder: (v) => v,
-		);
-	final enabled = context.knobs.boolean(label: 'Enabled', initialValue: true);
-	final selected = context.knobs.boolean(label: 'Selected', initialValue: false);
-	final size = context.knobs.double.slider(label: 'Icon size', initialValue: 24, min: 16, max: 40);
-	final color = context.knobs.color(label: 'Icon color');
-	final icon = context.knobs.list(
-		label: 'Icon',
-		options: const [Icons.search, Icons.menu, Icons.favorite, Icons.share, Icons.edit, Icons.delete],
-		labelBuilder: (icon) => icon.toString(),
-	);
+  final variant = context.knobs.object.dropdown(
+    label: 'Variant',
+    options: const ['standard', 'filled', 'filledTonal', 'outlined'],
+    labelBuilder: (v) => v,
+  );
+  final enabled = context.knobs.boolean(label: 'Enabled', initialValue: true);
+  final selected = context.knobs.boolean(
+    label: 'Selected',
+    initialValue: false,
+  );
+  final size = context.knobs.double.slider(
+    label: 'Icon size',
+    initialValue: 24,
+    min: 16,
+    max: 40,
+  );
+  final color = context.knobs.color(label: 'Icon color');
+  final icon = context.knobs.object.dropdown(
+    label: 'Icon',
+    options: const [
+      Icons.search,
+      Icons.menu,
+      Icons.favorite,
+      Icons.share,
+      Icons.edit,
+      Icons.delete,
+    ],
+    labelBuilder: (icon) => icon.toString(),
+  );
 
-	AppIconButton build() => switch (variant) {
-				'filled' => AppIconButton.filled(
-						icon: icon,
-						tooltip: 'Playground',
-						onPressed: enabled ? () {} : null,
-						isSelected: selected,
-						iconSize: size,
-						color: color,
-					),
-				'filledTonal' => AppIconButton.filledTonal(
-						icon: icon,
-						tooltip: 'Playground',
-						onPressed: enabled ? () {} : null,
-						isSelected: selected,
-						iconSize: size,
-						color: color,
-					),
-				'outlined' => AppIconButton.outlined(
-						icon: icon,
-						tooltip: 'Playground',
-						onPressed: enabled ? () {} : null,
-						isSelected: selected,
-						iconSize: size,
-						color: color,
-					),
-				_ => AppIconButton(
-						icon: icon,
-						tooltip: 'Playground',
-						onPressed: enabled ? () {} : null,
-						isSelected: selected,
-						iconSize: size,
-						color: color,
-					),
-			};
+  AppIconButton build() => switch (variant) {
+    'filled' => AppIconButton.filled(
+      icon: icon,
+      tooltip: 'Playground',
+      onPressed: enabled ? () {} : null,
+      isSelected: selected,
+      iconSize: size,
+      color: color,
+    ),
+    'filledTonal' => AppIconButton.filledTonal(
+      icon: icon,
+      tooltip: 'Playground',
+      onPressed: enabled ? () {} : null,
+      isSelected: selected,
+      iconSize: size,
+      color: color,
+    ),
+    'outlined' => AppIconButton.outlined(
+      icon: icon,
+      tooltip: 'Playground',
+      onPressed: enabled ? () {} : null,
+      isSelected: selected,
+      iconSize: size,
+      color: color,
+    ),
+    _ => AppIconButton(
+      icon: icon,
+      tooltip: 'Playground',
+      onPressed: enabled ? () {} : null,
+      isSelected: selected,
+      iconSize: size,
+      color: color,
+    ),
+  };
 
-	return Center(child: build());
+  return Center(child: build());
 }

--- a/widgetbook_kit/lib/stories/core_kit/widgets/buttons/app_icon_button_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/buttons/app_icon_button_stories.dart
@@ -1,2 +1,207 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/widgets/buttons/app_icon_button.dart';
+
+@widgetbook.UseCase(name: 'Default', type: AppIconButton)
+Widget appIconButtonDefault(BuildContext context) {
+	return Center(
+		child: AppIconButton(
+			icon: context.knobs.list(
+				label: 'Icon',
+				options: const [Icons.search, Icons.menu, Icons.favorite, Icons.share],
+				labelBuilder: (icon) => icon.toString(),
+			),
+			onPressed: () {},
+			tooltip: context.knobs.string(label: 'Tooltip', initialValue: 'Action'),
+		),
+	);
+}
+
+@widgetbook.UseCase(name: 'All Variants', type: AppIconButton)
+Widget appIconButtonAllVariants(BuildContext context) {
+	const icon = Icons.search;
+	return Row(
+		mainAxisAlignment: MainAxisAlignment.center,
+		children: [
+			AppIconButton(icon: icon, tooltip: 'Standard', onPressed: () {}),
+			const SizedBox(width: 16),
+			AppIconButton.filled(icon: icon, tooltip: 'Filled', onPressed: () {}),
+			const SizedBox(width: 16),
+			AppIconButton.filledTonal(icon: icon, tooltip: 'Filled Tonal', onPressed: () {}),
+			const SizedBox(width: 16),
+			AppIconButton.outlined(icon: icon, tooltip: 'Outlined', onPressed: () {}),
+		],
+	);
+}
+
+@widgetbook.UseCase(name: 'Common Icons', type: AppIconButton)
+Widget appIconButtonCommonIcons(BuildContext context) {
+	Widget group(String title, List<IconData> icons) => Column(
+				crossAxisAlignment: CrossAxisAlignment.start,
+				children: [
+					Text(title),
+					const SizedBox(height: 8),
+					Wrap(
+						spacing: 12,
+						runSpacing: 12,
+						children: icons
+								.map((i) => AppIconButton(icon: i, tooltip: title, onPressed: () {}))
+								.toList(),
+					),
+				],
+			);
+
+	return SingleChildScrollView(
+		padding: const EdgeInsets.all(16),
+		child: Column(
+			children: [
+				group('Navigation', const [Icons.arrow_back, Icons.close, Icons.menu, Icons.more_vert]),
+				const SizedBox(height: 16),
+				group('Actions', const [Icons.search, Icons.filter_list, Icons.settings, Icons.refresh]),
+				const SizedBox(height: 16),
+				group('Content', const [Icons.favorite_border, Icons.share, Icons.bookmark_border, Icons.edit]),
+				const SizedBox(height: 16),
+				group('Media', const [Icons.play_arrow, Icons.pause, Icons.skip_next, Icons.volume_up]),
+			],
+		),
+	);
+}
+
+@widgetbook.UseCase(name: 'States', type: AppIconButton)
+Widget appIconButtonStates(BuildContext context) {
+	return Row(
+		mainAxisAlignment: MainAxisAlignment.center,
+		children: [
+			AppIconButton(icon: Icons.favorite_border, tooltip: 'Enabled', onPressed: () {}),
+			const SizedBox(width: 16),
+			const AppIconButton(icon: Icons.delete, tooltip: 'Disabled', onPressed: null),
+			const SizedBox(width: 16),
+			AppIconButton(icon: Icons.favorite, tooltip: 'Selected', onPressed: () {}, isSelected: true),
+		],
+	);
+}
+
+@widgetbook.UseCase(name: 'Sizes', type: AppIconButton)
+Widget appIconButtonSizes(BuildContext context) {
+	return Row(
+		mainAxisAlignment: MainAxisAlignment.center,
+		children: [
+			AppIconButton(icon: Icons.search, tooltip: 'Small', onPressed: () {}, iconSize: 20),
+			const SizedBox(width: 16),
+			AppIconButton(icon: Icons.search, tooltip: 'Default', onPressed: () {}, iconSize: 24),
+			const SizedBox(width: 16),
+			AppIconButton(icon: Icons.search, tooltip: 'Large', onPressed: () {}, iconSize: 32),
+		],
+	);
+}
+
+@widgetbook.UseCase(name: 'Toggle Button', type: AppIconButton)
+Widget appIconButtonToggle(BuildContext context) {
+	final selected = context.knobs.boolean(label: 'Selected', initialValue: false);
+	return Row(
+		mainAxisAlignment: MainAxisAlignment.center,
+		children: [
+			AppIconButton(
+				icon: selected ? Icons.favorite : Icons.favorite_border,
+				tooltip: 'Favorite',
+				isSelected: selected,
+				onPressed: () {},
+			),
+			const SizedBox(width: 16),
+			AppIconButton(
+				icon: selected ? Icons.bookmark : Icons.bookmark_border,
+				tooltip: 'Bookmark',
+				isSelected: selected,
+				onPressed: () {},
+			),
+			const SizedBox(width: 16),
+			AppIconButton(
+				icon: selected ? Icons.visibility : Icons.visibility_off,
+				tooltip: 'Visibility',
+				isSelected: selected,
+				onPressed: () {},
+			),
+		],
+	);
+}
+
+@widgetbook.UseCase(name: 'Theme Variations', type: AppIconButton)
+Widget appIconButtonTheme(BuildContext context) {
+	final dark = context.knobs.boolean(label: 'Dark mode', initialValue: false);
+	final colorOverride = context.knobs.color(label: 'Custom icon color');
+	final ThemeData theme = dark ? ThemeData.dark(useMaterial3: true) : ThemeData.light(useMaterial3: true);
+
+	return Theme(
+		data: theme,
+		child: Row(
+			mainAxisAlignment: MainAxisAlignment.center,
+			children: [
+				AppIconButton(icon: Icons.settings, tooltip: 'Standard', onPressed: () {}, color: colorOverride),
+				const SizedBox(width: 16),
+				AppIconButton.filled(icon: Icons.toggle_on, tooltip: 'Filled', onPressed: () {}, color: colorOverride),
+				const SizedBox(width: 16),
+				AppIconButton.filledTonal(icon: Icons.toggle_on, tooltip: 'Tonal', onPressed: () {}, color: colorOverride),
+				const SizedBox(width: 16),
+				AppIconButton.outlined(icon: Icons.tune, tooltip: 'Outlined', onPressed: () {}, color: colorOverride),
+			],
+		),
+	);
+}
+
+@widgetbook.UseCase(name: 'Interactive Playground', type: AppIconButton)
+Widget appIconButtonPlayground(BuildContext context) {
+		final variant = context.knobs.list(
+			label: 'Variant',
+			options: const ['standard', 'filled', 'filledTonal', 'outlined'],
+			labelBuilder: (v) => v,
+		);
+	final enabled = context.knobs.boolean(label: 'Enabled', initialValue: true);
+	final selected = context.knobs.boolean(label: 'Selected', initialValue: false);
+	final size = context.knobs.double.slider(label: 'Icon size', initialValue: 24, min: 16, max: 40);
+	final color = context.knobs.color(label: 'Icon color');
+	final icon = context.knobs.list(
+		label: 'Icon',
+		options: const [Icons.search, Icons.menu, Icons.favorite, Icons.share, Icons.edit, Icons.delete],
+		labelBuilder: (icon) => icon.toString(),
+	);
+
+	AppIconButton build() => switch (variant) {
+				'filled' => AppIconButton.filled(
+						icon: icon,
+						tooltip: 'Playground',
+						onPressed: enabled ? () {} : null,
+						isSelected: selected,
+						iconSize: size,
+						color: color,
+					),
+				'filledTonal' => AppIconButton.filledTonal(
+						icon: icon,
+						tooltip: 'Playground',
+						onPressed: enabled ? () {} : null,
+						isSelected: selected,
+						iconSize: size,
+						color: color,
+					),
+				'outlined' => AppIconButton.outlined(
+						icon: icon,
+						tooltip: 'Playground',
+						onPressed: enabled ? () {} : null,
+						isSelected: selected,
+						iconSize: size,
+						color: color,
+					),
+				_ => AppIconButton(
+						icon: icon,
+						tooltip: 'Playground',
+						onPressed: enabled ? () {} : null,
+						isSelected: selected,
+						iconSize: size,
+						color: color,
+					),
+			};
+
+	return Center(child: build());
+}


### PR DESCRIPTION
# Pull Request

## 📄 Summary

This pull request introduces a new, fully featured `AppIconButton` widget to the codebase, providing a Material Design 3 (MD3) compliant, accessible, and customizable icon-only button with support for multiple visual variants. Additionally, it adds comprehensive Widgetbook stories to demonstrate and test all aspects of this new button.

The most important changes are:

**New Widget Implementation:**

* Implemented the `AppIconButton` widget in `app_icon_button.dart`, supporting MD3-compliant icon-only buttons with four variants (`standard`, `filled`, `filledTonal`, and `outlined`). The widget includes accessibility features, customizable icon, size, color, and state handling (`isSelected`, disabled, etc.).

**Component Documentation and Testing:**

* Added extensive Widgetbook stories in `app_icon_button_stories.dart` to showcase all variants, states (enabled, disabled, selected), common icons, sizing, theme variations (light/dark mode), toggle behavior, and an interactive playground for live property tweaking.

Closes #13 

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Packages (packages/*)
- [x] Widgetbook Kit (widgetbook_kit/)
- [ ] Documentation (docs/)
- [ ] CI / Infra (.github/)

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: <type>/<short-description> (e.g., feat/login-screen)
- [x] My PR title starts with one of the approved types listed above
- [x] My Dart code is formatted (dart format . or flutter format .)
- [x] I ran static analysis (flutter analyze) and resolved warnings
- [x] I ran tests successfully (flutter test)
- [x] I updated / checked pubspec.yaml and pubspec.lock for dependency changes
- [x] For UI changes, added Widgetbook stories with all variants.
- [x] I linked related issues using keywords like Closes #13 
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

Closes #13 

---

## 💬 Additional Notes (Optional)

✅ MD3 compliant: 48x48 touch target, 24dp icon, four variants.
✅ Accessibility: required tooltip, proper Semantics, isSelected support.
✅ Theming: full ColorScheme alignment, correct disabled alpha and state feedback.
✅ Widgetbook: 8 stories (variants, states, sizes, icons, theme, toggle, playground).
✅ Technical: analyzer clean, codebase maintenance.
