### PR TITLE
feat(core_kit): implement AppSectionHeader component with Widgetbook stories

### DIFF
--- a/packages/core_kit/lib/core_kit.dart
+++ b/packages/core_kit/lib/core_kit.dart
@@ -13,3 +13,4 @@ export 'theme/app_shadows.dart';
 export 'widgets/buttons/app_button.dart';
 export 'widgets/inputs/app_checkbox.dart';
 export 'widgets/buttons/app_text_button.dart';
+export 'widgets/surfaces/app_section_header.dart';

--- a/packages/core_kit/lib/widgets/surfaces/app_section_header.dart
+++ b/packages/core_kit/lib/widgets/surfaces/app_section_header.dart
@@ -1,6 +1,321 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppSectionHeader {
-  const AppSectionHeader();
+import 'package:flutter/material.dart';
+
+import '../../theme/app_spacing.dart';
+
+/// Defines the position of the divider relative to the section header.
+enum DividerPosition {
+  /// No divider is shown.
+  none,
+
+  /// Divider is shown above the section header.
+  above,
+
+  /// Divider is shown below the section header.
+  below,
+
+  /// Dividers are shown both above and below the section header.
+  both,
+}
+
+/// A Material Design 3 section header widget for organizing content.
+///
+/// [AppSectionHeader] is a visual divider that organizes content into logical
+/// groups by displaying a title and optional actions. It's commonly used in
+/// settings screens, forms, lists, and anywhere content needs to be categorized.
+///
+/// Section headers improve scannability and help users quickly find what they're
+/// looking for. They provide semantic structure for screen readers.
+///
+/// The widget follows M3 specifications:
+/// - Minimum height: 48dp (with single-line title)
+/// - Padding: 16dp horizontal, 8dp vertical (default)
+/// - Title: titleSmall (14sp, 500 weight)
+/// - Subtitle: bodySmall (12sp, regular weight)
+///
+/// Example:
+/// ```dart
+/// AppSectionHeader(
+///   title: 'Account Settings',
+/// )
+///
+/// AppSectionHeader(
+///   title: 'Privacy',
+///   subtitle: 'Manage your privacy and security settings',
+///   trailing: TextButton(
+///     onPressed: () {},
+///     child: Text('Edit'),
+///   ),
+/// )
+///
+/// // For sticky headers in scrollable content:
+/// CustomScrollView(
+///   slivers: [
+///     SliverPersistentHeader(
+///       pinned: true,
+///       delegate: SectionHeaderDelegate(
+///         child: AppSectionHeader(
+///           title: 'Pinned Section',
+///           backgroundColor: Theme.of(context).colorScheme.surface,
+///         ),
+///       ),
+///     ),
+///   ],
+/// )
+/// ```
+class AppSectionHeader extends StatelessWidget {
+  /// Creates a section header with the given [title].
+  ///
+  /// The [title] is the main text displayed in the section header.
+  const AppSectionHeader({
+    required this.title,
+    this.subtitle,
+    this.leading,
+    this.trailing,
+    this.padding,
+    this.showDivider = false,
+    this.dividerPosition = DividerPosition.below,
+    this.dividerIndent,
+    this.dividerEndIndent,
+    this.backgroundColor,
+    this.textStyle,
+    this.subtitleStyle,
+    this.isUpperCase = false,
+    this.minHeight = 48.0,
+    super.key,
+  });
+
+  /// The main title text of the section header.
+  ///
+  /// This is required and will be displayed prominently.
+  final String title;
+
+  /// An optional subtitle or description below the title.
+  ///
+  /// Use this to provide additional context about the section.
+  final String? subtitle;
+
+  /// An optional widget to display before the title.
+  ///
+  /// Typically an [Icon] widget.
+  final Widget? leading;
+
+  /// An optional widget to display after the title.
+  ///
+  /// Typically a [TextButton] or [IconButton] for section-level actions.
+  final Widget? trailing;
+
+  /// Custom padding for the section header.
+  ///
+  /// If null, defaults to horizontal 16dp and vertical 8dp padding.
+  final EdgeInsetsGeometry? padding;
+
+  /// Whether to show a divider.
+  ///
+  /// Defaults to false. When true, a divider is shown at the position
+  /// specified by [dividerPosition].
+  final bool showDivider;
+
+  /// The position of the divider relative to the section header content.
+  ///
+  /// Only applies when [showDivider] is true.
+  /// Defaults to [DividerPosition.below].
+  final DividerPosition dividerPosition;
+
+  /// The amount of empty space to the leading edge of the divider.
+  ///
+  /// If null, the divider extends to the edge of its parent.
+  final double? dividerIndent;
+
+  /// The amount of empty space to the trailing edge of the divider.
+  ///
+  /// If null, the divider extends to the edge of its parent.
+  final double? dividerEndIndent;
+
+  /// The background color of the section header.
+  ///
+  /// If null, the header has a transparent background.
+  /// Set this to an opaque color when using as a sticky header.
+  final Color? backgroundColor;
+
+  /// Custom text style for the title.
+  ///
+  /// If null, uses [TextTheme.titleSmall] with [ColorScheme.onSurfaceVariant].
+  final TextStyle? textStyle;
+
+  /// Custom text style for the subtitle.
+  ///
+  /// If null, uses [TextTheme.bodySmall] with [ColorScheme.onSurfaceVariant]
+  /// at 60% opacity.
+  final TextStyle? subtitleStyle;
+
+  /// Whether to display the title in uppercase.
+  ///
+  /// Defaults to false. M3 section headers often use uppercase styling.
+  final bool isUpperCase;
+
+  /// The minimum height of the section header.
+  ///
+  /// Defaults to 48dp as per Material Design 3 specifications.
+  final double minHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    // Build title text
+    final displayTitle = isUpperCase ? title.toUpperCase() : title;
+
+    final effectiveTitleStyle =
+        textStyle ??
+        theme.textTheme.titleSmall?.copyWith(
+          color: colorScheme.onSurfaceVariant,
+          fontWeight: FontWeight.w500,
+        );
+
+    final effectiveSubtitleStyle =
+        subtitleStyle ??
+        theme.textTheme.bodySmall?.copyWith(
+          color: colorScheme.onSurfaceVariant.withAlpha(153), // 60% opacity
+        );
+
+    final effectivePadding =
+        padding ??
+        const EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+          vertical: AppSpacing.sm,
+        );
+
+    // Build the content row with minimum height
+    Widget content = ConstrainedBox(
+      constraints: BoxConstraints(minHeight: minHeight),
+      child: Padding(
+        padding: effectivePadding,
+        child: Row(
+          children: [
+            if (leading != null) ...[
+              leading!,
+              const SizedBox(width: AppSpacing.sm),
+            ],
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(displayTitle, style: effectiveTitleStyle),
+                  if (subtitle != null) ...[
+                    const SizedBox(height: AppSpacing.xs / 2),
+                    Text(subtitle!, style: effectiveSubtitleStyle),
+                  ],
+                ],
+              ),
+            ),
+            if (trailing != null) trailing!,
+          ],
+        ),
+      ),
+    );
+
+    // Apply background color if specified
+    if (backgroundColor != null) {
+      content = ColoredBox(color: backgroundColor!, child: content);
+    }
+
+    // Build with dividers if needed
+    if (showDivider && dividerPosition != DividerPosition.none) {
+      final divider = Divider(
+        height: 1,
+        thickness: 1,
+        color: colorScheme.outlineVariant,
+        indent: dividerIndent,
+        endIndent: dividerEndIndent,
+      );
+
+      content = Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (dividerPosition == DividerPosition.above ||
+              dividerPosition == DividerPosition.both)
+            divider,
+          content,
+          if (dividerPosition == DividerPosition.below ||
+              dividerPosition == DividerPosition.both)
+            divider,
+        ],
+      );
+    }
+
+    // Wrap with semantics for accessibility
+    return Semantics(
+      header: true,
+      label: subtitle != null ? '$title, $subtitle' : title,
+      child: content,
+    );
+  }
+}
+
+/// A [SliverPersistentHeaderDelegate] for creating sticky section headers.
+///
+/// Use this delegate with [SliverPersistentHeader] to create section headers
+/// that stick to the top of the viewport when scrolling.
+///
+/// Example:
+/// ```dart
+/// CustomScrollView(
+///   slivers: [
+///     SliverPersistentHeader(
+///       pinned: true,
+///       delegate: SectionHeaderDelegate(
+///         child: AppSectionHeader(
+///           title: 'Pinned Section',
+///           backgroundColor: Theme.of(context).colorScheme.surface,
+///         ),
+///       ),
+///     ),
+///     SliverList(
+///       delegate: SliverChildListDelegate([
+///         // List items...
+///       ]),
+///     ),
+///   ],
+/// )
+/// ```
+class SectionHeaderDelegate extends SliverPersistentHeaderDelegate {
+  /// Creates a section header delegate.
+  ///
+  /// The [child] is typically an [AppSectionHeader] widget.
+  /// The [height] defaults to 48dp as per Material Design 3 specifications.
+  const SectionHeaderDelegate({required this.child, this.height = 48.0});
+
+  /// The widget to display as the section header.
+  final Widget child;
+
+  /// The height of the section header.
+  ///
+  /// Defaults to 48dp.
+  final double height;
+
+  @override
+  double get minExtent => height;
+
+  @override
+  double get maxExtent => height;
+
+  @override
+  Widget build(
+    BuildContext context,
+    double shrinkOffset,
+    bool overlapsContent,
+  ) {
+    return SizedBox.expand(child: child);
+  }
+
+  @override
+  bool shouldRebuild(SectionHeaderDelegate oldDelegate) {
+    return oldDelegate.child != child || oldDelegate.height != height;
+  }
 }

