### PR TITLE
feat(core-kit): implement AppSwitch component with Material Design 3 compliance

### DIFF
--- a/packages/core_kit/lib/widgets/inputs/app_switch.dart
+++ b/packages/core_kit/lib/widgets/inputs/app_switch.dart
@@ -1,6 +1,277 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppSwitch {
-  const AppSwitch();
+import 'package:flutter/material.dart';
+
+/// A Material Design 3 switch widget that provides consistent toggle switch
+/// experience across the application.
+///
+/// The [AppSwitch] component supports:
+/// - Standard on/off states
+/// - Optional text labels and subtitles
+/// - Optional leading icons
+/// - Material Design 3 theming
+/// - Custom color overrides
+/// - Accessibility features
+///
+/// ## Basic Usage
+///
+/// ```dart
+/// bool isEnabled = false;
+///
+/// AppSwitch(
+///   value: isEnabled,
+///   label: 'Enable notifications',
+///   onChanged: (value) {
+///     setState(() {
+///       isEnabled = value;
+///     });
+///   },
+/// )
+/// ```
+///
+/// ## With Subtitle
+///
+/// Provide additional context with a subtitle:
+///
+/// ```dart
+/// AppSwitch(
+///   value: true,
+///   label: 'Dark mode',
+///   subtitle: 'Use dark theme across the app',
+///   onChanged: (value) {
+///     // Handle state change
+///   },
+/// )
+/// ```
+///
+/// ## With Icon
+///
+/// Add a leading icon for visual context:
+///
+/// ```dart
+/// AppSwitch(
+///   value: false,
+///   label: 'Bluetooth',
+///   icon: Icons.bluetooth,
+///   onChanged: (value) {
+///     // Handle state change
+///   },
+/// )
+/// ```
+///
+/// ## Custom Colors
+///
+/// Override default colors:
+///
+/// ```dart
+/// AppSwitch(
+///   value: true,
+///   label: 'Custom switch',
+///   activeColor: Colors.green,
+///   activeTrackColor: Colors.green.withOpacity(0.5),
+///   onChanged: (value) {},
+/// )
+/// ```
+///
+/// ## Material Design 3 Specifications
+///
+/// - Track size: 52x32dp (M3 standard)
+/// - Thumb size: 16dp (off) → 24dp (on)
+/// - Touch target: Minimum 48x48dp
+/// - Animation: 200ms smooth transition
+/// - Colors: Uses theme's [ColorScheme] tokens
+///
+/// ## Accessibility
+///
+/// - Minimum touch target of 48x48dp
+/// - Semantic labels from [label] property
+/// - State changes announced to screen readers ("On", "Off")
+/// - Keyboard navigation support (Space/Enter to toggle)
+/// - Disabled state announced to screen readers
+///
+/// See also:
+/// - [Material Design 3 Switch](https://m3.material.io/components/switch/overview)
+/// - [Switch] - Flutter's base switch widget
+class AppSwitch extends StatelessWidget {
+  /// Creates a Material Design 3 switch.
+  ///
+  /// The [value] and [onChanged] parameters must not be null unless
+  /// the switch is disabled.
+  const AppSwitch({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    this.label,
+    this.subtitle,
+    this.icon,
+    this.activeColor,
+    this.inactiveColor,
+    this.activeTrackColor,
+    this.inactiveTrackColor,
+    this.enabled = true,
+  });
+
+  /// The current value of the switch.
+  ///
+  /// When true, the switch is in the "on" position.
+  /// When false, the switch is in the "off" position.
+  final bool value;
+
+  /// Called when the user toggles the switch.
+  ///
+  /// The switch passes the new value to the callback but does not actually
+  /// change state until the parent widget rebuilds the switch with the new
+  /// value.
+  ///
+  /// If this callback is null, the switch will be displayed as disabled.
+  final ValueChanged<bool>? onChanged;
+
+  /// Optional text label displayed next to the switch.
+  ///
+  /// When null, only the switch is displayed.
+  final String? label;
+
+  /// Optional subtitle text displayed below the label.
+  ///
+  /// Provides additional context or description for the switch.
+  /// Only displayed when [label] is also provided.
+  final String? subtitle;
+
+  /// Optional leading icon displayed before the label.
+  ///
+  /// Provides visual context for the switch purpose.
+  final IconData? icon;
+
+  /// The color to use when this switch is on.
+  ///
+  /// If null, uses the theme's primary color for the thumb.
+  final Color? activeColor;
+
+  /// The color to use when this switch is off.
+  ///
+  /// If null, uses the theme's outline color for the thumb.
+  final Color? inactiveColor;
+
+  /// The color to use for the track when this switch is on.
+  ///
+  /// If null, uses the theme's primary color.
+  final Color? activeTrackColor;
+
+  /// The color to use for the track when this switch is off.
+  ///
+  /// If null, uses the theme's surfaceContainerHighest color.
+  final Color? inactiveTrackColor;
+
+  /// Whether the switch is enabled for interaction.
+  ///
+  /// When false, the switch is displayed with reduced opacity and does not
+  /// respond to touch.
+  ///
+  /// Defaults to true.
+  final bool enabled;
+
+  /// Whether this switch is currently enabled.
+  ///
+  /// A switch is considered enabled if [enabled] is true and [onChanged]
+  /// is not null.
+  bool get _isEnabled => enabled && onChanged != null;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    // If both label and subtitle are null, return just the switch
+    if (label == null && subtitle == null) {
+      return _buildSwitch(theme, colorScheme);
+    }
+
+    // If there's a label or subtitle, build the full layout
+    return InkWell(
+      onTap: _isEnabled
+          ? () {
+              onChanged?.call(!value);
+            }
+          : null,
+      borderRadius: BorderRadius.circular(8),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 4.0),
+        child: Row(
+          children: [
+            // Leading icon (if provided)
+            if (icon != null) ...[
+              Icon(
+                icon,
+                size: 24,
+                color: _isEnabled
+                    ? colorScheme.onSurface
+                    : colorScheme.onSurface.withValues(alpha: 0.38),
+              ),
+              const SizedBox(width: 16),
+            ],
+            // Label and subtitle
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (label != null)
+                    Text(
+                      label!,
+                      style: theme.textTheme.bodyLarge?.copyWith(
+                        color: _isEnabled
+                            ? colorScheme.onSurface
+                            : colorScheme.onSurface.withValues(alpha: 0.38),
+                      ),
+                    ),
+                  if (subtitle != null) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      subtitle!,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: _isEnabled
+                            ? colorScheme.onSurfaceVariant
+                            : colorScheme.onSurfaceVariant.withValues(
+                                alpha: 0.38,
+                              ),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            const SizedBox(width: 16),
+            // Switch
+            _buildSwitch(theme, colorScheme),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Builds the switch widget with proper theming.
+  Widget _buildSwitch(ThemeData theme, ColorScheme colorScheme) {
+    return Switch(
+      value: value,
+      onChanged: _isEnabled ? onChanged : null,
+      thumbColor: activeColor != null || inactiveColor != null
+          ? WidgetStateProperty.resolveWith<Color?>((states) {
+              if (states.contains(WidgetState.selected)) {
+                return activeColor;
+              }
+              return inactiveColor;
+            })
+          : null,
+      trackColor: activeTrackColor != null || inactiveTrackColor != null
+          ? WidgetStateProperty.resolveWith<Color?>((states) {
+              if (states.contains(WidgetState.selected)) {
+                return activeTrackColor;
+              }
+              return inactiveTrackColor;
+            })
+          : null,
+      materialTapTargetSize: MaterialTapTargetSize.padded,
+    );
+  }
 }

--- a/packages/core_kit/test/widgets/inputs/app_switch_test.dart
+++ b/packages/core_kit/test/widgets/inputs/app_switch_test.dart
@@ -1,0 +1,498 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:core_kit/widgets/inputs/app_switch.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AppSwitch', () {
+    group('Basic Rendering', () {
+      testWidgets('renders with required properties', (tester) async {
+        bool switchValue = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: switchValue,
+                onChanged: (value) {
+                  switchValue = value;
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(Switch), findsOneWidget);
+      });
+
+      testWidgets('displays label when provided', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                label: 'Enable notifications',
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Enable notifications'), findsOneWidget);
+      });
+
+      testWidgets('displays subtitle when provided', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                label: 'Dark mode',
+                subtitle: 'Use dark theme across the app',
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Dark mode'), findsOneWidget);
+        expect(find.text('Use dark theme across the app'), findsOneWidget);
+      });
+
+      testWidgets('displays icon when provided', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                label: 'Bluetooth',
+                icon: Icons.bluetooth,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.bluetooth), findsOneWidget);
+      });
+
+      testWidgets('renders without label (switch only)', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(value: false, onChanged: (value) {}),
+            ),
+          ),
+        );
+
+        expect(find.byType(Switch), findsOneWidget);
+        expect(find.byType(Text), findsNothing);
+      });
+    });
+
+    group('State Management', () {
+      testWidgets('shows on state when value is true', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: AppSwitch(value: true, onChanged: (value) {})),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        expect(switchWidget.value, true);
+      });
+
+      testWidgets('shows off state when value is false', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(value: false, onChanged: (value) {}),
+            ),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        expect(switchWidget.value, false);
+      });
+
+      testWidgets('calls onChanged when toggled', (tester) async {
+        bool switchValue = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: switchValue,
+                onChanged: (value) {
+                  switchValue = value;
+                },
+              ),
+            ),
+          ),
+        );
+
+        // Tap the switch
+        await tester.tap(find.byType(Switch));
+        await tester.pumpAndSettle();
+
+        // Verify the value changed
+        expect(switchValue, true);
+      });
+
+      testWidgets('calls onChanged when label is tapped', (tester) async {
+        bool switchValue = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: StatefulBuilder(
+                builder: (context, setState) {
+                  return AppSwitch(
+                    value: switchValue,
+                    label: 'Toggle me',
+                    onChanged: (value) {
+                      setState(() {
+                        switchValue = value;
+                      });
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        // Tap the label
+        await tester.tap(find.text('Toggle me'));
+        await tester.pumpAndSettle();
+
+        // Verify the value changed
+        expect(switchValue, true);
+      });
+    });
+
+    group('Disabled State', () {
+      testWidgets('is disabled when onChanged is null', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: AppSwitch(value: false, onChanged: null)),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        expect(switchWidget.onChanged, isNull);
+      });
+
+      testWidgets('is disabled when enabled is false', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                enabled: false,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        expect(switchWidget.onChanged, isNull);
+      });
+
+      testWidgets('shows disabled on state', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: AppSwitch(value: true, onChanged: null)),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        expect(switchWidget.value, true);
+        expect(switchWidget.onChanged, isNull);
+      });
+
+      testWidgets('shows disabled off state', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: AppSwitch(value: false, onChanged: null)),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        expect(switchWidget.value, false);
+        expect(switchWidget.onChanged, isNull);
+      });
+
+      testWidgets('does not call onChanged when disabled', (tester) async {
+        bool callbackCalled = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                enabled: false,
+                onChanged: (value) {
+                  callbackCalled = true;
+                },
+              ),
+            ),
+          ),
+        );
+
+        // Try to tap the switch
+        await tester.tap(find.byType(Switch));
+        await tester.pumpAndSettle();
+
+        // Verify callback was not called
+        expect(callbackCalled, false);
+      });
+    });
+
+    group('Color Customization', () {
+      testWidgets('uses custom activeColor', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: true,
+                activeColor: Colors.green,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        final thumbColor = switchWidget.thumbColor;
+        expect(thumbColor, isNotNull);
+        // Verify thumbColor is a WidgetStateProperty
+        expect(thumbColor, isA<WidgetStateProperty<Color?>>());
+      });
+
+      testWidgets('uses custom inactiveColor', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                inactiveColor: Colors.grey,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        final thumbColor = switchWidget.thumbColor;
+        expect(thumbColor, isNotNull);
+        expect(thumbColor, isA<WidgetStateProperty<Color?>>());
+      });
+
+      testWidgets('uses custom activeTrackColor', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: true,
+                activeTrackColor: Colors.lightGreen,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        final trackColor = switchWidget.trackColor;
+        expect(trackColor, isNotNull);
+        expect(trackColor, isA<WidgetStateProperty<Color?>>());
+      });
+
+      testWidgets('uses custom inactiveTrackColor', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                inactiveTrackColor: Colors.blueGrey,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        final trackColor = switchWidget.trackColor;
+        expect(trackColor, isNotNull);
+        expect(trackColor, isA<WidgetStateProperty<Color?>>());
+      });
+    });
+
+    group('Layout Variants', () {
+      testWidgets('switch only layout has no padding or text', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(value: false, onChanged: (value) {}),
+            ),
+          ),
+        );
+
+        expect(find.byType(Text), findsNothing);
+        expect(find.byType(Switch), findsOneWidget);
+      });
+
+      testWidgets('switch with label has proper layout', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                label: 'Test label',
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Test label'), findsOneWidget);
+        expect(find.byType(Switch), findsOneWidget);
+        expect(find.byType(Row), findsOneWidget);
+      });
+
+      testWidgets('switch with icon, label, and subtitle has full layout', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                icon: Icons.wifi,
+                label: 'WiFi',
+                subtitle: 'Connect to wireless networks',
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.wifi), findsOneWidget);
+        expect(find.text('WiFi'), findsOneWidget);
+        expect(find.text('Connect to wireless networks'), findsOneWidget);
+        expect(find.byType(Switch), findsOneWidget);
+      });
+    });
+
+    group('Accessibility', () {
+      testWidgets('has minimum touch target size', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(value: false, onChanged: (value) {}),
+            ),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        expect(
+          switchWidget.materialTapTargetSize,
+          MaterialTapTargetSize.padded,
+        );
+      });
+
+      testWidgets('label provides semantic context', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                label: 'Enable dark mode',
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Enable dark mode'), findsOneWidget);
+      });
+
+      testWidgets('disabled state is properly indicated', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                label: 'Disabled switch',
+                onChanged: null,
+              ),
+            ),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        expect(switchWidget.onChanged, isNull);
+
+        // Find the label text widget
+        final textWidget = tester.widget<Text>(find.text('Disabled switch'));
+        final textStyle = textWidget.style;
+
+        // Check if the text has reduced opacity (disabled state)
+        expect(textStyle?.color?.a, lessThan(1.0));
+      });
+    });
+
+    group('Theme Integration', () {
+      testWidgets('uses theme colors when custom colors not provided', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(
+              colorScheme: ColorScheme.fromSeed(
+                seedColor: Colors.blue,
+                brightness: Brightness.light,
+              ),
+            ),
+            home: Scaffold(
+              body: AppSwitch(
+                value: true,
+                label: 'Themed switch',
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Themed switch'), findsOneWidget);
+        expect(find.byType(Switch), findsOneWidget);
+      });
+
+      testWidgets('respects dark theme', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(
+              colorScheme: ColorScheme.fromSeed(
+                seedColor: Colors.blue,
+                brightness: Brightness.dark,
+              ),
+            ),
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                label: 'Dark themed switch',
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Dark themed switch'), findsOneWidget);
+        expect(find.byType(Switch), findsOneWidget);
+      });
+    });
+  });
+}

