### PR TITLE
feat: implement AppCard component with Widgetbook stories

### DIFF
--- a/packages/core_kit/lib/widgets/surfaces/app_card.dart
+++ b/packages/core_kit/lib/widgets/surfaces/app_card.dart
@@ -3,73 +3,167 @@
 
 import 'package:flutter/material.dart';
 
+import '../../theme/app_radius.dart';
+
 /// A Material Design 3 card widget with consistent styling.
-/// Provides elevation, padding, and optional tap handling.
+///
+/// [AppCard] is a versatile surface container that groups related content and actions.
+/// It supports various styles including flat, elevated, and outlined variants.
+///
+/// Example:
+/// ```dart
+/// AppCard(
+///   onTap: () {},
+///   child: Text('Card Content'),
+/// )
+/// ```
 class AppCard extends StatelessWidget {
-  /// The widget to display inside the card
+  /// The widget to display inside the card.
   final Widget child;
 
-  /// Optional callback when the card is tapped
+  /// Optional callback when the card is tapped.
+  /// If provided, the card becomes interactive with a ripple effect.
   final VoidCallback? onTap;
 
-  /// Card elevation level (0-5)
+  /// Card elevation level.
+  /// - 0: Flat
+  /// - 1: Default
+  /// - 3: Elevated
   final double? elevation;
 
-  /// Internal padding of the card
+  /// Internal padding of the card.
   final EdgeInsetsGeometry? padding;
 
-  /// Card background color
+  /// Card background color.
   final Color? color;
 
-  /// Card border radius
-  final BorderRadius? borderRadius;
+  /// Card border radius. Defaults to [AppRadius.md] (12dp).
+  final BorderRadiusGeometry? borderRadius;
 
-  /// Creates an AppCard
+  /// External margin of the card.
+  final EdgeInsetsGeometry? margin;
+
+  /// Content clipping behavior.
+  final Clip? clipBehavior;
+
+  /// Color of the shadow when elevation is > 0.
+  final Color? shadowColor;
+
+  /// Overlay color for M3 elevation tint.
+  final Color? surfaceTintColor;
+
+  /// Whether to paint the border in front of the child.
+  final bool borderOnForeground;
+
+  /// Custom shape border.
+  final ShapeBorder? shape;
+
+  /// Creates a default [AppCard] with standard styling (1dp elevation).
   const AppCard({
     required this.child,
     this.onTap,
-    this.elevation,
+    this.elevation = 1.0,
     this.padding,
     this.color,
     this.borderRadius,
+    this.margin,
+    this.clipBehavior,
+    this.shadowColor,
+    this.surfaceTintColor,
+    this.borderOnForeground = true,
+    this.shape,
     super.key,
   });
 
-  /// Creates a flat card with minimal elevation
+  /// Creates a flat [AppCard] with no elevation (0dp).
+  /// Useful for grouping content on a surface without adding depth.
   const AppCard.flat({
     required this.child,
     this.onTap,
     this.padding,
     this.color,
     this.borderRadius,
+    this.margin,
+    this.clipBehavior,
+    this.shadowColor,
+    this.surfaceTintColor,
+    this.borderOnForeground = true,
+    this.shape,
     super.key,
   }) : elevation = 0;
 
-  /// Creates an elevated card with higher elevation
+  /// Creates an elevated [AppCard] with higher elevation (3dp).
+  /// Used for items that need more emphasis or separation.
   const AppCard.elevated({
     required this.child,
     this.onTap,
     this.padding,
     this.color,
     this.borderRadius,
+    this.margin,
+    this.clipBehavior,
+    this.shadowColor,
+    this.surfaceTintColor,
+    this.borderOnForeground = true,
+    this.shape,
     super.key,
-  }) : elevation = 4;
+  }) : elevation = 3;
+
+  /// Creates an outlined [AppCard] with a border and no elevation.
+  /// Useful for situations where elevation is not appropriate but separation is needed.
+  const AppCard.outlined({
+    required this.child,
+    this.onTap,
+    this.padding,
+    this.color,
+    this.borderRadius,
+    this.margin,
+    this.clipBehavior,
+    this.shadowColor,
+    this.surfaceTintColor,
+    this.borderOnForeground = true,
+    this.shape,
+    super.key,
+  }) : elevation = 0;
 
   @override
   Widget build(BuildContext context) {
-    final card = Card(
+    final theme = Theme.of(context);
+    final isOutlined = elevation == 0 && color == null && shape == null;
+
+    // Determine the shape with border radius
+    final effectiveShape =
+        shape ??
+        (isOutlined
+            ? RoundedRectangleBorder(
+                side: BorderSide(color: theme.colorScheme.outline),
+                borderRadius: borderRadius ?? AppRadius.mdRadius,
+              )
+            : RoundedRectangleBorder(
+                borderRadius: borderRadius ?? AppRadius.mdRadius,
+              ));
+
+    return Card(
       elevation: elevation,
       color: color,
-      shape: borderRadius != null
-          ? RoundedRectangleBorder(borderRadius: borderRadius!)
-          : null,
-      child: padding != null ? Padding(padding: padding!, child: child) : child,
+      shadowColor: shadowColor,
+      surfaceTintColor: surfaceTintColor,
+      margin: margin,
+      shape: effectiveShape,
+      clipBehavior: clipBehavior ?? Clip.hardEdge,
+      borderOnForeground: borderOnForeground,
+      child: onTap != null
+          ? InkWell(
+              onTap: onTap,
+              // Match the card's shape for the ripple
+              customBorder: effectiveShape,
+              child: padding != null
+                  ? Padding(padding: padding!, child: child)
+                  : child,
+            )
+          : (padding != null
+                ? Padding(padding: padding!, child: child)
+                : child),
     );
-
-    if (onTap != null) {
-      return InkWell(onTap: onTap, borderRadius: borderRadius, child: card);
-    }
-
-    return card;
   }
 }