--- a/packages/core_kit/lib/widgets/surfaces/app_section_header.dart
+++ b/packages/core_kit/lib/widgets/surfaces/app_section_header.dart
@@ -252,7 +252,7 @@ class AppSectionHeader extends StatelessWidget {
     // Wrap with semantics for accessibility
     return Semantics(
       header: true,
-      label: subtitle != null ? '$title, $subtitle' : title,
+      label: subtitle != null ? '$displayTitle, $subtitle' : displayTitle,
       child: content,
     );
   }

--- a/packages/core_kit/test/widgets/surfaces/app_section_header_test.dart
+++ b/packages/core_kit/test/widgets/surfaces/app_section_header_test.dart
@@ -1,0 +1,567 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:core_kit/widgets/surfaces/app_section_header.dart';
+
+void main() {
+  group('AppSectionHeader Tests', () {
+    // ==================== Basic Rendering Tests ====================
+
+    testWidgets('renders with title only', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppSectionHeader(title: 'Section Title')),
+        ),
+      );
+
+      expect(find.text('Section Title'), findsOneWidget);
+    });
+
+    testWidgets('renders with title and subtitle', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              subtitle: 'Section description text',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Section Title'), findsOneWidget);
+      expect(find.text('Section description text'), findsOneWidget);
+    });
+
+    testWidgets('renders uppercase title when isUpperCase is true', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(title: 'Section Title', isUpperCase: true),
+          ),
+        ),
+      );
+
+      expect(find.text('SECTION TITLE'), findsOneWidget);
+      expect(find.text('Section Title'), findsNothing);
+    });
+
+    // ==================== Leading & Trailing Tests ====================
+
+    testWidgets('renders with leading widget', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              leading: Icon(Icons.settings),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.settings), findsOneWidget);
+      expect(find.text('Section Title'), findsOneWidget);
+    });
+
+    testWidgets('renders with trailing widget', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              trailing: TextButton(
+                onPressed: () {},
+                child: const Text('Action'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Action'), findsOneWidget);
+      expect(find.byType(TextButton), findsOneWidget);
+    });
+
+    testWidgets('renders with both leading and trailing', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              leading: const Icon(Icons.notifications),
+              trailing: IconButton(
+                onPressed: () {},
+                icon: const Icon(Icons.arrow_forward),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.notifications), findsOneWidget);
+      expect(find.byIcon(Icons.arrow_forward), findsOneWidget);
+    });
+
+    // ==================== Divider Tests ====================
+
+    testWidgets('does not show divider by default', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppSectionHeader(title: 'Section Title')),
+        ),
+      );
+
+      expect(find.byType(Divider), findsNothing);
+    });
+
+    testWidgets('shows divider below when showDivider is true', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              showDivider: true,
+              dividerPosition: DividerPosition.below,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(Divider), findsOneWidget);
+    });
+
+    testWidgets('shows divider above when dividerPosition is above', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              showDivider: true,
+              dividerPosition: DividerPosition.above,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(Divider), findsOneWidget);
+    });
+
+    testWidgets('shows dividers both sides when dividerPosition is both', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              showDivider: true,
+              dividerPosition: DividerPosition.both,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(Divider), findsNWidgets(2));
+    });
+
+    testWidgets('does not show divider when dividerPosition is none', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              showDivider: true,
+              dividerPosition: DividerPosition.none,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(Divider), findsNothing);
+    });
+
+    // ==================== Custom Styling Tests ====================
+
+    testWidgets('applies custom padding', (tester) async {
+      const customPadding = EdgeInsets.all(24);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              padding: customPadding,
+            ),
+          ),
+        ),
+      );
+
+      final paddingFinder = find.ancestor(
+        of: find.text('Section Title'),
+        matching: find.byType(Padding),
+      );
+
+      expect(paddingFinder, findsWidgets);
+
+      // Find the Padding that has our custom padding
+      bool foundCustomPadding = false;
+      for (final element in paddingFinder.evaluate()) {
+        final widget = element.widget as Padding;
+        if (widget.padding == customPadding) {
+          foundCustomPadding = true;
+          break;
+        }
+      }
+      expect(foundCustomPadding, isTrue);
+    });
+
+    testWidgets('applies background color', (tester) async {
+      const bgColor = Colors.red;
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              backgroundColor: bgColor,
+            ),
+          ),
+        ),
+      );
+
+      // Find ColoredBox widgets and check if any has our background color
+      final coloredBoxFinder = find.byType(ColoredBox);
+      expect(coloredBoxFinder, findsWidgets);
+
+      bool foundBgColor = false;
+      for (final element in coloredBoxFinder.evaluate()) {
+        final coloredBox = element.widget as ColoredBox;
+        if (coloredBox.color == bgColor) {
+          foundBgColor = true;
+          break;
+        }
+      }
+      expect(foundBgColor, isTrue);
+    });
+
+    testWidgets('applies custom text style', (tester) async {
+      const customStyle = TextStyle(
+        fontSize: 20,
+        fontWeight: FontWeight.bold,
+        color: Colors.blue,
+      );
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              textStyle: customStyle,
+            ),
+          ),
+        ),
+      );
+
+      final textFinder = find.text('Section Title');
+      final textWidget = tester.widget<Text>(textFinder);
+
+      expect(textWidget.style?.fontSize, 20);
+      expect(textWidget.style?.fontWeight, FontWeight.bold);
+      expect(textWidget.style?.color, Colors.blue);
+    });
+
+    testWidgets('applies custom subtitle style', (tester) async {
+      const customSubtitleStyle = TextStyle(
+        fontSize: 14,
+        fontStyle: FontStyle.italic,
+        color: Colors.green,
+      );
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              subtitle: 'Subtitle text',
+              subtitleStyle: customSubtitleStyle,
+            ),
+          ),
+        ),
+      );
+
+      final subtitleFinder = find.text('Subtitle text');
+      final subtitleWidget = tester.widget<Text>(subtitleFinder);
+
+      expect(subtitleWidget.style?.fontSize, 14);
+      expect(subtitleWidget.style?.fontStyle, FontStyle.italic);
+      expect(subtitleWidget.style?.color, Colors.green);
+    });
+
+    // ==================== Accessibility Tests ====================
+
+    testWidgets('has correct semantics for accessibility', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppSectionHeader(title: 'Section Title')),
+        ),
+      );
+
+      final semanticsFinder = find.byType(Semantics);
+      expect(semanticsFinder, findsWidgets);
+
+      // Find the Semantics widget that wraps our content
+      final semanticsWidget = tester.widget<Semantics>(
+        find
+            .ancestor(
+              of: find.text('Section Title'),
+              matching: find.byType(Semantics),
+            )
+            .first,
+      );
+
+      expect(semanticsWidget.properties.header, isTrue);
+    });
+
+    testWidgets('includes subtitle in semantic label', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              subtitle: 'Description',
+            ),
+          ),
+        ),
+      );
+
+      final semanticsWidget = tester.widget<Semantics>(
+        find
+            .ancestor(
+              of: find.text('Section Title'),
+              matching: find.byType(Semantics),
+            )
+            .first,
+      );
+
+      expect(semanticsWidget.properties.label, 'Section Title, Description');
+    });
+
+    // ==================== Layout Tests ====================
+
+    testWidgets('content is laid out in a Row', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              leading: Icon(Icons.star),
+            ),
+          ),
+        ),
+      );
+
+      // Icon and text should be in a row
+      final rowFinder = find.ancestor(
+        of: find.byIcon(Icons.star),
+        matching: find.byType(Row),
+      );
+      expect(rowFinder, findsOneWidget);
+    });
+
+    testWidgets('trailing action is tappable', (tester) async {
+      bool actionTapped = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              trailing: TextButton(
+                onPressed: () {
+                  actionTapped = true;
+                },
+                child: const Text('Tap Me'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Tap Me'));
+      await tester.pumpAndSettle();
+
+      expect(actionTapped, isTrue);
+    });
+
+    // ==================== Min Height Tests ====================
+
+    testWidgets('has minimum height of 48dp by default', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppSectionHeader(title: 'Section Title')),
+        ),
+      );
+
+      final constrainedBoxFinder = find.byType(ConstrainedBox);
+      expect(constrainedBoxFinder, findsWidgets);
+
+      bool foundMinHeight = false;
+      for (final element in constrainedBoxFinder.evaluate()) {
+        final widget = element.widget as ConstrainedBox;
+        if (widget.constraints.minHeight == 48.0) {
+          foundMinHeight = true;
+          break;
+        }
+      }
+      expect(foundMinHeight, isTrue);
+    });
+
+    testWidgets('respects custom minHeight', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(title: 'Section Title', minHeight: 64.0),
+          ),
+        ),
+      );
+
+      final constrainedBoxFinder = find.byType(ConstrainedBox);
+      expect(constrainedBoxFinder, findsWidgets);
+
+      bool foundCustomHeight = false;
+      for (final element in constrainedBoxFinder.evaluate()) {
+        final widget = element.widget as ConstrainedBox;
+        if (widget.constraints.minHeight == 64.0) {
+          foundCustomHeight = true;
+          break;
+        }
+      }
+      expect(foundCustomHeight, isTrue);
+    });
+
+    // ==================== Divider Indent Tests ====================
+
+    testWidgets('applies divider indent', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              showDivider: true,
+              dividerIndent: 16.0,
+            ),
+          ),
+        ),
+      );
+
+      final dividerFinder = find.byType(Divider);
+      expect(dividerFinder, findsOneWidget);
+
+      final divider = tester.widget<Divider>(dividerFinder);
+      expect(divider.indent, 16.0);
+    });
+
+    testWidgets('applies divider end indent', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              showDivider: true,
+              dividerEndIndent: 16.0,
+            ),
+          ),
+        ),
+      );
+
+      final dividerFinder = find.byType(Divider);
+      expect(dividerFinder, findsOneWidget);
+
+      final divider = tester.widget<Divider>(dividerFinder);
+      expect(divider.endIndent, 16.0);
+    });
+  });
+
+  // ==================== SectionHeaderDelegate Tests ====================
+
+  group('SectionHeaderDelegate Tests', () {
+    testWidgets('renders in SliverPersistentHeader', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CustomScrollView(
+              slivers: [
+                SliverPersistentHeader(
+                  pinned: true,
+                  delegate: const SectionHeaderDelegate(
+                    child: AppSectionHeader(
+                      title: 'Sticky Section',
+                      backgroundColor: Colors.white,
+                    ),
+                  ),
+                ),
+                SliverList(
+                  delegate: SliverChildListDelegate([
+                    const ListTile(title: Text('Item 1')),
+                    const ListTile(title: Text('Item 2')),
+                  ]),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Sticky Section'), findsOneWidget);
+    });
+
+    testWidgets('has correct min and max extent', (tester) async {
+      const delegate = SectionHeaderDelegate(
+        child: AppSectionHeader(title: 'Test'),
+        height: 56.0,
+      );
+
+      expect(delegate.minExtent, 56.0);
+      expect(delegate.maxExtent, 56.0);
+    });
+
+    testWidgets('shouldRebuild returns true when child changes', (
+      tester,
+    ) async {
+      const delegate1 = SectionHeaderDelegate(
+        child: AppSectionHeader(title: 'Test 1'),
+      );
+
+      const delegate2 = SectionHeaderDelegate(
+        child: AppSectionHeader(title: 'Test 2'),
+      );
+
+      expect(delegate1.shouldRebuild(delegate2), isTrue);
+    });
+
+    testWidgets('shouldRebuild returns true when height changes', (
+      tester,
+    ) async {
+      const delegate1 = SectionHeaderDelegate(
+        child: AppSectionHeader(title: 'Test'),
+        height: 48.0,
+      );
+
+      const delegate2 = SectionHeaderDelegate(
+        child: AppSectionHeader(title: 'Test'),
+        height: 56.0,
+      );
+
+      expect(delegate1.shouldRebuild(delegate2), isTrue);
+    });
+  });
+}

--- a/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
+++ b/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
@@ -15,6 +15,8 @@ import 'package:widgetbook_kit/stories/core_kit/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_buttons_app_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_fab_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_icon_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_outlined_button_stories.dart'
@@ -25,6 +27,8 @@ import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_checkbox_stor
     as _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_card_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_section_header_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_surfaces_app_section_header_stories;
 
 final directories = <_widgetbook.WidgetbookNode>[
   _widgetbook.WidgetbookFolder(
@@ -233,6 +237,59 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories
                         .appButtonWithIcons,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'AppFab',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Collapsed vs Expanded',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabCollapsedExpanded,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Extended Variants',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabExtendedVariants,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Hide on Scroll',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabHideOnScroll,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Playground (Static)',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabPlayground,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Sizes',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabSizes,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'States',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabStates,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Theme Variations',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabThemeVariations,
               ),
             ],
           ),
