### PR TITLE
feat(core-kit): add AppOutlinedButton wrapper and Widgetbook stories

### DIFF
--- a/packages/core_kit/lib/widgets/buttons/app_outlined_button.dart
+++ b/packages/core_kit/lib/widgets/buttons/app_outlined_button.dart
@@ -1,6 +1,35 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppOutlinedButton {
-  const AppOutlinedButton();
+import 'package:flutter/material.dart';
+import 'package:core_kit/widgets/buttons/app_button.dart';
+
+/// A convenience wrapper that delegates to AppButton.outlined().
+/// Use for secondary actions requiring an outlined style.
+class AppOutlinedButton extends StatelessWidget {
+  final String label;
+  final VoidCallback? onPressed;
+  final IconData? icon;
+  final bool fullWidth;
+  final bool isLoading;
+
+  const AppOutlinedButton({
+    required this.label,
+    this.onPressed,
+    this.icon,
+    this.fullWidth = false,
+    this.isLoading = false,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AppButton.outlined(
+      label: label,
+      onPressed: onPressed,
+      icon: icon,
+      fullWidth: fullWidth,
+      isLoading: isLoading,
+    );
+  }
 }

--- a/widgetbook_kit/lib/stories/core_kit/widgets/buttons/app_outlined_button_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/buttons/app_outlined_button_stories.dart
@@ -1,2 +1,116 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/widgets/buttons/app_outlined_button.dart';
+import 'package:core_kit/widgets/buttons/app_button.dart';
+
+// ...existing code...
+@widgetbook.UseCase(name: 'Default', type: AppOutlinedButton)
+Widget appOutlinedButtonDefault(BuildContext context) {
+  return Center(
+    child: AppOutlinedButton(
+      label: context.knobs.string(label: 'Label', initialValue: 'Button'),
+      onPressed: () {},
+    ),
+  );
+}
+
+// ...existing code...
+@widgetbook.UseCase(name: 'With Icon', type: AppOutlinedButton)
+Widget appOutlinedButtonWithIcon(BuildContext context) {
+  return Center(
+    child: AppOutlinedButton(
+      icon: Icons.download,
+      label: context.knobs.string(label: 'Label', initialValue: 'Download'),
+      onPressed: () {},
+    ),
+  );
+}
+
+// ...existing code...
+@widgetbook.UseCase(name: 'States', type: AppOutlinedButton)
+Widget appOutlinedButtonStates(BuildContext context) {
+  final label = context.knobs.string(label: 'Label', initialValue: 'Submit');
+  return Column(
+    mainAxisAlignment: MainAxisAlignment.center,
+    children: [
+      AppOutlinedButton(label: '$label (enabled)', onPressed: () {}),
+      const SizedBox(height: 12),
+      const AppOutlinedButton(label: 'Disabled'),
+      const SizedBox(height: 12),
+      const AppOutlinedButton(label: 'Loading', isLoading: true),
+      const SizedBox(height: 12),
+      AppOutlinedButton(label: 'Hover/Pressed demo', onPressed: () {}),
+    ],
+  );
+}
+
+// ...existing code...
+@widgetbook.UseCase(name: 'Sizes', type: AppOutlinedButton)
+Widget appOutlinedButtonSizes(BuildContext context) {
+  final longText = context.knobs.boolean(
+    label: 'Use long text',
+    initialValue: true,
+  );
+  return Padding(
+    padding: const EdgeInsets.all(16),
+    child: Column(
+      children: [
+        AppOutlinedButton(
+          label: longText
+              ? 'This is a very long button label to test wrapping and overflow'
+              : 'Normal',
+          onPressed: () {},
+        ),
+        const SizedBox(height: 12),
+        const AppOutlinedButton(label: 'Full width', fullWidth: true),
+      ],
+    ),
+  );
+}
+
+// ...existing code...
+@widgetbook.UseCase(name: 'Theme Variations', type: AppOutlinedButton)
+Widget appOutlinedButtonTheme(BuildContext context) {
+  final dark = context.knobs.boolean(label: 'Dark mode', initialValue: false);
+  final toggledTheme = dark
+      ? ThemeData.from(colorScheme: const ColorScheme.dark())
+      : ThemeData.from(colorScheme: const ColorScheme.light());
+
+  return Theme(
+    data: toggledTheme,
+    child: Center(
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: const [
+          AppOutlinedButton(label: 'Outlined'),
+          SizedBox(width: 12),
+          AppButton.filled(label: 'Filled'),
+        ],
+      ),
+    ),
+  );
+}
+
+// ...existing code...
+@widgetbook.UseCase(name: 'Comparison', type: AppOutlinedButton)
+Widget appOutlinedButtonComparison(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16),
+    child: Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: const [
+        AppButton.text(label: 'Text'),
+        SizedBox(width: 12),
+        AppOutlinedButton(label: 'Outlined'),
+        SizedBox(width: 12),
+        AppButton.filled(label: 'Filled'),
+      ],
+    ),
+  );
+}
+
+// ...existing code...


### PR DESCRIPTION
# Pull Request

## 📄 Summary


This pull request introduces a new `AppOutlinedButton` widget as a convenience wrapper for outlined button styles, and adds comprehensive Widgetbook stories to demonstrate its usage and states. The changes aim to improve developer experience by providing a reusable outlined button component and thorough documentation/examples for UI development and testing.

**New widget implementation:**

* Added a new `AppOutlinedButton` class in `app_outlined_button.dart`, which extends `StatelessWidget` and delegates to `AppButton.outlined()`. This wrapper provides a simple interface for creating outlined buttons with configurable label, icon, loading state, and width.

**Widgetbook stories and documentation:**

* Added multiple Widgetbook use cases in `app_outlined_button_stories.dart` to showcase the new `AppOutlinedButton`:
  - Default usage and icon variant
  - Button states (enabled, disabled, loading, hover/pressed)
  - Size variations, including long labels and full-width option
  - Theme variations for light/dark mode
  - Comparison with other button styles (`AppButton.text`, `AppButton.filled`)

Closes #42
---

## 🧩 Affected Module(s)
- [x] Packages (`packages/analytics_kit`)
- [x] Widgetbook Kit (`widgetbook_kit/`)
- [ ] Documentation (`docs/`)
- [ ] CI / Infra (`.github/`)

---

## ✏️ PR Title
feat(analytics_kit): implement ScreenTrackingMixin with Widgetbook stories

---

## ✅ Checklist
- [x] Branch name follows format: `feat/analytics-screen-tracking-mixin`
- [x] PR title follows Conventional Commits
- [x] English-only content and SPDX headers present
- [x] Format: `pnpm format`
- [x] Analyze: `pnpm analyze` (no issues)
- [x] Tests: `pnpm test` (passing)
- [x] REUSE compliance: `reuse lint` (passing)
- [x] Widgetbook builds: `pnpm storybook` / `pnpm build-storybook`
- [x] No unrelated or generated platform files included

---

## 🔗 Related Issues

Closes #42

---

## 💬 Additional Notes (Optional)
- The mixin is opt‑in; disable auto‑tracking by overriding `enableAutoTrack => false`.
- Future enhancement: consider `RouteObserver` integration for advanced navigation patterns.

---

## 🧪 How to Test
```bash
pnpm bootstrap
pnpm analyze
pnpm test
pnpm storybook
