### PR TITLE
feat(core_kit): add Material Design 3 compliant AppListTile widget

### DIFF
--- a/packages/core_kit/lib/core_kit.dart
+++ b/packages/core_kit/lib/core_kit.dart
@@ -13,3 +13,4 @@ export 'theme/app_shadows.dart';
 export 'widgets/buttons/app_button.dart';
 export 'widgets/inputs/app_checkbox.dart';
 export 'widgets/buttons/app_text_button.dart';
+export 'widgets/surfaces/app_list_tile.dart';

--- a/packages/core_kit/lib/widgets/surfaces/app_list_tile.dart
+++ b/packages/core_kit/lib/widgets/surfaces/app_list_tile.dart
@@ -1,6 +1,218 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppListTile {
-  const AppListTile();
+import 'package:flutter/material.dart';
+import 'package:core_kit/theme/app_typography.dart';
+
+/// A Material Design 3 list tile widget.
+///
+/// A single fixed-height row that typically contains text, icons, and optional
+/// actions. List tiles provide a consistent layout with leading/trailing widgets
+/// and up to three lines of text.
+///
+/// The tile automatically adjusts its height based on:
+/// - One-line: 56dp (48dp if dense)
+/// - Two-line: 72dp (64dp if dense)
+/// - Three-line: 88dp (requires [isThreeLine] = true)
+///
+/// Example usage:
+///
+/// ```dart
+/// // Basic list tile
+/// AppListTile(
+///   leading: Icon(Icons.person),
+///   title: 'Profile',
+///   onTap: () => _openProfile(),
+/// )
+///
+/// // Two-line tile with subtitle
+/// AppListTile(
+///   leading: CircleAvatar(child: Icon(Icons.folder)),
+///   title: 'Documents',
+///   subtitle: '24 files',
+///   trailing: Icon(Icons.chevron_right),
+///   onTap: () => _openFolder(),
+/// )
+///
+/// // Settings tile with switch
+/// AppListTile(
+///   leading: Icon(Icons.notifications),
+///   title: 'Notifications',
+///   subtitle: 'Enable push notifications',
+///   trailing: Switch(value: _enabled, onChanged: _toggle),
+/// )
+/// ```
+///
+/// See also:
+/// - [ListTile], the underlying Material widget
+/// - Material Design 3 Lists: https://m3.material.io/components/lists
+class AppListTile extends StatelessWidget {
+  /// Creates a Material Design 3 list tile.
+  ///
+  /// The [title] parameter is required.
+  const AppListTile({
+    required this.title,
+    this.subtitle,
+    this.leading,
+    this.trailing,
+    this.onTap,
+    this.onLongPress,
+    this.selected = false,
+    this.enabled = true,
+    this.dense = false,
+    this.isThreeLine = false,
+    this.contentPadding,
+    this.tileColor,
+    this.selectedTileColor,
+    this.shape,
+    this.visualDensity,
+    super.key,
+  });
+
+  /// The primary content of the list tile.
+  ///
+  /// Displayed using Material Design 3 [AppTypography.bodyLarge] style
+  /// with [ColorScheme.onSurface] color (or [ColorScheme.onSecondaryContainer]
+  /// when selected).
+  final String title;
+
+  /// Additional content displayed below the title.
+  ///
+  /// Displayed using Material Design 3 [AppTypography.bodyMedium] style
+  /// with [ColorScheme.onSurfaceVariant] color.
+  /// For three-line layout, set [isThreeLine] to true.
+  final String? subtitle;
+
+  /// A widget to display before the title.
+  ///
+  /// Typically an [Icon] (24dp) or [CircleAvatar] (40dp).
+  final Widget? leading;
+
+  /// A widget to display after the title.
+  ///
+  /// Typically an [Icon], [Text], or interactive widget like [Switch].
+  final Widget? trailing;
+
+  /// Called when the user taps this list tile.
+  ///
+  /// If null and [enabled] is true, the tile is still interactive but
+  /// doesn't do anything when tapped.
+  final VoidCallback? onTap;
+
+  /// Called when the user long-presses on this list tile.
+  final VoidCallback? onLongPress;
+
+  /// Whether this list tile is part of a vertically dense list.
+  ///
+  /// Dense mode reduces the height:
+  /// - One-line: 56dp → 48dp
+  /// - Two-line: 72dp → 64dp
+  ///
+  /// Default is false.
+  final bool dense;
+
+  /// Whether this list tile is intended to display three lines of text.
+  ///
+  /// If true, the tile height increases to 88dp to accommodate the subtitle.
+  /// The subtitle should be limited to three lines of text.
+  ///
+  /// Default is false.
+  final bool isThreeLine;
+
+  /// Whether this list tile is currently selected.
+  ///
+  /// If true, the tile displays with [selectedTileColor] background and
+  /// appropriate text color from the theme.
+  ///
+  /// Default is false.
+  final bool selected;
+
+  /// Whether this list tile is interactive.
+  ///
+  /// If false, the tile appears disabled with reduced opacity and
+  /// [onTap] and [onLongPress] are ignored.
+  ///
+  /// Default is true.
+  final bool enabled;
+
+  /// The tile's internal padding.
+  ///
+  /// Default is EdgeInsets.symmetric(horizontal: 16.0).
+  final EdgeInsetsGeometry? contentPadding;
+
+  /// The tile's background color.
+  ///
+  /// If null, uses theme's surface color.
+  final Color? tileColor;
+
+  /// The tile's background color when [selected] is true.
+  ///
+  /// If null, uses theme's secondaryContainer color.
+  final Color? selectedTileColor;
+
+  /// The shape of the list tile's border.
+  ///
+  /// If null, no border is drawn.
+  final ShapeBorder? shape;
+
+  /// Defines how compact the tile's layout will be.
+  ///
+  /// This allows fine-tuning beyond the [dense] parameter.
+  final VisualDensity? visualDensity;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final textTheme = AppTypography.textTheme();
+
+    // Build title with proper typography and color
+    final titleWidget = Text(
+      title,
+      style: textTheme.bodyLarge?.copyWith(
+        color: selected
+            ? colorScheme.onSecondaryContainer
+            : colorScheme.onSurface,
+      ),
+    );
+
+    // Build subtitle with proper typography and color
+    final subtitleWidget = subtitle != null
+        ? Text(
+            subtitle!,
+            style: textTheme.bodyMedium?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+          )
+        : null;
+
+    return ListTile(
+      // Layout
+      contentPadding:
+          contentPadding ?? const EdgeInsets.symmetric(horizontal: 16.0),
+      dense: dense,
+      isThreeLine: isThreeLine,
+      visualDensity: visualDensity,
+
+      // Content
+      leading: leading,
+      title: titleWidget,
+      subtitle: subtitleWidget,
+      trailing: trailing,
+
+      // Interaction
+      onTap: enabled ? onTap : null,
+      onLongPress: enabled ? onLongPress : null,
+      enabled: enabled,
+      selected: selected,
+
+      // Styling
+      tileColor: tileColor,
+      selectedTileColor: selectedTileColor ?? colorScheme.secondaryContainer,
+      shape: shape,
+
+      // Ensure minimum 48dp touch target for accessibility
+      minVerticalPadding: dense ? 4.0 : 8.0,
+    );
+  }
 }