@@ -514,6 +571,59 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
                         .appCardPlayground,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'AppSectionHeader',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_section_header_stories
+                        .appSectionHeaderDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Interactive Playground',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_section_header_stories
+                        .appSectionHeaderPlayground,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Settings List Example',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_section_header_stories
+                        .appSectionHeaderSettingsList,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Theme Variations',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_section_header_stories
+                        .appSectionHeaderThemeVariations,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Divider',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_section_header_stories
+                        .appSectionHeaderWithDivider,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Leading',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_section_header_stories
+                        .appSectionHeaderWithLeading,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Subtitle',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_section_header_stories
+                        .appSectionHeaderWithSubtitle,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Trailing',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_section_header_stories
+                        .appSectionHeaderWithTrailing,
               ),
             ],
           ),

--- a/widgetbook_kit/lib/stories/core_kit/widgets/surfaces/app_section_header_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/surfaces/app_section_header_stories.dart
@@ -155,60 +155,91 @@ Widget appSectionHeaderWithDivider(BuildContext context) {
 
 @widgetbook.UseCase(name: 'Settings List Example', type: AppSectionHeader)
 Widget appSectionHeaderSettingsList(BuildContext context) {
-  return SingleChildScrollView(
-    child: Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        const AppSectionHeader(title: 'Account', isUpperCase: true),
-        ListTile(
-          leading: const Icon(Icons.person),
-          title: const Text('Profile'),
-          subtitle: const Text('john.doe@example.com'),
-          onTap: () {},
-        ),
-        ListTile(
-          leading: const Icon(Icons.email),
-          title: const Text('Email'),
-          onTap: () {},
-        ),
-        ListTile(
-          leading: const Icon(Icons.phone),
-          title: const Text('Phone number'),
-          onTap: () {},
-        ),
-        const SizedBox(height: AppSpacing.sm),
-        const AppSectionHeader(title: 'Privacy & Security', isUpperCase: true),
-        ListTile(
-          leading: const Icon(Icons.lock),
-          title: const Text('Password'),
-          subtitle: const Text('Last changed 30 days ago'),
-          onTap: () {},
-        ),
-        ListTile(
-          leading: const Icon(Icons.fingerprint),
-          title: const Text('Biometric login'),
-          trailing: Switch(value: true, onChanged: (_) {}),
-        ),
-        ListTile(
-          leading: const Icon(Icons.security),
-          title: const Text('Two-factor authentication'),
-          onTap: () {},
-        ),
-        const SizedBox(height: AppSpacing.sm),
-        const AppSectionHeader(title: 'Notifications', isUpperCase: true),
-        ListTile(
-          leading: const Icon(Icons.notifications),
-          title: const Text('Push notifications'),
-          trailing: Switch(value: true, onChanged: (_) {}),
-        ),
-        ListTile(
-          leading: const Icon(Icons.mail_outline),
-          title: const Text('Email notifications'),
-          trailing: Switch(value: false, onChanged: (_) {}),
-        ),
-      ],
-    ),
-  );
+  return const _SettingsListContent();
+}
+
+/// Stateful widget for Settings List Example to demonstrate realistic usage
+class _SettingsListContent extends StatefulWidget {
+  const _SettingsListContent();
+
+  @override
+  State<_SettingsListContent> createState() => _SettingsListContentState();
+}
+
+class _SettingsListContentState extends State<_SettingsListContent> {
+  bool _biometricLogin = true;
+  bool _pushNotifications = true;
+  bool _emailNotifications = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const AppSectionHeader(title: 'Account', isUpperCase: true),
+          ListTile(
+            leading: const Icon(Icons.person),
+            title: const Text('Profile'),
+            subtitle: const Text('john.doe@example.com'),
+            onTap: () {},
+          ),
+          ListTile(
+            leading: const Icon(Icons.email),
+            title: const Text('Email'),
+            onTap: () {},
+          ),
+          ListTile(
+            leading: const Icon(Icons.phone),
+            title: const Text('Phone number'),
+            onTap: () {},
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          const AppSectionHeader(
+            title: 'Privacy & Security',
+            isUpperCase: true,
+          ),
+          ListTile(
+            leading: const Icon(Icons.lock),
+            title: const Text('Password'),
+            subtitle: const Text('Last changed 30 days ago'),
+            onTap: () {},
+          ),
+          ListTile(
+            leading: const Icon(Icons.fingerprint),
+            title: const Text('Biometric login'),
+            trailing: Switch(
+              value: _biometricLogin,
+              onChanged: (value) => setState(() => _biometricLogin = value),
+            ),
+          ),
+          ListTile(
+            leading: const Icon(Icons.security),
+            title: const Text('Two-factor authentication'),
+            onTap: () {},
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          const AppSectionHeader(title: 'Notifications', isUpperCase: true),
+          ListTile(
+            leading: const Icon(Icons.notifications),
+            title: const Text('Push notifications'),
+            trailing: Switch(
+              value: _pushNotifications,
+              onChanged: (value) => setState(() => _pushNotifications = value),
+            ),
+          ),
+          ListTile(
+            leading: const Icon(Icons.mail_outline),
+            title: const Text('Email notifications'),
+            trailing: Switch(
+              value: _emailNotifications,
+              onChanged: (value) => setState(() => _emailNotifications = value),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
 }
 
 @widgetbook.UseCase(name: 'Theme Variations', type: AppSectionHeader)

--- a/widgetbook_kit/lib/stories/core_kit/widgets/surfaces/app_section_header_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/surfaces/app_section_header_stories.dart
@@ -159,7 +159,7 @@ Widget appSectionHeaderSettingsList(BuildContext context) {
     child: Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        const AppSectionHeader(title: 'ACCOUNT', isUpperCase: true),
+        const AppSectionHeader(title: 'Account', isUpperCase: true),
         ListTile(
           leading: const Icon(Icons.person),
           title: const Text('Profile'),
@@ -177,7 +177,7 @@ Widget appSectionHeaderSettingsList(BuildContext context) {
           onTap: () {},
         ),
         const SizedBox(height: AppSpacing.sm),
-        const AppSectionHeader(title: 'PRIVACY & SECURITY', isUpperCase: true),
+        const AppSectionHeader(title: 'Privacy & Security', isUpperCase: true),
         ListTile(
           leading: const Icon(Icons.lock),
           title: const Text('Password'),
@@ -195,7 +195,7 @@ Widget appSectionHeaderSettingsList(BuildContext context) {
           onTap: () {},
         ),
         const SizedBox(height: AppSpacing.sm),
-        const AppSectionHeader(title: 'NOTIFICATIONS', isUpperCase: true),
+        const AppSectionHeader(title: 'Notifications', isUpperCase: true),
         ListTile(
           leading: const Icon(Icons.notifications),
           title: const Text('Push notifications'),

--- a/widgetbook_kit/lib/stories/core_kit/widgets/surfaces/app_section_header_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/surfaces/app_section_header_stories.dart
@@ -1,2 +1,338 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/widgets/surfaces/app_section_header.dart';
+import 'package:core_kit/theme/app_spacing.dart';
+
+@widgetbook.UseCase(name: 'Default', type: AppSectionHeader)
+Widget appSectionHeaderDefault(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(AppSpacing.md),
+    child: AppSectionHeader(
+      title: context.knobs.string(
+        label: 'Title',
+        initialValue: 'Section Title',
+      ),
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'With Subtitle', type: AppSectionHeader)
+Widget appSectionHeaderWithSubtitle(BuildContext context) {
+  return const Padding(
+    padding: EdgeInsets.all(AppSpacing.md),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AppSectionHeader(
+          title: 'Account Settings',
+          subtitle: 'Manage your account preferences and security',
+        ),
+        SizedBox(height: AppSpacing.lg),
+        AppSectionHeader(
+          title: 'Privacy',
+          subtitle: 'Control who can see your information',
+        ),
+        SizedBox(height: AppSpacing.lg),
+        AppSectionHeader(
+          title: 'Notifications',
+          subtitle: 'Choose how you want to be notified',
+        ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'With Leading', type: AppSectionHeader)
+Widget appSectionHeaderWithLeading(BuildContext context) {
+  return const Padding(
+    padding: EdgeInsets.all(AppSpacing.md),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AppSectionHeader(
+          leading: Icon(Icons.person, size: 20),
+          title: 'Profile',
+        ),
+        SizedBox(height: AppSpacing.md),
+        AppSectionHeader(
+          leading: Icon(Icons.lock, size: 20),
+          title: 'Security',
+        ),
+        SizedBox(height: AppSpacing.md),
+        AppSectionHeader(
+          leading: Icon(Icons.notifications, size: 20),
+          title: 'Notifications',
+        ),
+        SizedBox(height: AppSpacing.md),
+        AppSectionHeader(
+          leading: Icon(Icons.palette, size: 20),
+          title: 'Appearance',
+          subtitle: 'Customize your app experience',
+        ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'With Trailing', type: AppSectionHeader)
+Widget appSectionHeaderWithTrailing(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(AppSpacing.md),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AppSectionHeader(
+          title: 'Recent Files',
+          trailing: TextButton(
+            onPressed: () {},
+            child: const Text('Clear all'),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        AppSectionHeader(
+          title: 'Favorites',
+          trailing: IconButton(
+            onPressed: () {},
+            icon: const Icon(Icons.edit, size: 20),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        AppSectionHeader(
+          title: 'Downloads',
+          subtitle: '12 items pending',
+          trailing: TextButton(onPressed: () {}, child: const Text('View all')),
+        ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'With Divider', type: AppSectionHeader)
+Widget appSectionHeaderWithDivider(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(AppSpacing.md),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          'Divider Below (Default)',
+          style: Theme.of(context).textTheme.labelLarge,
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        const AppSectionHeader(
+          title: 'Section with divider below',
+          showDivider: true,
+          dividerPosition: DividerPosition.below,
+        ),
+        const SizedBox(height: AppSpacing.lg),
+        Text('Divider Above', style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: AppSpacing.sm),
+        const AppSectionHeader(
+          title: 'Section with divider above',
+          showDivider: true,
+          dividerPosition: DividerPosition.above,
+        ),
+        const SizedBox(height: AppSpacing.lg),
+        Text('Divider Both', style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: AppSpacing.sm),
+        const AppSectionHeader(
+          title: 'Section with dividers on both sides',
+          showDivider: true,
+          dividerPosition: DividerPosition.both,
+        ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Settings List Example', type: AppSectionHeader)
+Widget appSectionHeaderSettingsList(BuildContext context) {
+  return SingleChildScrollView(
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const AppSectionHeader(title: 'ACCOUNT', isUpperCase: true),
+        ListTile(
+          leading: const Icon(Icons.person),
+          title: const Text('Profile'),
+          subtitle: const Text('john.doe@example.com'),
+          onTap: () {},
+        ),
+        ListTile(
+          leading: const Icon(Icons.email),
+          title: const Text('Email'),
+          onTap: () {},
+        ),
+        ListTile(
+          leading: const Icon(Icons.phone),
+          title: const Text('Phone number'),
+          onTap: () {},
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        const AppSectionHeader(title: 'PRIVACY & SECURITY', isUpperCase: true),
+        ListTile(
+          leading: const Icon(Icons.lock),
+          title: const Text('Password'),
+          subtitle: const Text('Last changed 30 days ago'),
+          onTap: () {},
+        ),
+        ListTile(
+          leading: const Icon(Icons.fingerprint),
+          title: const Text('Biometric login'),
+          trailing: Switch(value: true, onChanged: (_) {}),
+        ),
+        ListTile(
+          leading: const Icon(Icons.security),
+          title: const Text('Two-factor authentication'),
+          onTap: () {},
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        const AppSectionHeader(title: 'NOTIFICATIONS', isUpperCase: true),
+        ListTile(
+          leading: const Icon(Icons.notifications),
+          title: const Text('Push notifications'),
+          trailing: Switch(value: true, onChanged: (_) {}),
+        ),
+        ListTile(
+          leading: const Icon(Icons.mail_outline),
+          title: const Text('Email notifications'),
+          trailing: Switch(value: false, onChanged: (_) {}),
+        ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Theme Variations', type: AppSectionHeader)
+Widget appSectionHeaderThemeVariations(BuildContext context) {
+  final colorScheme = Theme.of(context).colorScheme;
+
+  return Padding(
+    padding: const EdgeInsets.all(AppSpacing.md),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text('Default Theme', style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: AppSpacing.sm),
+        const AppSectionHeader(
+          title: 'Default Section Header',
+          subtitle: 'Uses theme colors automatically',
+        ),
+        const SizedBox(height: AppSpacing.lg),
+        Text(
+          'With Background Color',
+          style: Theme.of(context).textTheme.labelLarge,
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        AppSectionHeader(
+          title: 'Highlighted Section',
+          subtitle: 'With primary container background',
+          backgroundColor: colorScheme.primaryContainer,
+        ),
+        const SizedBox(height: AppSpacing.lg),
+        Text('Custom Colors', style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: AppSpacing.sm),
+        AppSectionHeader(
+          title: 'Custom Styled Section',
+          subtitle: 'With custom text colors',
+          textStyle: TextStyle(
+            color: colorScheme.primary,
+            fontWeight: FontWeight.bold,
+            fontSize: 16,
+          ),
+          subtitleStyle: TextStyle(
+            color: colorScheme.secondary,
+            fontStyle: FontStyle.italic,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.lg),
+        Text(
+          'Sticky Header Style',
+          style: Theme.of(context).textTheme.labelLarge,
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        AppSectionHeader(
+          title: 'Sticky Section',
+          backgroundColor: colorScheme.surface,
+          showDivider: true,
+          dividerPosition: DividerPosition.below,
+        ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Interactive Playground', type: AppSectionHeader)
+Widget appSectionHeaderPlayground(BuildContext context) {
+  final title = context.knobs.string(
+    label: 'Title',
+    initialValue: 'Section Header',
+  );
+
+  final subtitle = context.knobs.stringOrNull(
+    label: 'Subtitle',
+    initialValue: null,
+  );
+
+  final showLeading = context.knobs.boolean(
+    label: 'Show Leading Icon',
+    initialValue: false,
+  );
+
+  final showTrailing = context.knobs.boolean(
+    label: 'Show Trailing Action',
+    initialValue: false,
+  );
+
+  final isUpperCase = context.knobs.boolean(
+    label: 'Uppercase Title',
+    initialValue: false,
+  );
+
+  final showDivider = context.knobs.boolean(
+    label: 'Show Divider',
+    initialValue: false,
+  );
+
+  final dividerPositionOptions = context.knobs.object.dropdown<DividerPosition>(
+    label: 'Divider Position',
+    options: DividerPosition.values,
+    labelBuilder: (value) => value.name,
+  );
+
+  final showBackground = context.knobs.boolean(
+    label: 'Show Background',
+    initialValue: false,
+  );
+
+  final colorScheme = Theme.of(context).colorScheme;
+
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(AppSpacing.md),
+      child: AppSectionHeader(
+        title: title,
+        subtitle: subtitle,
+        leading: showLeading ? const Icon(Icons.settings, size: 20) : null,
+        trailing: showTrailing
+            ? TextButton(onPressed: () {}, child: const Text('Action'))
+            : null,
+        isUpperCase: isUpperCase,
+        showDivider: showDivider,
+        dividerPosition: dividerPositionOptions,
+        backgroundColor: showBackground
+            ? colorScheme.surfaceContainerLow
+            : null,
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
# Pull Request

## 📄 Summary

Implement the AppSectionHeader component for organizing content into logical groups with titles and optional actions. This widget is commonly used in settings screens, forms, lists, and navigation drawers.

**Features:**
- Title and subtitle support
- Leading and trailing widget support
- Divider support with position control (above, below, both)
- Material Design 3 specifications (48dp min height, proper typography and colors)
- Accessibility with semantic header role
- SectionHeaderDelegate for sticky header support

---

## 🧩 Affected Module(s)

- [x] Packages (packages/*)
- [x] Widgetbook Kit (widgetbook_kit/)
- [ ] Documentation (docs/)
- [ ] CI / Infra (.github/)

---

## ✅ Checklist

- [x] My branch name follows format: <type>/<short-description> (e.g., feat/login-screen)
- [x] My PR title starts with one of the approved types listed above
- [x] My Dart code is formatted (dart format . or flutter format .)
- [x] I ran static analysis (flutter analyze) and resolved warnings
- [x] I ran tests successfully (flutter test)
- [x] I updated / checked pubspec.yaml and pubspec.lock for dependency changes
- [x] For UI changes, I added screenshots and/or updated golden tests (if applicable)
- [x] I linked related issues using keywords like Closes #42
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

Closes #20

---

## 💬 Additional Notes (Optional)

### Files Changed:
- [packages/core_kit/lib/widgets/surfaces/app_section_header.dart](cci:7://file:///home/mrcan/Documents/projects/hexaMobileShare/packages/core_kit/lib/widgets/surfaces/app_section_header.dart:0:0-0:0) - Widget implementation
- [packages/core_kit/lib/core_kit.dart](cci:7://file:///home/mrcan/Documents/projects/hexaMobileShare/packages/core_kit/lib/core_kit.dart:0:0-0:0) - Export added
- [packages/core_kit/test/widgets/surfaces/app_section_header_test.dart](cci:7://file:///home/mrcan/Documents/projects/hexaMobileShare/packages/core_kit/test/widgets/surfaces/app_section_header_test.dart:0:0-0:0) - 27 widget tests
- [widgetbook_kit/lib/stories/core_kit/widgets/surfaces/app_section_header_stories.dart](cci:7://file:///home/mrcan/Documents/projects/hexaMobileShare/widgetbook_kit/lib/stories/core_kit/widgets/surfaces/app_section_header_stories.dart:0:0-0:0) - 8 Widgetbook stories

### Widgetbook Stories:
1. Default
2. With Subtitle
3. With Leading
4. With Trailing
5. With Divider
6. Settings List Example
7. Theme Variations
8. Interactive Playground