--- a/packages/core_kit/test/widgets/surfaces/app_card_test.dart
+++ b/packages/core_kit/test/widgets/surfaces/app_card_test.dart
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:core_kit/widgets/surfaces/app_card.dart';
+
+void main() {
+  group('AppCard Tests', () {
+    testWidgets('AppCard default variant renders correctly', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: AppCard(child: const Text('Default Card'))),
+        ),
+      );
+
+      final cardFinder = find.byType(Card);
+      expect(cardFinder, findsOneWidget);
+
+      final Card card = tester.widget(cardFinder);
+      expect(card.elevation, 1.0);
+      expect(card.clipBehavior, Clip.hardEdge);
+      expect(find.text('Default Card'), findsOneWidget);
+    });
+
+    testWidgets('AppCard.flat variant has 0 elevation', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: AppCard.flat(child: const Text('Flat Card'))),
+        ),
+      );
+
+      final Card card = tester.widget(find.byType(Card));
+      expect(card.elevation, 0.0);
+    });
+
+    testWidgets('AppCard.elevated variant has 3 elevation', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppCard.elevated(child: const Text('Elevated Card')),
+          ),
+        ),
+      );
+
+      final Card card = tester.widget(find.byType(Card));
+      expect(card.elevation, 3.0);
+    });
+
+    testWidgets('AppCard.outlined variant has border and 0 elevation', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppCard.outlined(child: const Text('Outlined Card')),
+          ),
+        ),
+      );
+
+      final Card card = tester.widget(find.byType(Card));
+      expect(card.elevation, 0.0);
+
+      final shape = card.shape as RoundedRectangleBorder;
+      expect(shape.side.style, BorderStyle.solid);
+    });
+
+    testWidgets('AppCard handles onTap interaction', (tester) async {
+      bool tapped = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppCard(
+              onTap: () {
+                tapped = true;
+              },
+              child: const Text('Tappable Card'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(AppCard));
+      await tester.pumpAndSettle();
+
+      expect(tapped, isTrue);
+      // Ensure InkWell is present
+      expect(find.byType(InkWell), findsOneWidget);
+    });
+
+    testWidgets('AppCard applies custom properties correctly', (tester) async {
+      const customPadding = EdgeInsets.all(20);
+      const customColor = Colors.red;
+      const customRadius = BorderRadius.all(Radius.circular(20));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppCard(
+              padding: customPadding,
+              color: customColor,
+              borderRadius: customRadius,
+              child: const Text('Custom Card'),
+            ),
+          ),
+        ),
+      );
+
+      final Card card = tester.widget(find.byType(Card));
+      expect(card.color, customColor);
+
+      // Find the Padding that directly wraps the text "Custom Card"
+      // Note: There might be other paddings (e.g. Card margin), so we target the specific one.
+      final paddingFinder = find
+          .ancestor(
+            of: find.text('Custom Card'),
+            matching: find.byType(Padding),
+          )
+          .first;
+
+      final paddingWidget = tester.widget<Padding>(paddingFinder);
+      expect(paddingWidget.padding, customPadding);
+
+      final shape = card.shape as RoundedRectangleBorder;
+      expect(shape.borderRadius, customRadius);
+    });
+
+    testWidgets('AppCard structure renders InkWell inside Card', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppCard(onTap: () {}, child: const Text('Structure Test')),
+          ),
+        ),
+      );
+
+      // Verify InkWell is a descendant of Card
+      expect(
+        find.descendant(of: find.byType(Card), matching: find.byType(InkWell)),
+        findsOneWidget,
+      );
+    });
+  });
+}