--- a/packages/core_kit/test/widgets/surfaces/app_list_tile_test.dart
+++ b/packages/core_kit/test/widgets/surfaces/app_list_tile_test.dart
@@ -1,0 +1,449 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:core_kit/core_kit.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AppListTile', () {
+    testWidgets('renders with title only', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppListTile(title: 'Test Title')),
+        ),
+      );
+
+      expect(find.text('Test Title'), findsOneWidget);
+    });
+
+    testWidgets('renders with title and subtitle', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppListTile(title: 'Test Title', subtitle: 'Test Subtitle'),
+          ),
+        ),
+      );
+
+      expect(find.text('Test Title'), findsOneWidget);
+      expect(find.text('Test Subtitle'), findsOneWidget);
+    });
+
+    testWidgets('renders with leading widget', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppListTile(leading: Icon(Icons.star), title: 'Test Title'),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.star), findsOneWidget);
+      expect(find.text('Test Title'), findsOneWidget);
+    });
+
+    testWidgets('renders with trailing widget', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              title: 'Test Title',
+              trailing: Icon(Icons.chevron_right),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Test Title'), findsOneWidget);
+      expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+    });
+
+    testWidgets('renders with all widgets', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              leading: Icon(Icons.star),
+              title: 'Test Title',
+              subtitle: 'Test Subtitle',
+              trailing: Icon(Icons.chevron_right),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.star), findsOneWidget);
+      expect(find.text('Test Title'), findsOneWidget);
+      expect(find.text('Test Subtitle'), findsOneWidget);
+      expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+    });
+
+    testWidgets('calls onTap when tapped', (WidgetTester tester) async {
+      var tapped = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppListTile(title: 'Test Title', onTap: () => tapped = true),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(AppListTile));
+      await tester.pump();
+
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('calls onLongPress when long pressed', (
+      WidgetTester tester,
+    ) async {
+      var longPressed = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              title: 'Test Title',
+              onLongPress: () => longPressed = true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.longPress(find.byType(AppListTile));
+      await tester.pump();
+
+      expect(longPressed, isTrue);
+    });
+
+    testWidgets('does not call onTap when disabled', (
+      WidgetTester tester,
+    ) async {
+      var tapped = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              title: 'Test Title',
+              enabled: false,
+              onTap: () => tapped = true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(AppListTile));
+      await tester.pump();
+
+      expect(tapped, isFalse);
+    });
+
+    testWidgets('does not call onLongPress when disabled', (
+      WidgetTester tester,
+    ) async {
+      var longPressed = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              title: 'Test Title',
+              enabled: false,
+              onLongPress: () => longPressed = true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.longPress(find.byType(AppListTile));
+      await tester.pump();
+
+      expect(longPressed, isFalse);
+    });
+
+    testWidgets('displays selected state', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppListTile(title: 'Test Title', selected: true),
+          ),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.selected, isTrue);
+    });
+
+    testWidgets('applies dense mode', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppListTile(title: 'Test Title', dense: true)),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.dense, isTrue);
+    });
+
+    testWidgets('enables three-line mode', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              title: 'Test Title',
+              subtitle: 'Test Title',
+              isThreeLine: true,
+            ),
+          ),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.isThreeLine, isTrue);
+    });
+
+    testWidgets('applies custom content padding', (WidgetTester tester) async {
+      const customPadding = EdgeInsets.all(24.0);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              title: 'Test Title',
+              contentPadding: customPadding,
+            ),
+          ),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.contentPadding, customPadding);
+    });
+
+    testWidgets('applies custom tile color', (WidgetTester tester) async {
+      const customColor = Colors.blue;
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppListTile(title: 'Test Title', tileColor: customColor),
+          ),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.tileColor, customColor);
+    });
+
+    testWidgets('applies custom selected tile color', (
+      WidgetTester tester,
+    ) async {
+      const customColor = Colors.green;
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              title: 'Test Title',
+              selected: true,
+              selectedTileColor: customColor,
+            ),
+          ),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.selectedTileColor, customColor);
+    });
+
+    testWidgets('uses default selected tile color from theme', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            useMaterial3: true,
+            colorScheme: ColorScheme.light(secondaryContainer: Colors.purple),
+          ),
+          home: const Scaffold(
+            body: AppListTile(title: 'Test Title', selected: true),
+          ),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.selectedTileColor, Colors.purple);
+    });
+
+    testWidgets('applies custom shape', (WidgetTester tester) async {
+      final customShape = RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16.0),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppListTile(title: 'Test Title', shape: customShape),
+          ),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.shape, customShape);
+    });
+
+    testWidgets('applies custom visual density', (WidgetTester tester) async {
+      const customDensity = VisualDensity.compact;
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              title: 'Test Title',
+              visualDensity: customDensity,
+            ),
+          ),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.visualDensity, customDensity);
+    });
+
+    testWidgets('applies default horizontal padding', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppListTile(title: 'Test Title')),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(
+        listTile.contentPadding,
+        const EdgeInsets.symmetric(horizontal: 16.0),
+      );
+    });
+
+    testWidgets('ensures minimum touch target in dense mode', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppListTile(title: 'Test Title', dense: true)),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.minVerticalPadding, 4.0);
+    });
+
+    testWidgets('ensures minimum touch target in normal mode', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppListTile(title: 'Test Title')),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.minVerticalPadding, 8.0);
+    });
+
+    testWidgets('works with complex leading widget', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              leading: Stack(
+                children: const [
+                  CircleAvatar(child: Icon(Icons.person)),
+                  Positioned(
+                    right: 0,
+                    bottom: 0,
+                    child: CircleAvatar(
+                      radius: 6,
+                      backgroundColor: Colors.green,
+                    ),
+                  ),
+                ],
+              ),
+              title: 'Test Title',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(CircleAvatar), findsNWidgets(2));
+      expect(find.text('Test Title'), findsOneWidget);
+    });
+
+    testWidgets('works with complex trailing widget', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              title: 'Test Title',
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: const [
+                  Icon(Icons.favorite),
+                  SizedBox(width: 8),
+                  Icon(Icons.more_vert),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.favorite), findsOneWidget);
+      expect(find.byIcon(Icons.more_vert), findsOneWidget);
+      expect(find.text('Test Title'), findsOneWidget);
+    });
+
+    testWidgets('works in ListView', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ListView(
+              children: const [
+                AppListTile(title: 'Item 1'),
+                AppListTile(title: 'Item 2'),
+                AppListTile(title: 'Item 3'),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Item 1'), findsOneWidget);
+      expect(find.text('Item 2'), findsOneWidget);
+      expect(find.text('Item 3'), findsOneWidget);
+    });
+
+    testWidgets('maintains accessibility in dense mode', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppListTile(title: 'Test Title', dense: true)),
+        ),
+      );
+
+      // Verify that even in dense mode, the touch target is adequate
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.dense, isTrue);
+      expect(listTile.minVerticalPadding, 4.0);
+    });
+  });
+}

