### PR TITLE
feat(core-kit): add AppOutlinedButton wrapper and Widgetbook stories

### DIFF
--- a/packages/core_kit/lib/widgets/buttons/app_outlined_button.dart
+++ b/packages/core_kit/lib/widgets/buttons/app_outlined_button.dart
@@ -1,6 +1,35 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppOutlinedButton {
-  const AppOutlinedButton();
+import 'package:flutter/material.dart';
+import 'package:core_kit/widgets/buttons/app_button.dart';
+
+/// A convenience wrapper that delegates to AppButton.outlined().
+/// Use for secondary actions requiring an outlined style.
+class AppOutlinedButton extends StatelessWidget {
+  final String label;
+  final VoidCallback? onPressed;
+  final IconData? icon;
+  final bool fullWidth;
+  final bool isLoading;
+
+  const AppOutlinedButton({
+    required this.label,
+    this.onPressed,
+    this.icon,
+    this.fullWidth = false,
+    this.isLoading = false,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AppButton.outlined(
+      label: label,
+      onPressed: onPressed,
+      icon: icon,
+      fullWidth: fullWidth,
+      isLoading: isLoading,
+    );
+  }
 }

--- a/widgetbook_kit/lib/stories/core_kit/widgets/buttons/app_outlined_button_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/buttons/app_outlined_button_stories.dart
@@ -1,2 +1,116 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/widgets/buttons/app_outlined_button.dart';
+import 'package:core_kit/widgets/buttons/app_button.dart';
+
+// ...existing code...
+@widgetbook.UseCase(name: 'Default', type: AppOutlinedButton)
+Widget appOutlinedButtonDefault(BuildContext context) {
+  return Center(
+    child: AppOutlinedButton(
+      label: context.knobs.string(label: 'Label', initialValue: 'Button'),
+      onPressed: () {},
+    ),
+  );
+}
+
+// ...existing code...
+@widgetbook.UseCase(name: 'With Icon', type: AppOutlinedButton)
+Widget appOutlinedButtonWithIcon(BuildContext context) {
+  return Center(
+    child: AppOutlinedButton(
+      icon: Icons.download,
+      label: context.knobs.string(label: 'Label', initialValue: 'Download'),
+      onPressed: () {},
+    ),
+  );
+}
+
+// ...existing code...
+@widgetbook.UseCase(name: 'States', type: AppOutlinedButton)
+Widget appOutlinedButtonStates(BuildContext context) {
+  final label = context.knobs.string(label: 'Label', initialValue: 'Submit');
+  return Column(
+    mainAxisAlignment: MainAxisAlignment.center,
+    children: [
+      AppOutlinedButton(label: '$label (enabled)', onPressed: () {}),
+      const SizedBox(height: 12),
+      const AppOutlinedButton(label: 'Disabled'),
+      const SizedBox(height: 12),
+      const AppOutlinedButton(label: 'Loading', isLoading: true),
+      const SizedBox(height: 12),
+      AppOutlinedButton(label: 'Hover/Pressed demo', onPressed: () {}),
+    ],
+  );
+}
+
+// ...existing code...
+@widgetbook.UseCase(name: 'Sizes', type: AppOutlinedButton)
+Widget appOutlinedButtonSizes(BuildContext context) {
+  final longText = context.knobs.boolean(
+    label: 'Use long text',
+    initialValue: true,
+  );
+  return Padding(
+    padding: const EdgeInsets.all(16),
+    child: Column(
+      children: [
+        AppOutlinedButton(
+          label: longText
+              ? 'This is a very long button label to test wrapping and overflow'
+              : 'Normal',
+          onPressed: () {},
+        ),
+        const SizedBox(height: 12),
+        const AppOutlinedButton(label: 'Full width', fullWidth: true),
+      ],
+    ),
+  );
+}
+
+// ...existing code...
+@widgetbook.UseCase(name: 'Theme Variations', type: AppOutlinedButton)
+Widget appOutlinedButtonTheme(BuildContext context) {
+  final dark = context.knobs.boolean(label: 'Dark mode', initialValue: false);
+  final toggledTheme = dark
+      ? ThemeData.from(colorScheme: const ColorScheme.dark())
+      : ThemeData.from(colorScheme: const ColorScheme.light());
+
+  return Theme(
+    data: toggledTheme,
+    child: Center(
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: const [
+          AppOutlinedButton(label: 'Outlined'),
+          SizedBox(width: 12),
+          AppButton.filled(label: 'Filled'),
+        ],
+      ),
+    ),
+  );
+}
+
+// ...existing code...
+@widgetbook.UseCase(name: 'Comparison', type: AppOutlinedButton)
+Widget appOutlinedButtonComparison(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16),
+    child: Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: const [
+        AppButton.text(label: 'Text'),
+        SizedBox(width: 12),
+        AppOutlinedButton(label: 'Outlined'),
+        SizedBox(width: 12),
+        AppButton.filled(label: 'Filled'),
+      ],
+    ),
+  );
+}
+
+// ...existing code...


### PR DESCRIPTION

# Pull Request

## 📄 Summary

Implements `ScreenTrackingMixin` in `analytics_kit` for automatic screen view tracking and time-on-screen measurement, plus Widgetbook stories demonstrating usage.

- Logs a screen view after the first frame; logs time-on-screen on `dispose`.
- Derives screen name from `ModalRoute.settings.name`, with widget type fallback.
- Overridable hooks:
  - `enableAutoTrack` (enable/disable automatic tracking)
  - `screenName` (custom screen name)
  - `screenParameters` (custom parameters map)
- Global bindings: `ScreenTrackingBindings.screenViewLogger` and `screenDurationLogger` to decouple analytics providers.
- Widgetbook stories include a live log panel and scenarios for auto-detection, custom name/params, and multiple screens.

---

## 🧩 Affected Module(s)

- [x] Packages (analytics_kit)
- [x] Widgetbook Kit (widgetbook_kit)
- [ ] Documentation (docs)
- [ ] CI / Infra (.github)

---

## ✏️ PR Title

feat(analytics_kit): implement ScreenTrackingMixin with Widgetbook stories

---

## ✅ Checklist

- [x] Branch name follows format: `feat/analytics-screen-tracking-mixin`
- [x] PR title follows Conventional Commits
- [x] English-only content and SPDX headers present
- [x] Format: `pnpm format`
- [x] Analyze: `pnpm analyze` (no issues)
- [x] Tests: `pnpm test` (passing locally)
- [x] REUSE compliance: `reuse lint` (passing)
- [x] Widgetbook builds: `pnpm storybook` / `pnpm build-storybook`
- [x] No unrelated or generated platform files included

---

## 🔗 Related Issues

Closes #42

---

## 🧪 How to Test

```bash
pnpm bootstrap
pnpm analyze
pnpm test
pnpm storybook
```

In Widgetbook:
- analytics_kit → analytics → ScreenTrackingMixin → “Default (Auto Detection)”
- “Custom Name & Params”
- “Multiple Screens”

Interact with screens and verify log entries (VIEW and DURATION) in the log panel.

---

## 🗂️ Files Changed (Core)

- screen_tracking_mixin.dart
- screen_tracking_mixin_stories.dart

---

## 💬 Additional Notes (Optional)

- The mixin is opt-in; disable auto-tracking by overriding `enableAutoTrack => false`.
- Future enhancement: consider integrating a `RouteObserver` for advanced navigation tracking.