--- a/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
+++ b/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
@@ -15,10 +15,16 @@ import 'package:widgetbook_kit/stories/core_kit/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_buttons_app_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories;
-import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_checkbox_stories.dart'
-    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_icon_button_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_outlined_button_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_text_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_checkbox_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_switch_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories;
 
 final directories = <_widgetbook.WidgetbookNode>[
   _widgetbook.WidgetbookFolder(
@@ -231,6 +237,100 @@ final directories = <_widgetbook.WidgetbookNode>[
             ],
           ),
           _widgetbook.WidgetbookComponent(
+            name: 'AppIconButton',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'All Variants',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonAllVariants,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Common Icons',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonCommonIcons,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Interactive Playground',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonPlayground,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Sizes',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonSizes,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'States',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonStates,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Theme Variations',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonTheme,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Toggle Button',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonToggle,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'AppOutlinedButton',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Comparison',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonComparison,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Sizes',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonSizes,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'States',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonStates,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Theme Variations',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonTheme,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Icon',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonWithIcon,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
             name: 'AppTextButton',
             useCases: [
               _widgetbook.WidgetbookUseCase(
@@ -362,6 +462,53 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories
                         .appCheckboxThemeVariations,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'AppSwitch',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'All States',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
+                        .appSwitchStates,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
+                        .appSwitchDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Real-World Examples',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
+                        .appSwitchExamples,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Settings List',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
+                        .appSwitchSettingsList,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Theme Variations',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
+                        .appSwitchThemeVariations,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Icons',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
+                        .appSwitchIcons,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Labels',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
+                        .appSwitchLabels,
               ),
             ],
           ),

--- a/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_switch_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_switch_stories.dart
@@ -1,2 +1,438 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/widgets/inputs/app_switch.dart';
+
+// 1. Default Switch - Basic toggle
+@widgetbook.UseCase(name: 'Default', type: AppSwitch)
+Widget appSwitchDefault(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: AppSwitch(
+      value: false,
+      label: 'Toggle switch',
+      onChanged: (value) {},
+    ),
+  );
+}
+
+// 2. States - All switch states
+@widgetbook.UseCase(name: 'All States', type: AppSwitch)
+Widget appSwitchStates(BuildContext context) {
+  return SingleChildScrollView(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'On (Active)',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          AppSwitch(value: true, label: 'Switch is on', onChanged: (value) {}),
+          const SizedBox(height: 16),
+          const Text(
+            'Off (Inactive)',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          AppSwitch(
+            value: false,
+            label: 'Switch is off',
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 16),
+          const Text(
+            'Disabled On',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const AppSwitch(
+            value: true,
+            label: 'Disabled (on state)',
+            onChanged: null,
+          ),
+          const SizedBox(height: 16),
+          const Text(
+            'Disabled Off',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const AppSwitch(
+            value: false,
+            label: 'Disabled (off state)',
+            onChanged: null,
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+// 3. With Labels - Label variations
+@widgetbook.UseCase(name: 'With Labels', type: AppSwitch)
+Widget appSwitchLabels(BuildContext context) {
+  return SingleChildScrollView(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'No Label (Switch Only)',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          AppSwitch(value: true, onChanged: (value) {}),
+          const SizedBox(height: 24),
+          const Text(
+            'Short Label',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          AppSwitch(value: true, label: 'Wi-Fi', onChanged: (value) {}),
+          const SizedBox(height: 24),
+          const Text(
+            'Long Label',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          AppSwitch(
+            value: false,
+            label: 'Automatically connect to available wireless networks',
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 24),
+          const Text(
+            'With Subtitle (Additional Context)',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          AppSwitch(
+            value: true,
+            label: 'Dark mode',
+            subtitle: 'Use dark theme across the app for better visibility',
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 16),
+          AppSwitch(
+            value: false,
+            label: 'Push notifications',
+            subtitle: 'Receive notifications about important updates',
+            onChanged: (value) {},
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+// 4. With Icons - Icon integration
+@widgetbook.UseCase(name: 'With Icons', type: AppSwitch)
+Widget appSwitchIcons(BuildContext context) {
+  return SingleChildScrollView(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Leading Icon + Switch',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 16),
+          AppSwitch(
+            value: true,
+            icon: Icons.wifi,
+            label: 'Wi-Fi',
+            subtitle: 'Connect to wireless networks',
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 16),
+          AppSwitch(
+            value: true,
+            icon: Icons.bluetooth,
+            label: 'Bluetooth',
+            subtitle: 'Connect to nearby devices',
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 16),
+          AppSwitch(
+            value: false,
+            icon: Icons.airplanemode_active,
+            label: 'Airplane mode',
+            subtitle: 'Disable all wireless connections',
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 16),
+          AppSwitch(
+            value: true,
+            icon: Icons.notifications,
+            label: 'Notifications',
+            subtitle: 'Show notifications on lock screen',
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 16),
+          AppSwitch(
+            value: false,
+            icon: Icons.location_on,
+            label: 'Location services',
+            subtitle: 'Allow apps to use your location',
+            onChanged: (value) {},
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+// 5. Settings List - Realistic settings UI
+@widgetbook.UseCase(name: 'Settings List', type: AppSwitch)
+Widget appSwitchSettingsList(BuildContext context) {
+  return Scaffold(
+    appBar: AppBar(title: const Text('Settings')),
+    body: ListView(
+      children: [
+        const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            'Network & Connectivity',
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.bold,
+              color: Colors.grey,
+            ),
+          ),
+        ),
+        AppSwitch(
+          value: true,
+          icon: Icons.wifi,
+          label: 'Wi-Fi',
+          subtitle: 'Connected to My Network',
+          onChanged: (value) {},
+        ),
+        const Divider(height: 1),
+        AppSwitch(
+          value: true,
+          icon: Icons.bluetooth,
+          label: 'Bluetooth',
+          onChanged: (value) {},
+        ),
+        const Divider(height: 1),
+        AppSwitch(
+          value: false,
+          icon: Icons.airplanemode_active,
+          label: 'Airplane mode',
+          onChanged: (value) {},
+        ),
+        const SizedBox(height: 24),
+        const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            'Notifications',
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.bold,
+              color: Colors.grey,
+            ),
+          ),
+        ),
+        AppSwitch(
+          value: true,
+          icon: Icons.notifications,
+          label: 'Push notifications',
+          subtitle: 'Show notifications on lock screen',
+          onChanged: (value) {},
+        ),
+        const Divider(height: 1),
+        AppSwitch(
+          value: false,
+          icon: Icons.vibration,
+          label: 'Vibrate',
+          onChanged: (value) {},
+        ),
+        const Divider(height: 1),
+        const AppSwitch(
+          value: false,
+          icon: Icons.volume_off,
+          label: 'Do not disturb',
+          subtitle: 'Disabled by administrator',
+          onChanged: null,
+        ),
+        const SizedBox(height: 24),
+        const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            'Privacy',
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.bold,
+              color: Colors.grey,
+            ),
+          ),
+        ),
+        AppSwitch(
+          value: true,
+          icon: Icons.location_on,
+          label: 'Location services',
+          subtitle: 'Allow apps to use your location',
+          onChanged: (value) {},
+        ),
+        const Divider(height: 1),
+        AppSwitch(
+          value: false,
+          icon: Icons.camera_alt,
+          label: 'Camera access',
+          onChanged: (value) {},
+        ),
+        const Divider(height: 1),
+        AppSwitch(
+          value: false,
+          icon: Icons.mic,
+          label: 'Microphone access',
+          onChanged: (value) {},
+        ),
+      ],
+    ),
+  );
+}
+
+// 6. Theme Variations - Light, dark, and custom colors
+@widgetbook.UseCase(name: 'Theme Variations', type: AppSwitch)
+Widget appSwitchThemeVariations(BuildContext context) {
+  return SingleChildScrollView(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Toggle theme in Widgetbook to see variations',
+            style: TextStyle(fontStyle: FontStyle.italic, fontSize: 12),
+          ),
+          const SizedBox(height: 16),
+          const Text(
+            'Default Colors',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          AppSwitch(
+            value: true,
+            label: 'On (uses primary color)',
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 8),
+          AppSwitch(
+            value: false,
+            label: 'Off (uses surface color)',
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 24),
+          const Text(
+            'Custom Brand Colors',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          AppSwitch(
+            value: true,
+            label: 'Green switch',
+            activeColor: Colors.white,
+            activeTrackColor: Colors.green,
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 8),
+          AppSwitch(
+            value: true,
+            label: 'Orange switch',
+            activeColor: Colors.white,
+            activeTrackColor: Colors.deepOrange,
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 8),
+          AppSwitch(
+            value: true,
+            label: 'Blue switch',
+            activeColor: Colors.white,
+            activeTrackColor: Colors.blue,
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 24),
+          const Text(
+            'Contrast Demonstration',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: AppSwitch(
+                  value: true,
+                  label: 'On',
+                  onChanged: (value) {},
+                ),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: AppSwitch(
+                  value: false,
+                  label: 'Off',
+                  onChanged: (value) {},
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+// 7. Real-World Examples
+@widgetbook.UseCase(name: 'Real-World Examples', type: AppSwitch)
+Widget appSwitchExamples(BuildContext context) {
+  return SingleChildScrollView(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Common Use Cases',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 16),
+          AppSwitch(
+            value: true,
+            icon: Icons.dark_mode,
+            label: 'Dark mode',
+            subtitle: 'Reduces eye strain in low light',
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 16),
+          AppSwitch(
+            value: false,
+            icon: Icons.save_alt,
+            label: 'Auto-save',
+            subtitle: 'Automatically save changes',
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 16),
+          AppSwitch(
+            value: true,
+            icon: Icons.backup,
+            label: 'Cloud backup',
+            subtitle: 'Back up to cloud storage',
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 16),
+          const AppSwitch(
+            value: false,
+            icon: Icons.analytics,
+            label: 'Analytics',
+            subtitle: 'Managed by organization policy',
+            onChanged: null,
+          ),
+        ],
+      ),
+    ),
+  );
+}

--- a/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_switch_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_switch_stories.dart
@@ -373,66 +373,89 @@ class _SettingsListDemoState extends State<_SettingsListDemo> {
   }
 }
 
-// 6. Theme Variations - Light, dark, and custom colors (Static - for comparison)
+// 6. Theme Variations - Light, dark, and custom colors (Interactive)
 @widgetbook.UseCase(name: 'Theme Variations', type: AppSwitch)
 Widget appSwitchThemeVariations(BuildContext context) {
-  return SingleChildScrollView(
-    child: Padding(
-      padding: const EdgeInsets.all(16.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: const [
-          Text(
-            'Toggle theme in Widgetbook to see variations',
-            style: TextStyle(fontStyle: FontStyle.italic, fontSize: 12),
-          ),
-          SizedBox(height: 16),
-          Text('Default Colors', style: TextStyle(fontWeight: FontWeight.bold)),
-          SizedBox(height: 8),
-          AppSwitch(
-            value: true,
-            label: 'On (uses primary color)',
-            onChanged: null,
-          ),
-          SizedBox(height: 8),
-          AppSwitch(
-            value: false,
-            label: 'Off (uses surface color)',
-            onChanged: null,
-          ),
-          SizedBox(height: 24),
-          Text(
-            'Custom Brand Colors',
-            style: TextStyle(fontWeight: FontWeight.bold),
-          ),
-          SizedBox(height: 8),
-          AppSwitch(
-            value: true,
-            label: 'Green switch',
-            activeColor: Colors.white,
-            activeTrackColor: Colors.green,
-            onChanged: null,
-          ),
-          SizedBox(height: 8),
-          AppSwitch(
-            value: true,
-            label: 'Orange switch',
-            activeColor: Colors.white,
-            activeTrackColor: Colors.deepOrange,
-            onChanged: null,
-          ),
-          SizedBox(height: 8),
-          AppSwitch(
-            value: true,
-            label: 'Blue switch',
-            activeColor: Colors.white,
-            activeTrackColor: Colors.blue,
-            onChanged: null,
-          ),
-        ],
+  return const _ThemeVariationsDemo();
+}
+
+class _ThemeVariationsDemo extends StatefulWidget {
+  const _ThemeVariationsDemo();
+
+  @override
+  State<_ThemeVariationsDemo> createState() => _ThemeVariationsDemoState();
+}
+
+class _ThemeVariationsDemoState extends State<_ThemeVariationsDemo> {
+  bool _defaultOn = true;
+  bool _defaultOff = false;
+  bool _greenSwitch = true;
+  bool _orangeSwitch = true;
+  bool _blueSwitch = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Toggle theme in Widgetbook to see variations',
+              style: TextStyle(fontStyle: FontStyle.italic, fontSize: 12),
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'Default Colors',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            AppSwitch(
+              value: _defaultOn,
+              label: 'On (uses primary color)',
+              onChanged: (value) => setState(() => _defaultOn = value),
+            ),
+            const SizedBox(height: 8),
+            AppSwitch(
+              value: _defaultOff,
+              label: 'Off (uses surface color)',
+              onChanged: (value) => setState(() => _defaultOff = value),
+            ),
+            const SizedBox(height: 24),
+            const Text(
+              'Custom Brand Colors',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            AppSwitch(
+              value: _greenSwitch,
+              label: 'Green switch',
+              activeColor: Colors.white,
+              activeTrackColor: Colors.green,
+              onChanged: (value) => setState(() => _greenSwitch = value),
+            ),
+            const SizedBox(height: 8),
+            AppSwitch(
+              value: _orangeSwitch,
+              label: 'Orange switch',
+              activeColor: Colors.white,
+              activeTrackColor: Colors.deepOrange,
+              onChanged: (value) => setState(() => _orangeSwitch = value),
+            ),
+            const SizedBox(height: 8),
+            AppSwitch(
+              value: _blueSwitch,
+              label: 'Blue switch',
+              activeColor: Colors.white,
+              activeTrackColor: Colors.blue,
+              onChanged: (value) => setState(() => _blueSwitch = value),
+            ),
+          ],
+        ),
       ),
-    ),
-  );
+    );
+  }
 }
 
 // 7. Real-World Examples (Interactive)

--- a/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_switch_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_switch_stories.dart
@@ -5,20 +5,36 @@ import 'package:flutter/material.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 import 'package:core_kit/widgets/inputs/app_switch.dart';
 
-// 1. Default Switch - Basic toggle
+// 1. Default Switch - Basic toggle (Interactive)
 @widgetbook.UseCase(name: 'Default', type: AppSwitch)
 Widget appSwitchDefault(BuildContext context) {
-  return Padding(
-    padding: const EdgeInsets.all(16.0),
-    child: AppSwitch(
-      value: false,
-      label: 'Toggle switch',
-      onChanged: (value) {},
-    ),
-  );
+  return const _DefaultSwitchDemo();
 }
 
-// 2. States - All switch states
+class _DefaultSwitchDemo extends StatefulWidget {
+  const _DefaultSwitchDemo();
+
+  @override
+  State<_DefaultSwitchDemo> createState() => _DefaultSwitchDemoState();
+}
+
+class _DefaultSwitchDemoState extends State<_DefaultSwitchDemo> {
+  bool _value = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: AppSwitch(
+        value: _value,
+        label: 'Toggle switch',
+        onChanged: (value) => setState(() => _value = value),
+      ),
+    );
+  }
+}
+
+// 2. States - All switch states (Static - for comparison)
 @widgetbook.UseCase(name: 'All States', type: AppSwitch)
 Widget appSwitchStates(BuildContext context) {
   return SingleChildScrollView(
@@ -26,38 +42,18 @@ Widget appSwitchStates(BuildContext context) {
       padding: const EdgeInsets.all(16.0),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const Text(
-            'On (Active)',
-            style: TextStyle(fontWeight: FontWeight.bold),
-          ),
-          AppSwitch(value: true, label: 'Switch is on', onChanged: (value) {}),
-          const SizedBox(height: 16),
-          const Text(
-            'Off (Inactive)',
-            style: TextStyle(fontWeight: FontWeight.bold),
-          ),
+        children: const [
+          Text('On (Active)', style: TextStyle(fontWeight: FontWeight.bold)),
+          AppSwitch(value: true, label: 'Switch is on', onChanged: null),
+          SizedBox(height: 16),
+          Text('Off (Inactive)', style: TextStyle(fontWeight: FontWeight.bold)),
+          AppSwitch(value: false, label: 'Switch is off', onChanged: null),
+          SizedBox(height: 16),
+          Text('Disabled On', style: TextStyle(fontWeight: FontWeight.bold)),
+          AppSwitch(value: true, label: 'Disabled (on state)', onChanged: null),
+          SizedBox(height: 16),
+          Text('Disabled Off', style: TextStyle(fontWeight: FontWeight.bold)),
           AppSwitch(
-            value: false,
-            label: 'Switch is off',
-            onChanged: (value) {},
-          ),
-          const SizedBox(height: 16),
-          const Text(
-            'Disabled On',
-            style: TextStyle(fontWeight: FontWeight.bold),
-          ),
-          const AppSwitch(
-            value: true,
-            label: 'Disabled (on state)',
-            onChanged: null,
-          ),
-          const SizedBox(height: 16),
-          const Text(
-            'Disabled Off',
-            style: TextStyle(fontWeight: FontWeight.bold),
-          ),
-          const AppSwitch(
             value: false,
             label: 'Disabled (off state)',
             onChanged: null,
@@ -68,235 +64,316 @@ Widget appSwitchStates(BuildContext context) {
   );
 }
 
-// 3. With Labels - Label variations
+// 3. With Labels - Label variations (Interactive)
 @widgetbook.UseCase(name: 'With Labels', type: AppSwitch)
 Widget appSwitchLabels(BuildContext context) {
-  return SingleChildScrollView(
-    child: Padding(
-      padding: const EdgeInsets.all(16.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const Text(
-            'No Label (Switch Only)',
-            style: TextStyle(fontWeight: FontWeight.bold),
-          ),
-          const SizedBox(height: 8),
-          AppSwitch(value: true, onChanged: (value) {}),
-          const SizedBox(height: 24),
-          const Text(
-            'Short Label',
-            style: TextStyle(fontWeight: FontWeight.bold),
-          ),
-          const SizedBox(height: 8),
-          AppSwitch(value: true, label: 'Wi-Fi', onChanged: (value) {}),
-          const SizedBox(height: 24),
-          const Text(
-            'Long Label',
-            style: TextStyle(fontWeight: FontWeight.bold),
-          ),
-          const SizedBox(height: 8),
-          AppSwitch(
-            value: false,
-            label: 'Automatically connect to available wireless networks',
-            onChanged: (value) {},
-          ),
-          const SizedBox(height: 24),
-          const Text(
-            'With Subtitle (Additional Context)',
-            style: TextStyle(fontWeight: FontWeight.bold),
-          ),
-          const SizedBox(height: 8),
-          AppSwitch(
-            value: true,
-            label: 'Dark mode',
-            subtitle: 'Use dark theme across the app for better visibility',
-            onChanged: (value) {},
-          ),
-          const SizedBox(height: 16),
-          AppSwitch(
-            value: false,
-            label: 'Push notifications',
-            subtitle: 'Receive notifications about important updates',
-            onChanged: (value) {},
-          ),
-        ],
-      ),
-    ),
-  );
+  return const _LabelsDemo();
 }
 
-// 4. With Icons - Icon integration
+class _LabelsDemo extends StatefulWidget {
+  const _LabelsDemo();
+
+  @override
+  State<_LabelsDemo> createState() => _LabelsDemoState();
+}
+
+class _LabelsDemoState extends State<_LabelsDemo> {
+  bool _noLabel = true;
+  bool _shortLabel = true;
+  bool _longLabel = false;
+  bool _darkMode = true;
+  bool _notifications = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'No Label (Switch Only)',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            AppSwitch(
+              value: _noLabel,
+              onChanged: (value) => setState(() => _noLabel = value),
+            ),
+            const SizedBox(height: 24),
+            const Text(
+              'Short Label',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            AppSwitch(
+              value: _shortLabel,
+              label: 'Wi-Fi',
+              onChanged: (value) => setState(() => _shortLabel = value),
+            ),
+            const SizedBox(height: 24),
+            const Text(
+              'Long Label',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            AppSwitch(
+              value: _longLabel,
+              label: 'Automatically connect to available wireless networks',
+              onChanged: (value) => setState(() => _longLabel = value),
+            ),
+            const SizedBox(height: 24),
+            const Text(
+              'With Subtitle (Additional Context)',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            AppSwitch(
+              value: _darkMode,
+              label: 'Dark mode',
+              subtitle: 'Use dark theme across the app for better visibility',
+              onChanged: (value) => setState(() => _darkMode = value),
+            ),
+            const SizedBox(height: 16),
+            AppSwitch(
+              value: _notifications,
+              label: 'Push notifications',
+              subtitle: 'Receive notifications about important updates',
+              onChanged: (value) => setState(() => _notifications = value),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// 4. With Icons - Icon integration (Interactive)
 @widgetbook.UseCase(name: 'With Icons', type: AppSwitch)
 Widget appSwitchIcons(BuildContext context) {
-  return SingleChildScrollView(
-    child: Padding(
-      padding: const EdgeInsets.all(16.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+  return const _IconsDemo();
+}
+
+class _IconsDemo extends StatefulWidget {
+  const _IconsDemo();
+
+  @override
+  State<_IconsDemo> createState() => _IconsDemoState();
+}
+
+class _IconsDemoState extends State<_IconsDemo> {
+  bool _wifi = true;
+  bool _bluetooth = true;
+  bool _airplane = false;
+  bool _notifications = true;
+  bool _location = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Leading Icon + Switch',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+            AppSwitch(
+              value: _wifi,
+              icon: Icons.wifi,
+              label: 'Wi-Fi',
+              subtitle: 'Connect to wireless networks',
+              onChanged: (value) => setState(() => _wifi = value),
+            ),
+            const SizedBox(height: 16),
+            AppSwitch(
+              value: _bluetooth,
+              icon: Icons.bluetooth,
+              label: 'Bluetooth',
+              subtitle: 'Connect to nearby devices',
+              onChanged: (value) => setState(() => _bluetooth = value),
+            ),
+            const SizedBox(height: 16),
+            AppSwitch(
+              value: _airplane,
+              icon: Icons.airplanemode_active,
+              label: 'Airplane mode',
+              subtitle: 'Disable all wireless connections',
+              onChanged: (value) => setState(() => _airplane = value),
+            ),
+            const SizedBox(height: 16),
+            AppSwitch(
+              value: _notifications,
+              icon: Icons.notifications,
+              label: 'Notifications',
+              subtitle: 'Show notifications on lock screen',
+              onChanged: (value) => setState(() => _notifications = value),
+            ),
+            const SizedBox(height: 16),
+            AppSwitch(
+              value: _location,
+              icon: Icons.location_on,
+              label: 'Location services',
+              subtitle: 'Allow apps to use your location',
+              onChanged: (value) => setState(() => _location = value),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// 5. Settings List - Realistic settings UI (Interactive - Critical!)
+@widgetbook.UseCase(name: 'Settings List', type: AppSwitch)
+Widget appSwitchSettingsList(BuildContext context) {
+  return const _SettingsListDemo();
+}
+
+class _SettingsListDemo extends StatefulWidget {
+  const _SettingsListDemo();
+
+  @override
+  State<_SettingsListDemo> createState() => _SettingsListDemoState();
+}
+
+class _SettingsListDemoState extends State<_SettingsListDemo> {
+  // Network & Connectivity
+  bool _wifi = true;
+  bool _bluetooth = true;
+  bool _airplane = false;
+
+  // Notifications
+  bool _pushNotifications = true;
+  bool _vibrate = false;
+
+  // Privacy
+  bool _location = true;
+  bool _camera = false;
+  bool _microphone = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: ListView(
         children: [
-          const Text(
-            'Leading Icon + Switch',
-            style: TextStyle(fontWeight: FontWeight.bold),
+          // Network & Connectivity Section
+          const Padding(
+            padding: EdgeInsets.all(16.0),
+            child: Text(
+              'Network & Connectivity',
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.bold,
+                color: Colors.grey,
+              ),
+            ),
           ),
-          const SizedBox(height: 16),
           AppSwitch(
-            value: true,
+            value: _wifi,
             icon: Icons.wifi,
             label: 'Wi-Fi',
-            subtitle: 'Connect to wireless networks',
-            onChanged: (value) {},
+            subtitle: 'Connected to My Network',
+            onChanged: (value) => setState(() => _wifi = value),
           ),
-          const SizedBox(height: 16),
+          const Divider(height: 1),
           AppSwitch(
-            value: true,
+            value: _bluetooth,
             icon: Icons.bluetooth,
             label: 'Bluetooth',
-            subtitle: 'Connect to nearby devices',
-            onChanged: (value) {},
+            onChanged: (value) => setState(() => _bluetooth = value),
           ),
-          const SizedBox(height: 16),
+          const Divider(height: 1),
           AppSwitch(
-            value: false,
+            value: _airplane,
             icon: Icons.airplanemode_active,
             label: 'Airplane mode',
-            subtitle: 'Disable all wireless connections',
-            onChanged: (value) {},
+            onChanged: (value) => setState(() => _airplane = value),
           ),
-          const SizedBox(height: 16),
+          const SizedBox(height: 24),
+
+          // Notifications Section
+          const Padding(
+            padding: EdgeInsets.all(16.0),
+            child: Text(
+              'Notifications',
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.bold,
+                color: Colors.grey,
+              ),
+            ),
+          ),
           AppSwitch(
-            value: true,
+            value: _pushNotifications,
             icon: Icons.notifications,
-            label: 'Notifications',
+            label: 'Push notifications',
             subtitle: 'Show notifications on lock screen',
-            onChanged: (value) {},
+            onChanged: (value) => setState(() => _pushNotifications = value),
           ),
-          const SizedBox(height: 16),
+          const Divider(height: 1),
           AppSwitch(
+            value: _vibrate,
+            icon: Icons.vibration,
+            label: 'Vibrate',
+            onChanged: (value) => setState(() => _vibrate = value),
+          ),
+          const Divider(height: 1),
+          // Do not disturb - Disabled
+          const AppSwitch(
             value: false,
+            icon: Icons.volume_off,
+            label: 'Do not disturb',
+            subtitle: 'Disabled by administrator',
+            onChanged: null,
+          ),
+          const SizedBox(height: 24),
+
+          // Privacy Section
+          const Padding(
+            padding: EdgeInsets.all(16.0),
+            child: Text(
+              'Privacy',
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.bold,
+                color: Colors.grey,
+              ),
+            ),
+          ),
+          AppSwitch(
+            value: _location,
             icon: Icons.location_on,
             label: 'Location services',
             subtitle: 'Allow apps to use your location',
-            onChanged: (value) {},
+            onChanged: (value) => setState(() => _location = value),
+          ),
+          const Divider(height: 1),
+          AppSwitch(
+            value: _camera,
+            icon: Icons.camera_alt,
+            label: 'Camera access',
+            onChanged: (value) => setState(() => _camera = value),
+          ),
+          const Divider(height: 1),
+          AppSwitch(
+            value: _microphone,
+            icon: Icons.mic,
+            label: 'Microphone access',
+            onChanged: (value) => setState(() => _microphone = value),
           ),
         ],
       ),
-    ),
-  );
+    );
+  }
 }
 
-// 5. Settings List - Realistic settings UI
-@widgetbook.UseCase(name: 'Settings List', type: AppSwitch)
-Widget appSwitchSettingsList(BuildContext context) {
-  return Scaffold(
-    appBar: AppBar(title: const Text('Settings')),
-    body: ListView(
-      children: [
-        const Padding(
-          padding: EdgeInsets.all(16.0),
-          child: Text(
-            'Network & Connectivity',
-            style: TextStyle(
-              fontSize: 14,
-              fontWeight: FontWeight.bold,
-              color: Colors.grey,
-            ),
-          ),
-        ),
-        AppSwitch(
-          value: true,
-          icon: Icons.wifi,
-          label: 'Wi-Fi',
-          subtitle: 'Connected to My Network',
-          onChanged: (value) {},
-        ),
-        const Divider(height: 1),
-        AppSwitch(
-          value: true,
-          icon: Icons.bluetooth,
-          label: 'Bluetooth',
-          onChanged: (value) {},
-        ),
-        const Divider(height: 1),
-        AppSwitch(
-          value: false,
-          icon: Icons.airplanemode_active,
-          label: 'Airplane mode',
-          onChanged: (value) {},
-        ),
-        const SizedBox(height: 24),
-        const Padding(
-          padding: EdgeInsets.all(16.0),
-          child: Text(
-            'Notifications',
-            style: TextStyle(
-              fontSize: 14,
-              fontWeight: FontWeight.bold,
-              color: Colors.grey,
-            ),
-          ),
-        ),
-        AppSwitch(
-          value: true,
-          icon: Icons.notifications,
-          label: 'Push notifications',
-          subtitle: 'Show notifications on lock screen',
-          onChanged: (value) {},
-        ),
-        const Divider(height: 1),
-        AppSwitch(
-          value: false,
-          icon: Icons.vibration,
-          label: 'Vibrate',
-          onChanged: (value) {},
-        ),
-        const Divider(height: 1),
-        const AppSwitch(
-          value: false,
-          icon: Icons.volume_off,
-          label: 'Do not disturb',
-          subtitle: 'Disabled by administrator',
-          onChanged: null,
-        ),
-        const SizedBox(height: 24),
-        const Padding(
-          padding: EdgeInsets.all(16.0),
-          child: Text(
-            'Privacy',
-            style: TextStyle(
-              fontSize: 14,
-              fontWeight: FontWeight.bold,
-              color: Colors.grey,
-            ),
-          ),
-        ),
-        AppSwitch(
-          value: true,
-          icon: Icons.location_on,
-          label: 'Location services',
-          subtitle: 'Allow apps to use your location',
-          onChanged: (value) {},
-        ),
-        const Divider(height: 1),
-        AppSwitch(
-          value: false,
-          icon: Icons.camera_alt,
-          label: 'Camera access',
-          onChanged: (value) {},
-        ),
-        const Divider(height: 1),
-        AppSwitch(
-          value: false,
-          icon: Icons.mic,
-          label: 'Microphone access',
-          onChanged: (value) {},
-        ),
-      ],
-    ),
-  );
-}
-
-// 6. Theme Variations - Light, dark, and custom colors
+// 6. Theme Variations - Light, dark, and custom colors (Static - for comparison)
 @widgetbook.UseCase(name: 'Theme Variations', type: AppSwitch)
 Widget appSwitchThemeVariations(BuildContext context) {
   return SingleChildScrollView(
@@ -304,81 +381,53 @@ Widget appSwitchThemeVariations(BuildContext context) {
       padding: const EdgeInsets.all(16.0),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const Text(
+        children: const [
+          Text(
             'Toggle theme in Widgetbook to see variations',
             style: TextStyle(fontStyle: FontStyle.italic, fontSize: 12),
           ),
-          const SizedBox(height: 16),
-          const Text(
-            'Default Colors',
-            style: TextStyle(fontWeight: FontWeight.bold),
-          ),
-          const SizedBox(height: 8),
+          SizedBox(height: 16),
+          Text('Default Colors', style: TextStyle(fontWeight: FontWeight.bold)),
+          SizedBox(height: 8),
           AppSwitch(
             value: true,
             label: 'On (uses primary color)',
-            onChanged: (value) {},
+            onChanged: null,
           ),
-          const SizedBox(height: 8),
+          SizedBox(height: 8),
           AppSwitch(
             value: false,
             label: 'Off (uses surface color)',
-            onChanged: (value) {},
+            onChanged: null,
           ),
-          const SizedBox(height: 24),
-          const Text(
+          SizedBox(height: 24),
+          Text(
             'Custom Brand Colors',
             style: TextStyle(fontWeight: FontWeight.bold),
           ),
-          const SizedBox(height: 8),
+          SizedBox(height: 8),
           AppSwitch(
             value: true,
             label: 'Green switch',
             activeColor: Colors.white,
             activeTrackColor: Colors.green,
-            onChanged: (value) {},
+            onChanged: null,
           ),
-          const SizedBox(height: 8),
+          SizedBox(height: 8),
           AppSwitch(
             value: true,
             label: 'Orange switch',
             activeColor: Colors.white,
             activeTrackColor: Colors.deepOrange,
-            onChanged: (value) {},
+            onChanged: null,
           ),
-          const SizedBox(height: 8),
+          SizedBox(height: 8),
           AppSwitch(
             value: true,
             label: 'Blue switch',
             activeColor: Colors.white,
             activeTrackColor: Colors.blue,
-            onChanged: (value) {},
-          ),
-          const SizedBox(height: 24),
-          const Text(
-            'Contrast Demonstration',
-            style: TextStyle(fontWeight: FontWeight.bold),
-          ),
-          const SizedBox(height: 8),
-          Row(
-            children: [
-              Expanded(
-                child: AppSwitch(
-                  value: true,
-                  label: 'On',
-                  onChanged: (value) {},
-                ),
-              ),
-              const SizedBox(width: 16),
-              Expanded(
-                child: AppSwitch(
-                  value: false,
-                  label: 'Off',
-                  onChanged: (value) {},
-                ),
-              ),
-            ],
+            onChanged: null,
           ),
         ],
       ),
@@ -386,53 +435,72 @@ Widget appSwitchThemeVariations(BuildContext context) {
   );
 }
 
-// 7. Real-World Examples
+// 7. Real-World Examples (Interactive)
 @widgetbook.UseCase(name: 'Real-World Examples', type: AppSwitch)
 Widget appSwitchExamples(BuildContext context) {
-  return SingleChildScrollView(
-    child: Padding(
-      padding: const EdgeInsets.all(16.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const Text(
-            'Common Use Cases',
-            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-          ),
-          const SizedBox(height: 16),
-          AppSwitch(
-            value: true,
-            icon: Icons.dark_mode,
-            label: 'Dark mode',
-            subtitle: 'Reduces eye strain in low light',
-            onChanged: (value) {},
-          ),
-          const SizedBox(height: 16),
-          AppSwitch(
-            value: false,
-            icon: Icons.save_alt,
-            label: 'Auto-save',
-            subtitle: 'Automatically save changes',
-            onChanged: (value) {},
-          ),
-          const SizedBox(height: 16),
-          AppSwitch(
-            value: true,
-            icon: Icons.backup,
-            label: 'Cloud backup',
-            subtitle: 'Back up to cloud storage',
-            onChanged: (value) {},
-          ),
-          const SizedBox(height: 16),
-          const AppSwitch(
-            value: false,
-            icon: Icons.analytics,
-            label: 'Analytics',
-            subtitle: 'Managed by organization policy',
-            onChanged: null,
-          ),
-        ],
+  return const _RealWorldDemo();
+}
+
+class _RealWorldDemo extends StatefulWidget {
+  const _RealWorldDemo();
+
+  @override
+  State<_RealWorldDemo> createState() => _RealWorldDemoState();
+}
+
+class _RealWorldDemoState extends State<_RealWorldDemo> {
+  bool _darkMode = true;
+  bool _autoSave = false;
+  bool _cloudBackup = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Common Use Cases',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+            AppSwitch(
+              value: _darkMode,
+              icon: Icons.dark_mode,
+              label: 'Dark mode',
+              subtitle: 'Reduces eye strain in low light',
+              onChanged: (value) => setState(() => _darkMode = value),
+            ),
+            const SizedBox(height: 16),
+            AppSwitch(
+              value: _autoSave,
+              icon: Icons.save_alt,
+              label: 'Auto-save',
+              subtitle: 'Automatically save changes',
+              onChanged: (value) => setState(() => _autoSave = value),
+            ),
+            const SizedBox(height: 16),
+            AppSwitch(
+              value: _cloudBackup,
+              icon: Icons.backup,
+              label: 'Cloud backup',
+              subtitle: 'Back up to cloud storage',
+              onChanged: (value) => setState(() => _cloudBackup = value),
+            ),
+            const SizedBox(height: 16),
+            // Analytics - Disabled (managed by organization)
+            const AppSwitch(
+              value: false,
+              icon: Icons.analytics,
+              label: 'Analytics',
+              subtitle: 'Managed by organization policy',
+              onChanged: null,
+            ),
+          ],
+        ),
       ),
-    ),
-  );
+    );
+  }
 }


### PR DESCRIPTION
## 📄 Summary

Implement the [AppSwitch](cci:2://file:///home/mrcan/Documents/projects/hexaMobileShare/packages/core_kit/lib/widgets/inputs/app_switch.dart:95:0-276:1) component with Material Design 3 compliance for the `core_kit` package.

This PR adds a fully functional toggle switch widget with:
- Label, subtitle, and icon support
- On/off and disabled states
- Custom color options
- Comprehensive accessibility features (48x48dp touch targets, semantic labels)
- 26 widget tests with 100% pass rate
- 7 Widgetbook stories showcasing all features

Closes #17

---

## 🧩 Affected Module(s)

- [x] Packages (packages/*)
- [x] Widgetbook Kit (widgetbook_kit/)
- [ ] Documentation (docs/)
- [ ] CI / Infra (.github/)

---

## ✅ Checklist

- [✅] My branch name follows format: `<type>/<short-description>` (e.g., feat/login-screen)
- [✅] My PR title starts with one of the approved types listed above
- [✅] My Dart code is formatted (`dart format .` or `flutter format .`)
- [✅] I ran static analysis (`flutter analyze`) and resolved warnings
- [✅] I ran tests successfully (`flutter test`)
- [✅] I updated / checked pubspec.yaml and pubspec.lock for dependency changes
- [✅] For UI changes, I added screenshots and/or updated golden tests (if applicable)
- [✅] I linked related issues using keywords like `Closes #42`
- [✅] I ensured this PR has no unrelated changes
- [✅] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

Closes #17

---

## 💬 Additional Notes

### Files Changed:
- [packages/core_kit/lib/widgets/inputs/app_switch.dart](cci:7://file:///home/mrcan/Documents/projects/hexaMobileShare/packages/core_kit/lib/widgets/inputs/app_switch.dart:0:0-0:0) - Widget implementation
- [packages/core_kit/test/widgets/inputs/app_switch_test.dart](cci:7://file:///home/mrcan/Documents/projects/hexaMobileShare/packages/core_kit/test/widgets/inputs/app_switch_test.dart:0:0-0:0) - 26 widget tests
- [widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_switch_stories.dart](cci:7://file:///home/mrcan/Documents/projects/hexaMobileShare/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_switch_stories.dart:0:0-0:0) - 7 stories
- [widgetbook_kit/lib/app/widgetbook_app.directories.g.dart](cci:7://file:///home/mrcan/Documents/projects/hexaMobileShare/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart:0:0-0:0) - Generated

### Test Results:
- ✅ 26/26 tests passed (100% pass rate)
- ✅ `flutter analyze` - No issues found
- ✅ `reuse lint` - REUSE compliant
- ✅ All CI checks passed

### Widgetbook Stories:
1. Default
2. All States
3. With Labels
4. With Icons
5. Settings List
6. Theme Variations
7. Real-World Examples