--- a/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
+++ b/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
@@ -15,10 +15,16 @@ import 'package:widgetbook_kit/stories/core_kit/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_buttons_app_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories;
-import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_checkbox_stories.dart'
-    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_icon_button_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_outlined_button_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_text_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_checkbox_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_list_tile_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories;
 
 final directories = <_widgetbook.WidgetbookNode>[
   _widgetbook.WidgetbookFolder(
@@ -231,6 +237,100 @@ final directories = <_widgetbook.WidgetbookNode>[
             ],
           ),
           _widgetbook.WidgetbookComponent(
+            name: 'AppIconButton',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'All Variants',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonAllVariants,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Common Icons',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonCommonIcons,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Interactive Playground',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonPlayground,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Sizes',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonSizes,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'States',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonStates,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Theme Variations',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonTheme,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Toggle Button',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonToggle,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'AppOutlinedButton',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Comparison',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonComparison,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Sizes',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonSizes,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'States',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonStates,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Theme Variations',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonTheme,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Icon',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonWithIcon,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
             name: 'AppTextButton',
             useCases: [
               _widgetbook.WidgetbookUseCase(
@@ -362,6 +462,82 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories
                         .appCheckboxThemeVariations,
+              ),
+            ],
+          ),
+        ],
+      ),
+      _widgetbook.WidgetbookFolder(
+        name: 'surfaces',
+        children: [
+          _widgetbook.WidgetbookComponent(
+            name: 'AppListTile',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Common Patterns',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTilePatterns,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTileDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Dense Mode',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTileDense,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Interactive Playground',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTilePlayground,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Leading Widgets',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTileLeading,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'One Line',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTileOneLine,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'States',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTileStates,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Theme Variations',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTileThemes,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Three Line',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTileThreeLine,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Trailing Widgets',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTileTrailing,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Two Line',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTileTwoLine,
               ),
             ],
           ),