--- a/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
+++ b/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
@@ -15,10 +15,16 @@ import 'package:widgetbook_kit/stories/core_kit/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_buttons_app_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories;
-import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_checkbox_stories.dart'
-    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_icon_button_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_outlined_button_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_text_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_checkbox_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_card_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories;
 
 final directories = <_widgetbook.WidgetbookNode>[
   _widgetbook.WidgetbookFolder(
@@ -231,6 +237,100 @@ final directories = <_widgetbook.WidgetbookNode>[
             ],
           ),
           _widgetbook.WidgetbookComponent(
+            name: 'AppIconButton',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'All Variants',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonAllVariants,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Common Icons',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonCommonIcons,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Interactive Playground',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonPlayground,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Sizes',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonSizes,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'States',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonStates,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Theme Variations',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonTheme,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Toggle Button',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonToggle,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'AppOutlinedButton',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Comparison',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonComparison,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Sizes',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonSizes,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'States',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonStates,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Theme Variations',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonTheme,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Icon',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonWithIcon,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
             name: 'AppTextButton',
             useCases: [
               _widgetbook.WidgetbookUseCase(
@@ -362,6 +462,58 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories
                         .appCheckboxThemeVariations,
+              ),
+            ],
+          ),
+        ],
+      ),
+      _widgetbook.WidgetbookFolder(
+        name: 'surfaces',
+        children: [
+          _widgetbook.WidgetbookComponent(
+            name: 'AppCard',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'All Variants',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
+                        .appCardVariants,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Content Types',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
+                        .appCardContentTypes,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Custom Styling',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
+                        .appCardCustom,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
+                        .appCardDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Elevation Levels',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
+                        .appCardElevations,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Interactive',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
+                        .appCardInteractive,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Interactive Playground',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
+                        .appCardPlayground,
               ),
             ],
           ),