--- a/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
+++ b/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
@@ -23,8 +23,8 @@ import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_text_button_
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_checkbox_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories;
-import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_list_tile_stories.dart'
-    as _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_card_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories;
 
 final directories = <_widgetbook.WidgetbookNode>[
   _widgetbook.WidgetbookFolder(
@@ -471,73 +471,49 @@ final directories = <_widgetbook.WidgetbookNode>[
         name: 'surfaces',
         children: [
           _widgetbook.WidgetbookComponent(
-            name: 'AppListTile',
+            name: 'AppCard',
             useCases: [
               _widgetbook.WidgetbookUseCase(
-                name: 'Common Patterns',
+                name: 'All Variants',
                 builder:
-                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
-                        .appListTilePatterns,
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
+                        .appCardVariants,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Content Types',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
+                        .appCardContentTypes,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Custom Styling',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
+                        .appCardCustom,
               ),
               _widgetbook.WidgetbookUseCase(
                 name: 'Default',
                 builder:
-                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
-                        .appListTileDefault,
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
+                        .appCardDefault,
               ),
               _widgetbook.WidgetbookUseCase(
-                name: 'Dense Mode',
+                name: 'Elevation Levels',
                 builder:
-                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
-                        .appListTileDense,
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
+                        .appCardElevations,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Interactive',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
+                        .appCardInteractive,
               ),
               _widgetbook.WidgetbookUseCase(
                 name: 'Interactive Playground',
                 builder:
-                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
-                        .appListTilePlayground,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Leading Widgets',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
-                        .appListTileLeading,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'One Line',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
-                        .appListTileOneLine,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'States',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
-                        .appListTileStates,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Theme Variations',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
-                        .appListTileThemes,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Three Line',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
-                        .appListTileThreeLine,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Trailing Widgets',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
-                        .appListTileTrailing,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Two Line',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
-                        .appListTileTwoLine,
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
+                        .appCardPlayground,
               ),
             ],
           ),

--- a/widgetbook_kit/lib/stories/core_kit/widgets/surfaces/app_list_tile_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/surfaces/app_list_tile_stories.dart
@@ -1,2 +1,655 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:core_kit/core_kit.dart';
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+// ============================================================================
+// Story 1: Default List Tile - Basic one-line
+// ============================================================================
+
+/// Default list tile with leading icon and trailing chevron.
+@widgetbook.UseCase(name: 'Default', type: AppListTile)
+Widget appListTileDefault(BuildContext context) {
+  return Scaffold(
+    body: ListView(
+      children: [
+        AppListTile(
+          leading: const Icon(Icons.star),
+          title: context.knobs.string(
+            label: 'Title',
+            initialValue: 'List item',
+          ),
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+// ============================================================================
+// Story 2: Line Variations - One, two, three lines
+// ============================================================================
+
+/// One-line list tile with title only.
+@widgetbook.UseCase(name: 'One Line', type: AppListTile)
+Widget appListTileOneLine(BuildContext context) {
+  return Scaffold(
+    body: ListView(
+      children: [
+        AppListTile(
+          leading: const Icon(Icons.inbox),
+          title: 'Inbox',
+          trailing: const Text('24'),
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const Icon(Icons.send),
+          title: 'Sent',
+          trailing: const Text('8'),
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const Icon(Icons.drafts),
+          title: 'Drafts',
+          trailing: const Text('3'),
+          onTap: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+/// Two-line list tile with title and subtitle.
+@widgetbook.UseCase(name: 'Two Line', type: AppListTile)
+Widget appListTileTwoLine(BuildContext context) {
+  return Scaffold(
+    body: ListView(
+      children: [
+        AppListTile(
+          leading: const CircleAvatar(child: Icon(Icons.folder)),
+          title: 'Documents',
+          subtitle: '24 files',
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const CircleAvatar(child: Icon(Icons.photo)),
+          title: 'Photos',
+          subtitle: '156 items',
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const CircleAvatar(child: Icon(Icons.music_note)),
+          title: 'Music',
+          subtitle: '42 songs',
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+/// Three-line list tile with extended subtitle.
+@widgetbook.UseCase(name: 'Three Line', type: AppListTile)
+Widget appListTileThreeLine(BuildContext context) {
+  return Scaffold(
+    body: ListView(
+      children: [
+        AppListTile(
+          leading: const CircleAvatar(
+            backgroundImage: NetworkImage('https://i.pravatar.cc/150?img=1'),
+          ),
+          title: 'John Doe',
+          subtitle: 'Hey! How are you doing today?\nSent 2 hours ago',
+          isThreeLine: true,
+          trailing: const Text('12:30'),
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const CircleAvatar(
+            backgroundImage: NetworkImage('https://i.pravatar.cc/150?img=2'),
+          ),
+          title: 'Jane Smith',
+          subtitle: 'Can we schedule a meeting for tomorrow?\nSent 5 hours ago',
+          isThreeLine: true,
+          trailing: const Text('09:15'),
+          onTap: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+// ============================================================================
+// Story 3: With Leading Widgets
+// ============================================================================
+
+/// List tiles with various leading widgets.
+@widgetbook.UseCase(name: 'Leading Widgets', type: AppListTile)
+Widget appListTileLeading(BuildContext context) {
+  return Scaffold(
+    body: ListView(
+      children: [
+        // Icon (24dp)
+        AppListTile(
+          leading: const Icon(Icons.settings, size: 24),
+          title: 'Settings',
+          subtitle: 'App preferences',
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        // Avatar (40dp)
+        AppListTile(
+          leading: const CircleAvatar(radius: 20, child: Icon(Icons.person)),
+          title: 'John Doe',
+          subtitle: 'Software Engineer',
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        // Checkbox
+        AppListTile(
+          leading: Checkbox(
+            value: context.knobs.boolean(
+              label: 'Checkbox checked',
+              initialValue: false,
+            ),
+            onChanged: (_) {},
+          ),
+          title: 'Select item',
+          subtitle: 'Optional description',
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        // Image thumbnail
+        AppListTile(
+          leading: Container(
+            width: 56,
+            height: 56,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(8),
+              image: const DecorationImage(
+                image: NetworkImage('https://picsum.photos/100'),
+                fit: BoxFit.cover,
+              ),
+            ),
+          ),
+          title: 'Photo Album',
+          subtitle: 'Summer vacation 2024',
+          onTap: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+// ============================================================================
+// Story 4: With Trailing Widgets
+// ============================================================================
+
+/// List tiles with various trailing widgets.
+@widgetbook.UseCase(name: 'Trailing Widgets', type: AppListTile)
+Widget appListTileTrailing(BuildContext context) {
+  return Scaffold(
+    body: ListView(
+      children: [
+        // Chevron icon (navigation)
+        AppListTile(
+          leading: const Icon(Icons.account_circle),
+          title: 'Profile',
+          subtitle: 'View your profile',
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        // Info icon
+        AppListTile(
+          leading: const Icon(Icons.info_outline),
+          title: 'About',
+          trailing: const Icon(Icons.info),
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        // Switch toggle
+        AppListTile(
+          leading: const Icon(Icons.notifications),
+          title: 'Notifications',
+          subtitle: 'Enable push notifications',
+          trailing: Switch(
+            value: context.knobs.boolean(
+              label: 'Notifications enabled',
+              initialValue: true,
+            ),
+            onChanged: (_) {},
+          ),
+        ),
+        const Divider(height: 1),
+        // Text (timestamp)
+        AppListTile(
+          leading: const CircleAvatar(child: Icon(Icons.message)),
+          title: 'New Message',
+          subtitle: 'Hey, how are you?',
+          trailing: const Text('2:30 PM', style: TextStyle(fontSize: 12)),
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        // Icon button
+        AppListTile(
+          leading: const Icon(Icons.favorite),
+          title: 'Favorites',
+          subtitle: '5 items',
+          trailing: IconButton(
+            icon: const Icon(Icons.more_vert),
+            onPressed: () {},
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+// ============================================================================
+// Story 5: States - Default, Selected, Disabled, Hover, Pressed
+// ============================================================================
+
+/// List tiles in various interaction states.
+@widgetbook.UseCase(name: 'States', type: AppListTile)
+Widget appListTileStates(BuildContext context) {
+  final selectedState = context.knobs.boolean(
+    label: 'Selected',
+    initialValue: false,
+  );
+  final enabledState = context.knobs.boolean(
+    label: 'Enabled',
+    initialValue: true,
+  );
+
+  return Scaffold(
+    body: ListView(
+      children: [
+        // Default state
+        AppListTile(
+          leading: const Icon(Icons.home),
+          title: 'Home',
+          subtitle: 'Default state',
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        // Selected state
+        AppListTile(
+          leading: const Icon(Icons.star),
+          title: 'Favorites',
+          subtitle: 'Selected state',
+          trailing: const Icon(Icons.chevron_right),
+          selected: selectedState,
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        // Disabled state
+        AppListTile(
+          leading: const Icon(Icons.block),
+          title: 'Disabled',
+          subtitle: 'Cannot interact',
+          trailing: const Icon(Icons.chevron_right),
+          enabled: enabledState,
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        // Pressed state (has ripple on tap)
+        AppListTile(
+          leading: const Icon(Icons.touch_app),
+          title: 'Press Me',
+          subtitle: 'Tap to see ripple effect',
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+// ============================================================================
+// Story 6: Dense Mode - Compact layout
+// ============================================================================
+
+/// Dense mode list tiles with reduced height.
+@widgetbook.UseCase(name: 'Dense Mode', type: AppListTile)
+Widget appListTileDense(BuildContext context) {
+  final denseMode = context.knobs.boolean(
+    label: 'Dense Mode',
+    initialValue: true,
+  );
+
+  return Scaffold(
+    appBar: AppBar(
+      title: Text(denseMode ? 'Dense Mode (48dp)' : 'Regular Mode (56dp)'),
+    ),
+    body: ListView(
+      children: [
+        AppListTile(
+          leading: const Icon(Icons.inbox, size: 20),
+          title: 'Inbox',
+          trailing: const Text('24'),
+          dense: denseMode,
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const Icon(Icons.send, size: 20),
+          title: 'Sent',
+          trailing: const Text('8'),
+          dense: denseMode,
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const Icon(Icons.drafts, size: 20),
+          title: 'Drafts',
+          trailing: const Text('3'),
+          dense: denseMode,
+          onTap: () {},
+        ),
+        const SizedBox(height: 16),
+        const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            'Dense two-line (64dp vs 72dp)',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+        ),
+        AppListTile(
+          leading: const Icon(Icons.folder, size: 20),
+          title: 'Documents',
+          subtitle: '24 files',
+          trailing: const Icon(Icons.chevron_right),
+          dense: denseMode,
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const Icon(Icons.photo, size: 20),
+          title: 'Photos',
+          subtitle: '156 items',
+          trailing: const Icon(Icons.chevron_right),
+          dense: denseMode,
+          onTap: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+// ============================================================================
+// Story 7: Common Patterns - Real-world examples
+// ============================================================================
+
+/// Common list tile patterns used in real apps.
+@widgetbook.UseCase(name: 'Common Patterns', type: AppListTile)
+Widget appListTilePatterns(BuildContext context) {
+  return Scaffold(
+    appBar: AppBar(title: const Text('Settings')),
+    body: ListView(
+      children: [
+        const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            'Settings List',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+        ),
+        AppListTile(
+          leading: const Icon(Icons.wifi),
+          title: 'Wi-Fi',
+          subtitle: 'MyNetwork',
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () {},
+        ),
+        AppListTile(
+          leading: const Icon(Icons.bluetooth),
+          title: 'Bluetooth',
+          subtitle: 'Off',
+          trailing: Switch(value: false, onChanged: (_) {}),
+        ),
+        const Divider(),
+        const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            'Contact List',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+        ),
+        AppListTile(
+          leading: const CircleAvatar(
+            backgroundImage: NetworkImage('https://i.pravatar.cc/150?img=3'),
+          ),
+          title: 'Alice Johnson',
+          subtitle: 'Hey, are you free tomorrow?',
+          trailing: const Text('2 min ago'),
+          onTap: () {},
+        ),
+        AppListTile(
+          leading: const CircleAvatar(
+            backgroundImage: NetworkImage('https://i.pravatar.cc/150?img=4'),
+          ),
+          title: 'Bob Williams',
+          subtitle: 'Thanks for the help!',
+          trailing: const Text('1 hour ago'),
+          onTap: () {},
+        ),
+        const Divider(),
+        const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            'Navigation Menu',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+        ),
+        AppListTile(
+          leading: const Icon(Icons.home),
+          title: 'Home',
+          onTap: () {},
+        ),
+        AppListTile(
+          leading: const Icon(Icons.person),
+          title: 'Profile',
+          onTap: () {},
+        ),
+        AppListTile(
+          leading: const Icon(Icons.settings),
+          title: 'Settings',
+          onTap: () {},
+        ),
+        const Divider(),
+        const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            'Selectable List',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+        ),
+        AppListTile(
+          leading: Checkbox(value: true, onChanged: (_) {}),
+          title: 'Item 1',
+          subtitle: 'First selected item',
+          onTap: () {},
+        ),
+        AppListTile(
+          leading: Checkbox(value: false, onChanged: (_) {}),
+          title: 'Item 2',
+          subtitle: 'Second unselected item',
+          onTap: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+// ============================================================================
+// Story 8: Theme Variations - Light/Dark modes
+// ============================================================================
+
+/// List tiles in different theme modes.
+@widgetbook.UseCase(name: 'Theme Variations', type: AppListTile)
+Widget appListTileThemes(BuildContext context) {
+  return Scaffold(
+    body: ListView(
+      children: [
+        const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            'Theme automatically adapts to light/dark mode.\nUse the theme switcher in Widgetbook toolbar.',
+            textAlign: TextAlign.center,
+          ),
+        ),
+        const Divider(),
+        AppListTile(
+          leading: const Icon(Icons.brightness_6),
+          title: 'Theme Mode',
+          subtitle: 'Automatically adapts to light/dark',
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const Icon(Icons.star),
+          title: 'Selected Item',
+          subtitle: 'Shows secondaryContainer background',
+          selected: true,
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const Icon(Icons.palette),
+          title: 'Custom Tile Color',
+          subtitle: 'Using primaryContainer',
+          tileColor: Theme.of(context).colorScheme.primaryContainer,
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const Icon(Icons.color_lens),
+          title: 'Custom Selected Color',
+          subtitle: 'Using tertiaryContainer',
+          selected: true,
+          selectedTileColor: Theme.of(context).colorScheme.tertiaryContainer,
+          onTap: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+// ============================================================================
+// Story 9: Interactive Playground - Full customization
+// ============================================================================
+
+/// Interactive playground to customize all list tile properties.
+@widgetbook.UseCase(name: 'Interactive Playground', type: AppListTile)
+Widget appListTilePlayground(BuildContext context) {
+  // Title and subtitle
+  final title = context.knobs.string(
+    label: 'Title',
+    initialValue: 'List Item Title',
+  );
+  final subtitle = context.knobs.string(
+    label: 'Subtitle',
+    initialValue: 'Optional subtitle text',
+  );
+  final showSubtitle = context.knobs.boolean(
+    label: 'Show Subtitle',
+    initialValue: true,
+  );
+
+  // Leading widget options
+  final leadingType = context.knobs.object.dropdown(
+    label: 'Leading Widget',
+    options: ['None', 'Icon', 'Avatar', 'Checkbox'],
+    labelBuilder: (option) => option,
+    initialOption: 'Icon',
+  );
+
+  // Trailing widget options
+  final trailingType = context.knobs.object.dropdown(
+    label: 'Trailing Widget',
+    options: ['None', 'Icon', 'Chevron', 'Switch', 'Text'],
+    labelBuilder: (option) => option,
+    initialOption: 'Chevron',
+  );
+
+  // States
+  final selected = context.knobs.boolean(
+    label: 'Selected',
+    initialValue: false,
+  );
+  final enabled = context.knobs.boolean(label: 'Enabled', initialValue: true);
+  final dense = context.knobs.boolean(label: 'Dense Mode', initialValue: false);
+  final isThreeLine = context.knobs.boolean(
+    label: 'Three Line',
+    initialValue: false,
+  );
+
+  // Build leading widget
+  Widget? leading;
+  switch (leadingType) {
+    case 'Icon':
+      leading = const Icon(Icons.star);
+    case 'Avatar':
+      leading = const CircleAvatar(child: Icon(Icons.person));
+    case 'Checkbox':
+      leading = Checkbox(value: selected, onChanged: (_) {});
+    case 'None':
+      leading = null;
+  }
+
+  // Build trailing widget
+  Widget? trailing;
+  switch (trailingType) {
+    case 'Icon':
+      trailing = const Icon(Icons.info);
+    case 'Chevron':
+      trailing = const Icon(Icons.chevron_right);
+    case 'Switch':
+      trailing = Switch(value: selected, onChanged: (_) {});
+    case 'Text':
+      trailing = const Text('12:30');
+    case 'None':
+      trailing = null;
+  }
+
+  return Scaffold(
+    appBar: AppBar(title: const Text('Interactive Playground')),
+    body: ListView(
+      children: [
+        const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            'Use the knobs panel to customize the list tile properties.',
+            textAlign: TextAlign.center,
+          ),
+        ),
+        const Divider(),
+        AppListTile(
+          leading: leading,
+          title: title,
+          subtitle: showSubtitle ? subtitle : null,
+          trailing: trailing,
+          selected: selected,
+          enabled: enabled,
+          dense: dense,
+          isThreeLine: isThreeLine,
+          onTap: () {},
+        ),
+      ],
+    ),
+  );
+}


### PR DESCRIPTION
# Pull Request

This pull request introduces a new reusable Material Design 3 list tile widget, `AppListTile`, to the core kit, and integrates it into the design system's Widgetbook documentation and story explorer. It also adds Widgetbook support and stories for new button components (`AppIconButton`, `AppOutlinedButton`). The changes improve consistency, reusability, and documentation of UI components.

**New component: AppListTile**

- Added a new `AppListTile` widget in `core_kit`, providing a customizable Material Design 3 list tile with support for leading/trailing widgets, title, subtitle, dense/three-line modes, and theming. The implementation includes comprehensive documentation and follows Material guidelines. (`packages/core_kit/lib/widgets/surfaces/app_list_tile.dart`)
- Exported `AppListTile` from `core_kit.dart` for use throughout the codebase. (`packages/core_kit/lib/core_kit.dart`)

**Widgetbook integration and stories**

- Registered `AppListTile` in Widgetbook with a dedicated folder and multiple use cases (e.g., default, dense, three-line, theme variations, playground, etc.), improving discoverability and documentation for designers and developers. (`widgetbook_kit/lib/app/widgetbook_app.directories.g.dart`) [[1]](diffhunk://#diff-c0bcce5523f19a884f9e01d6ef361f44d02d024e03a463bee7c14636e341cc7aL18-R27) [[2]](diffhunk://#diff-c0bcce5523f19a884f9e01d6ef361f44d02d024e03a463bee7c14636e341cc7aR470-R545)
- Added imports and registration for new button components (`AppIconButton`, `AppOutlinedButton`) and their Widgetbook stories, along with their use cases for comprehensive documentation and testing. (`widgetbook_kit/lib/app/widgetbook_app.directories.g.dart`) [[1]](diffhunk://#diff-c0bcce5523f19a884f9e01d6ef361f44d02d024e03a463bee7c14636e341cc7aL18-R27) [[2]](diffhunk://#diff-c0bcce5523f19a884f9e01d6ef361f44d02d024e03a463bee7c14636e341cc7aR239-R332)

Closes #19 

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Packages (packages/*)
- [x] Widgetbook Kit (widgetbook_kit/)
- [ ] Documentation (docs/)
- [ ] CI / Infra (.github/)

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: <type>/<short-description> (e.g., feat/login-screen)
- [x] My PR title starts with one of the approved types listed above
- [x] My Dart code is formatted (dart format . or flutter format .)
- [x] I ran static analysis (flutter analyze) and resolved warnings
- [x] I ran tests successfully (flutter test)
- [x] I updated / checked pubspec.yaml and pubspec.lock for dependency changes
- [x] For UI changes, I added Widgetbook stories
- [x] I linked related issues using keywords like Closes #19 
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

```text
Closes #19 
```

---

## 💬 Additional Notes (Optional)

- Widgetbook stories were updated to align with the final `AppListTile` API (string-based `title` and `subtitle`).
- The implementation follows Material Design 3 guidelines and core design tokens.
- All changes are fully covered by tests and CI checks are passing.