--- a/widgetbook_kit/lib/stories/core_kit/widgets/surfaces/app_card_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/surfaces/app_card_stories.dart
@@ -1,2 +1,282 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/widgets/surfaces/app_card.dart';
+import 'package:core_kit/theme/app_spacing.dart';
+
+@widgetbook.UseCase(name: 'Default', type: AppCard)
+Widget appCardDefault(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(AppSpacing.md),
+    child: AppCard(
+      padding: const EdgeInsets.all(AppSpacing.md),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            'Default Card (Level 1)',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          const Text(
+            'This is the default card variant with 1dp elevation and medium radius.',
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'All Variants', type: AppCard)
+Widget appCardVariants(BuildContext context) {
+  return SingleChildScrollView(
+    padding: const EdgeInsets.all(AppSpacing.md),
+    child: Column(
+      children: [
+        _buildVariantExample(
+          context,
+          'Flat (Level 0)',
+          AppCard.flat(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: const Text('Flat Card\nNo elevation, blends with surface'),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        _buildVariantExample(
+          context,
+          'Default (Level 1)',
+          AppCard(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: const Text('Default AppCard\nStandard 1dp elevation'),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        _buildVariantExample(
+          context,
+          'Elevated (Level 2/3)',
+          AppCard.elevated(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: const Text(
+              'Elevated Card\nHigher elevation (3dp) for emphasis',
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        _buildVariantExample(
+          context,
+          'Outlined (Level 0)',
+          AppCard.outlined(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: const Text('Outlined Card\nBordered with no elevation'),
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+Widget _buildVariantExample(BuildContext context, String title, Widget card) {
+  return Column(
+    crossAxisAlignment: CrossAxisAlignment.stretch,
+    children: [
+      Text(title, style: Theme.of(context).textTheme.labelLarge),
+      const SizedBox(height: AppSpacing.xs),
+      card,
+    ],
+  );
+}
+
+@widgetbook.UseCase(name: 'Interactive', type: AppCard)
+Widget appCardInteractive(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(AppSpacing.md),
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AppCard(
+          onTap: () {},
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  const Icon(Icons.touch_app),
+                  const SizedBox(width: AppSpacing.sm),
+                  Text(
+                    'Tappable Card',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              const Text(
+                'Tap this card to see the ripple effect. The ripple is clipped to the card shape.',
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        AppCard.outlined(
+          onTap: () {},
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: const SizedBox(
+            width: double.infinity,
+            child: Text('Tappable Outlined Card', textAlign: TextAlign.center),
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Content Types', type: AppCard)
+Widget appCardContentTypes(BuildContext context) {
+  return SingleChildScrollView(
+    padding: const EdgeInsets.all(AppSpacing.md),
+    child: Column(
+      children: [
+        // List Card
+        AppCard(
+          child: Column(
+            children: [
+              ListTile(
+                leading: const Icon(Icons.image),
+                title: const Text('List Tile within Card'),
+                subtitle: const Text('Using ListTile for consistency'),
+              ),
+              const Divider(height: 1),
+              ListTile(
+                leading: const Icon(Icons.description),
+                title: const Text('Second Item'),
+                onTap: () {},
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        // Media Card
+        AppCard(
+          clipBehavior: Clip.antiAlias,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                height: 150,
+                color: Colors.grey.shade300,
+                alignment: Alignment.center,
+                child: const Icon(Icons.image, size: 48, color: Colors.grey),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(AppSpacing.md),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Media Card',
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: AppSpacing.xs),
+                    const Text(
+                      'Card with an image (placeholder) and content below.',
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Elevation Levels', type: AppCard)
+Widget appCardElevations(BuildContext context) {
+  return SingleChildScrollView(
+    padding: const EdgeInsets.all(AppSpacing.md),
+    child: Column(
+      children: [
+        for (final elevation in [0.0, 1.0, 3.0, 6.0, 8.0, 12.0])
+          Padding(
+            padding: const EdgeInsets.only(bottom: AppSpacing.md),
+            child: AppCard(
+              elevation: elevation,
+              padding: const EdgeInsets.all(AppSpacing.md),
+              child: SizedBox(
+                width: double.infinity,
+                child: Text('Elevation ${elevation.toInt()}'),
+              ),
+            ),
+          ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Custom Styling', type: AppCard)
+Widget appCardCustom(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(AppSpacing.md),
+    child: AppCard(
+      color: Theme.of(context).colorScheme.primaryContainer,
+      borderRadius: const BorderRadius.only(
+        topLeft: Radius.circular(20),
+        bottomRight: Radius.circular(20),
+      ),
+      padding: const EdgeInsets.all(24),
+      elevation: 5,
+      shadowColor: Colors.red.withValues(alpha: 0.5),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: const [
+          Text('Custom Styled Card'),
+          SizedBox(height: 8),
+          Text('Custom color, radius, padding, and shadow.'),
+        ],
+      ),
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Interactive Playground', type: AppCard)
+Widget appCardPlayground(BuildContext context) {
+  final elevation = context.knobs.double.slider(
+    label: 'Elevation',
+    initialValue: 1,
+    min: 0,
+    max: 12,
+  );
+
+  final onTapEnabled = context.knobs.boolean(
+    label: 'Enable onTap',
+    initialValue: true,
+  );
+
+  final isOutlined = context.knobs.boolean(
+    label: 'Is Outlined',
+    initialValue: false,
+  );
+
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(AppSpacing.md),
+      child: isOutlined
+          ? AppCard.outlined(
+              onTap: onTapEnabled ? () {} : null,
+              padding: const EdgeInsets.all(AppSpacing.md),
+              child: const Text('Playground Card (Outlined)'),
+            )
+          : AppCard(
+              elevation: elevation,
+              onTap: onTapEnabled ? () {} : null,
+              padding: const EdgeInsets.all(AppSpacing.md),
+              child: Text('Playground Card (Elev: $elevation)'),
+            ),
+    ),
+  );
+}


### PR DESCRIPTION
## 📄 Summary

Implement AppCard component with Material Design 3 compliance for Issue #18.

### Changes:
- Add `AppCard.flat()`, `AppCard.elevated()`, `AppCard.outlined()` variants
- Fix InkWell ripple clipping bug (moved inside Card)
- Add new properties: `margin`, `clipBehavior`, `shadowColor`, `surfaceTintColor`
- Add comprehensive widget tests (7 tests)
- Add 7 Widgetbook stories (Default, All Variants, Interactive, Content Types, Elevation Levels, Custom Styling, Interactive Playground)

Closes #18

---

## 🧩 Affected Module(s)

- [x] Packages (`packages/*`)
- [x] Widgetbook Kit (`widgetbook_kit/`)
- [ ] Documentation (`docs/`)
- [ ] CI / Infra (`.github/`)

---

## ✅ Checklist

- [✅] My branch name follows format: `<type>/<short-description>`
- [✅] My PR title starts with one of the approved types
- [✅] My Dart code is formatted (`dart format .`)
- [✅] I ran static analysis (`flutter analyze`) and resolved warnings
- [✅] I ran tests successfully (`flutter test`)
- [✅] I updated / checked `pubspec.yaml` and `pubspec.lock` for dependency changes
- [✅] For UI changes, I added Widgetbook stories
- [✅] I linked related issues using keywords like `Closes #18`
- [✅] I ensured this PR has no unrelated changes
- [✅] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

Closes #18

---

## 💬 Additional Notes

Run Widgetbook to see the component in action:
\`\`\`bash
pnpm storybook
\`\`\`
Then navigate to: `core_kit > widgets > surfaces > AppCard`