### PR TITLE
feat(core_kit): implement AppFilterChip with MD3 compliance

### DIFF
--- a/packages/core_kit/lib/core_kit.dart
+++ b/packages/core_kit/lib/core_kit.dart
@@ -21,3 +21,4 @@ export 'widgets/inputs/app_search_field.dart';
 export 'widgets/surfaces/app_list_tile.dart';
 export 'widgets/inputs/app_radio_group.dart';
 export 'widgets/inputs/app_slider.dart';
+export 'widgets/chips/app_filter_chip.dart';

--- a/packages/core_kit/lib/widgets/chips/app_filter_chip.dart
+++ b/packages/core_kit/lib/widgets/chips/app_filter_chip.dart
@@ -1,6 +1,317 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppFilterChip {
-  const AppFilterChip();
+import 'package:flutter/material.dart';
+
+/// A Material Design 3 filter chip widget.
+///
+/// Filter chips allow users to refine content by selecting from predefined
+/// filter criteria. They support multi-selection with visual feedback through
+/// checkmarks and background highlighting.
+///
+/// The chip automatically handles:
+/// - Selected/unselected toggle states
+/// - Checkmark icon display when selected
+/// - Background color changes based on selection state
+/// - Outlined border when unselected
+/// - Disabled state with reduced opacity
+/// - Keyboard navigation with focus indicators
+/// - Touch ripple effects
+///
+/// Material Design 3 specifications:
+/// - Height: 32dp
+/// - Horizontal padding: 16dp (8dp with icons)
+/// - Checkmark size: 18dp
+/// - Icon spacing: 8dp from label
+/// - Unselected: Outlined with 1dp border
+/// - Selected: Filled with secondary container color
+///
+/// Example usage:
+///
+/// ```dart
+/// // Basic filter chip
+/// AppFilterChip(
+///   label: 'Shoes',
+///   selected: false,
+///   onSelected: (selected) {
+///     setState(() => _isSelected = selected);
+///   },
+/// )
+///
+/// // Filter chip with custom icon
+/// AppFilterChip(
+///   label: 'New Arrivals',
+///   icon: Icons.fiber_new,
+///   selected: true,
+///   onSelected: (selected) => _handleFilter(selected),
+/// )
+///
+/// // Filter group with multiple chips
+/// Wrap(
+///   spacing: 8,
+///   children: [
+///     AppFilterChip(
+///       label: 'Electronics',
+///       selected: _filters.contains('electronics'),
+///       onSelected: (selected) => _toggleFilter('electronics'),
+///     ),
+///     AppFilterChip(
+///       label: 'Clothing',
+///       selected: _filters.contains('clothing'),
+///       onSelected: (selected) => _toggleFilter('clothing'),
+///     ),
+///   ],
+/// )
+///
+/// // Filter chip with avatar
+/// AppFilterChip(
+///   label: 'John Doe',
+///   avatar: CircleAvatar(child: Text('JD')),
+///   selected: _selectedUser == 'john',
+///   onSelected: (selected) => _selectUser('john'),
+/// )
+/// ```
+///
+/// See also:
+/// - [FilterChip], the underlying Material widget
+/// - [Chip], for other chip variants
+/// - Material Design 3 Chips: https://m3.material.io/components/chips
+class AppFilterChip extends StatelessWidget {
+  /// Creates a Material Design 3 filter chip.
+  ///
+  /// The [label] and [onSelected] parameters are required.
+  /// The [selected] parameter defaults to false.
+  const AppFilterChip({
+    required this.label,
+    required this.onSelected,
+    this.selected = false,
+    this.icon,
+    this.avatar,
+    this.enabled = true,
+    this.selectedColor,
+    this.unselectedColor,
+    this.checkmarkColor,
+    this.labelStyle,
+    this.padding,
+    this.elevation,
+    this.pressElevation,
+    this.shape,
+    this.tooltip,
+    this.visualDensity,
+    this.focusNode,
+    this.autofocus = false,
+    super.key,
+  });
+
+  /// The primary content of the filter chip.
+  ///
+  /// Displayed using Material Design 3 labelLarge style.
+  final String label;
+
+  /// Called when the filter chip selection state changes.
+  ///
+  /// The callback receives a boolean indicating the new selected state.
+  /// This is called when the user taps the chip.
+  final ValueChanged<bool>? onSelected;
+
+  /// Whether this filter chip is currently selected.
+  ///
+  /// When true:
+  /// - Shows checkmark icon
+  /// - Uses secondary container background color
+  /// - Uses on-secondary-container text color
+  ///
+  /// When false:
+  /// - No checkmark icon
+  /// - Outlined border style
+  /// - Transparent background
+  ///
+  /// Default is false.
+  final bool selected;
+
+  /// An optional icon displayed before the label when unselected.
+  ///
+  /// This icon is replaced by a checkmark when the chip is selected.
+  /// The icon should be 18dp in size to match Material Design 3 specs.
+  final IconData? icon;
+
+  /// An optional avatar displayed before the label.
+  ///
+  /// Typically used for user or entity filters. The avatar is shown
+  /// in both selected and unselected states.
+  ///
+  /// When both [avatar] and [icon] are provided, [avatar] takes precedence.
+  final Widget? avatar;
+
+  /// Whether the filter chip is interactive.
+  ///
+  /// If false:
+  /// - Chip appears with 38% opacity
+  /// - [onSelected] is not called
+  /// - No touch ripple effect
+  ///
+  /// Default is true.
+  final bool enabled;
+
+  /// The background color when the chip is selected.
+  ///
+  /// If null, uses theme's secondaryContainer color.
+  final Color? selectedColor;
+
+  /// The border color when the chip is unselected.
+  ///
+  /// If null, uses theme's outline color.
+  final Color? unselectedColor;
+
+  /// The color of the checkmark icon when selected.
+  ///
+  /// If null, uses theme's onSecondaryContainer color.
+  final Color? checkmarkColor;
+
+  /// The style for the label text.
+  ///
+  /// If null, uses theme's labelLarge style.
+  final TextStyle? labelStyle;
+
+  /// The padding around the chip content.
+  ///
+  /// Default is EdgeInsets.symmetric(horizontal: 16.0) for text-only chips,
+  /// or EdgeInsets.symmetric(horizontal: 8.0) when icon/avatar is present.
+  final EdgeInsetsGeometry? padding;
+
+  /// The elevation when the chip is unselected and not pressed.
+  ///
+  /// Default is 0.0 (flat).
+  final double? elevation;
+
+  /// The elevation when the chip is pressed.
+  ///
+  /// Default is 0.0 (flat).
+  final double? pressElevation;
+
+  /// The shape of the chip's border.
+  ///
+  /// If null, uses a stadium border (fully rounded).
+  final OutlinedBorder? shape;
+
+  /// Tooltip message shown on long press.
+  final String? tooltip;
+
+  /// Defines how compact the chip's layout will be.
+  final VisualDensity? visualDensity;
+
+  /// An optional focus node for keyboard navigation.
+  final FocusNode? focusNode;
+
+  /// Whether this chip should request focus when first built.
+  ///
+  /// Default is false.
+  final bool autofocus;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final textTheme = theme.textTheme;
+
+    // Determine colors based on selection state
+    final effectiveSelectedColor =
+        selectedColor ?? colorScheme.secondaryContainer;
+    final effectiveLabelColor = selected
+        ? colorScheme.onSecondaryContainer
+        : colorScheme.onSurfaceVariant;
+    final effectiveCheckmarkColor =
+        checkmarkColor ?? colorScheme.onSecondaryContainer;
+
+    // Build label with proper typography
+    final labelWidget = Text(
+      label,
+      style: (labelStyle ?? textTheme.labelLarge)?.copyWith(
+        color: effectiveLabelColor,
+      ),
+    );
+
+    // Determine leading widget based on state and properties
+    Widget? leadingWidget;
+    bool showCheckmark = false;
+
+    if (avatar != null) {
+      // Avatar takes precedence and shows in both states
+      leadingWidget = avatar;
+      showCheckmark = false;
+    } else if (selected) {
+      // Show checkmark when selected (replaces custom icon if present)
+      leadingWidget = Icon(
+        Icons.check,
+        size: 18,
+        color: effectiveCheckmarkColor,
+      );
+      showCheckmark = false; // We're manually adding checkmark as avatar
+    } else if (icon != null) {
+      // Show custom icon only when unselected
+      leadingWidget = Icon(icon, size: 18, color: effectiveLabelColor);
+      showCheckmark = false;
+    }
+
+    // Build the filter chip
+    Widget chip = FilterChip(
+      label: labelWidget,
+      selected: selected,
+      onSelected: enabled ? onSelected : null,
+      avatar: leadingWidget,
+
+      // Disable built-in checkmark since we handle it manually
+      showCheckmark: showCheckmark,
+      checkmarkColor: effectiveCheckmarkColor,
+
+      // Selection color (background when selected)
+      selectedColor: effectiveSelectedColor,
+
+      // Background color when unselected (transparent for outlined style)
+      backgroundColor: Colors.transparent,
+
+      // Border color when unselected
+      side: selected
+          ? BorderSide.none
+          : BorderSide(color: unselectedColor ?? colorScheme.outline, width: 1),
+
+      // Shape with stadium border (fully rounded ends)
+      shape: shape ?? const StadiumBorder(),
+
+      // Padding
+      padding: padding,
+      labelPadding:
+          padding ??
+          EdgeInsets.symmetric(horizontal: leadingWidget != null ? 8.0 : 16.0),
+
+      // Elevation
+      elevation: elevation ?? 0.0,
+      pressElevation: pressElevation ?? 0.0,
+
+      // Visual density
+      visualDensity: visualDensity,
+
+      // Focus handling
+      focusNode: focusNode,
+      autofocus: autofocus,
+
+      // Material state properties for custom styling
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+    );
+
+    // Wrap with tooltip if provided
+    if (tooltip != null) {
+      chip = Tooltip(message: tooltip, child: chip);
+    }
+
+    // Apply disabled opacity if not enabled
+    if (!enabled) {
+      chip = Opacity(
+        opacity: 0.38, // Material Design 3 disabled opacity
+        child: chip,
+      );
+    }
+
+    return chip;
+  }
 }

--- a/packages/core_kit/test/widgets/chips/app_filter_chip_test.dart
+++ b/packages/core_kit/test/widgets/chips/app_filter_chip_test.dart
@@ -1,0 +1,493 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:core_kit/widgets/chips/app_filter_chip.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AppFilterChip', () {
+    testWidgets('renders with label only', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppFilterChip(label: 'Test Filter', onSelected: (_) {}),
+          ),
+        ),
+      );
+
+      expect(find.text('Test Filter'), findsOneWidget);
+    });
+
+    testWidgets('renders in unselected state by default', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppFilterChip(label: 'Test Filter', onSelected: (_) {}),
+          ),
+        ),
+      );
+
+      final filterChip = tester.widget<FilterChip>(find.byType(FilterChip));
+      expect(filterChip.selected, isFalse);
+    });
+
+    testWidgets('renders in selected state when specified', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppFilterChip(
+              label: 'Test Filter',
+              selected: true,
+              onSelected: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      final filterChip = tester.widget<FilterChip>(find.byType(FilterChip));
+      expect(filterChip.selected, isTrue);
+    });
+
+    testWidgets('shows checkmark when selected', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppFilterChip(
+              label: 'Test Filter',
+              selected: true,
+              onSelected: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      // Check that checkmark icon is present (manually added as avatar)
+      expect(find.byIcon(Icons.check), findsOneWidget);
+    });
+
+    testWidgets('does not show checkmark when unselected', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppFilterChip(
+              label: 'Test Filter',
+              selected: false,
+              onSelected: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      // Checkmark should not be visible in unselected state
+      expect(find.byIcon(Icons.check), findsNothing);
+    });
+
+    testWidgets('calls onSelected with true when tapped while unselected', (
+      WidgetTester tester,
+    ) async {
+      bool? selectedValue;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppFilterChip(
+              label: 'Test Filter',
+              selected: false,
+              onSelected: (value) => selectedValue = value,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(AppFilterChip));
+      await tester.pump();
+
+      expect(selectedValue, isTrue);
+    });
+
+    testWidgets('calls onSelected with false when tapped while selected', (
+      WidgetTester tester,
+    ) async {
+      bool? selectedValue;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppFilterChip(
+              label: 'Test Filter',
+              selected: true,
+              onSelected: (value) => selectedValue = value,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(AppFilterChip));
+      await tester.pump();
+
+      expect(selectedValue, isFalse);
+    });
+
+    testWidgets('does not call onSelected when disabled', (
+      WidgetTester tester,
+    ) async {
+      bool? selectedValue;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppFilterChip(
+              label: 'Test Filter',
+              enabled: false,
+              onSelected: (value) => selectedValue = value,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(AppFilterChip));
+      await tester.pump();
+
+      expect(selectedValue, isNull);
+    });
+
+    testWidgets('renders with custom icon when unselected', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppFilterChip(
+              label: 'Test Filter',
+              icon: Icons.star,
+              selected: false,
+              onSelected: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.star), findsOneWidget);
+      expect(find.byIcon(Icons.check), findsNothing);
+    });
+
+    testWidgets('replaces custom icon with checkmark when selected', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppFilterChip(
+              label: 'Test Filter',
+              icon: Icons.star,
+              selected: true,
+              onSelected: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.check), findsOneWidget);
+      expect(find.byIcon(Icons.star), findsNothing);
+    });
+
+    testWidgets('renders with avatar in both states', (
+      WidgetTester tester,
+    ) async {
+      const avatar = CircleAvatar(child: Text('A'));
+
+      // Unselected state
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppFilterChip(
+              label: 'Test Filter',
+              avatar: avatar,
+              selected: false,
+              onSelected: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byWidget(avatar), findsOneWidget);
+      expect(find.byIcon(Icons.check), findsNothing);
+
+      // Selected state
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppFilterChip(
+              label: 'Test Filter',
+              avatar: avatar,
+              selected: true,
+              onSelected: (_) {},
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byWidget(avatar), findsOneWidget);
+      // Checkmark is hidden when avatar is present
+      expect(find.byIcon(Icons.check), findsNothing);
+    });
+
+    testWidgets('avatar takes precedence over icon', (
+      WidgetTester tester,
+    ) async {
+      const avatar = CircleAvatar(child: Text('A'));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppFilterChip(
+              label: 'Test Filter',
+              icon: Icons.star,
+              avatar: avatar,
+              selected: false,
+              onSelected: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byWidget(avatar), findsOneWidget);
+      expect(find.byIcon(Icons.star), findsNothing);
+    });
+
+    testWidgets('applies custom selected color', (WidgetTester tester) async {
+      const customColor = Colors.purple;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppFilterChip(
+              label: 'Test Filter',
+              selected: true,
+              selectedColor: customColor,
+              onSelected: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      final filterChip = tester.widget<FilterChip>(find.byType(FilterChip));
+      expect(filterChip.selectedColor, equals(customColor));
+    });
+
+    testWidgets('applies custom checkmark color', (WidgetTester tester) async {
+      const customColor = Colors.red;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppFilterChip(
+              label: 'Test Filter',
+              selected: true,
+              checkmarkColor: customColor,
+              onSelected: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      final filterChip = tester.widget<FilterChip>(find.byType(FilterChip));
+      expect(filterChip.checkmarkColor, equals(customColor));
+    });
+
+    testWidgets('applies custom label style', (WidgetTester tester) async {
+      const customStyle = TextStyle(fontSize: 20, fontWeight: FontWeight.bold);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppFilterChip(
+              label: 'Test Filter',
+              labelStyle: customStyle,
+              onSelected: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      final textWidget = tester.widget<Text>(find.text('Test Filter'));
+      expect(textWidget.style?.fontSize, equals(20));
+      expect(textWidget.style?.fontWeight, equals(FontWeight.bold));
+    });
+
+    testWidgets('renders with custom elevation', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppFilterChip(
+              label: 'Test Filter',
+              elevation: 4.0,
+              onSelected: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      final filterChip = tester.widget<FilterChip>(find.byType(FilterChip));
+      expect(filterChip.elevation, equals(4.0));
+    });
+
+    testWidgets('renders with custom shape', (WidgetTester tester) async {
+      const customShape = RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(Radius.circular(8)),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppFilterChip(
+              label: 'Test Filter',
+              shape: customShape,
+              onSelected: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      final filterChip = tester.widget<FilterChip>(find.byType(FilterChip));
+      expect(filterChip.shape, equals(customShape));
+    });
+
+    testWidgets('renders with tooltip', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppFilterChip(
+              label: 'Test Filter',
+              tooltip: 'Filter tooltip',
+              onSelected: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(Tooltip), findsOneWidget);
+
+      final tooltip = tester.widget<Tooltip>(find.byType(Tooltip));
+      expect(tooltip.message, equals('Filter tooltip'));
+    });
+
+    testWidgets('applies disabled opacity when not enabled', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppFilterChip(
+              label: 'Test Filter',
+              enabled: false,
+              onSelected: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      final opacity = tester.widget<Opacity>(find.byType(Opacity));
+      expect(opacity.opacity, equals(0.38));
+    });
+
+    testWidgets('supports keyboard focus', (WidgetTester tester) async {
+      final focusNode = FocusNode();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppFilterChip(
+              label: 'Test Filter',
+              focusNode: focusNode,
+              autofocus: true,
+              onSelected: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+
+      expect(focusNode.hasFocus, isTrue);
+    });
+
+    testWidgets('works in filter group', (WidgetTester tester) async {
+      final selectedFilters = <String>{};
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StatefulBuilder(
+              builder: (context, setState) {
+                return Wrap(
+                  spacing: 8,
+                  children: [
+                    AppFilterChip(
+                      label: 'Electronics',
+                      selected: selectedFilters.contains('electronics'),
+                      onSelected: (selected) {
+                        setState(() {
+                          if (selected) {
+                            selectedFilters.add('electronics');
+                          } else {
+                            selectedFilters.remove('electronics');
+                          }
+                        });
+                      },
+                    ),
+                    AppFilterChip(
+                      label: 'Clothing',
+                      selected: selectedFilters.contains('clothing'),
+                      onSelected: (selected) {
+                        setState(() {
+                          if (selected) {
+                            selectedFilters.add('clothing');
+                          } else {
+                            selectedFilters.remove('clothing');
+                          }
+                        });
+                      },
+                    ),
+                  ],
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      // Initially no filters selected
+      expect(selectedFilters, isEmpty);
+
+      // Tap first chip
+      await tester.tap(find.text('Electronics'));
+      await tester.pumpAndSettle();
+
+      expect(selectedFilters, contains('electronics'));
+      expect(selectedFilters, isNot(contains('clothing')));
+
+      // Tap second chip
+      await tester.tap(find.text('Clothing'));
+      await tester.pumpAndSettle();
+
+      expect(selectedFilters, contains('electronics'));
+      expect(selectedFilters, contains('clothing'));
+
+      // Untap first chip
+      await tester.tap(find.text('Electronics'));
+      await tester.pumpAndSettle();
+
+      expect(selectedFilters, isNot(contains('electronics')));
+      expect(selectedFilters, contains('clothing'));
+    });
+  });
+}

--- a/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
+++ b/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
@@ -11,6 +11,8 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:widgetbook/widgetbook.dart' as _widgetbook;
+import 'package:widgetbook_kit/stories/analytics_kit/analytics/screen_tracking_mixin_stories.dart'
+    as _widgetbook_kit_stories_analytics_kit_analytics_screen_tracking_mixin_stories;
 import 'package:widgetbook_kit/stories/core_kit/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_buttons_app_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_button_stories.dart'
@@ -23,6 +25,8 @@ import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_outlined_but
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_text_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/chips/app_filter_chip_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_chips_app_filter_chip_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_checkbox_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_dropdown_stories.dart'
@@ -33,6 +37,8 @@ import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_radio_group_s
     as _widgetbook_kit_stories_core_kit_widgets_inputs_app_radio_group_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_search_field_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_slider_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_slider_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_switch_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_text_field_stories.dart'
@@ -45,6 +51,65 @@ import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_section_hea
     as _widgetbook_kit_stories_core_kit_widgets_surfaces_app_section_header_stories;
 
 final directories = <_widgetbook.WidgetbookNode>[
+  _widgetbook.WidgetbookFolder(
+    name: 'stories',
+    children: [
+      _widgetbook.WidgetbookFolder(
+        name: 'analytics_kit',
+        children: [
+          _widgetbook.WidgetbookFolder(
+            name: 'analytics',
+            children: [
+              _widgetbook.WidgetbookComponent(
+                name: 'BasicTrackingScreen',
+                useCases: [
+                  _widgetbook.WidgetbookUseCase(
+                    name: 'Basic Usage',
+                    builder:
+                        _widgetbook_kit_stories_analytics_kit_analytics_screen_tracking_mixin_stories
+                            .basicUsageUseCase,
+                  ),
+                ],
+              ),
+              _widgetbook.WidgetbookComponent(
+                name: 'CustomNameScreen',
+                useCases: [
+                  _widgetbook.WidgetbookUseCase(
+                    name: 'Custom Screen Name',
+                    builder:
+                        _widgetbook_kit_stories_analytics_kit_analytics_screen_tracking_mixin_stories
+                            .customNameUseCase,
+                  ),
+                ],
+              ),
+              _widgetbook.WidgetbookComponent(
+                name: 'NavigationDemoScreen',
+                useCases: [
+                  _widgetbook.WidgetbookUseCase(
+                    name: 'Navigation Demo',
+                    builder:
+                        _widgetbook_kit_stories_analytics_kit_analytics_screen_tracking_mixin_stories
+                            .navigationDemoUseCase,
+                  ),
+                ],
+              ),
+              _widgetbook.WidgetbookComponent(
+                name: 'ParametersTrackingScreen',
+                useCases: [
+                  _widgetbook.WidgetbookUseCase(
+                    name: 'With Parameters',
+                    builder:
+                        _widgetbook_kit_stories_analytics_kit_analytics_screen_tracking_mixin_stories
+                            .parametersUseCase,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
+  ),
   _widgetbook.WidgetbookFolder(
     name: 'widgets',
     children: [
@@ -451,6 +516,70 @@ final directories = <_widgetbook.WidgetbookNode>[
         ],
       ),
       _widgetbook.WidgetbookFolder(
+        name: 'chips',
+        children: [
+          _widgetbook.WidgetbookComponent(
+            name: 'AppFilterChip',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Basic Unselected',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_chips_app_filter_chip_stories
+                        .basicFilterChip,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Custom Colors',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_chips_app_filter_chip_stories
+                        .filterChipCustomColors,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Disabled State',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_chips_app_filter_chip_stories
+                        .disabledFilterChip,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Filter Group Demo',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_chips_app_filter_chip_stories
+                        .filterChipGroup,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Interactive Playground',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_chips_app_filter_chip_stories
+                        .filterChipPlayground,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Selected State',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_chips_app_filter_chip_stories
+                        .selectedFilterChip,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Avatar',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_chips_app_filter_chip_stories
+                        .filterChipWithAvatar,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Icon',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_chips_app_filter_chip_stories
+                        .filterChipWithIcon,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Tooltip',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_chips_app_filter_chip_stories
+                        .withTooltipChip,
+              ),
+            ],
+          ),
+        ],
+      ),
+      _widgetbook.WidgetbookFolder(
         name: 'inputs',
         children: [
           _widgetbook.WidgetbookComponent(
@@ -751,6 +880,59 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
                         .searchFieldWithResults,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'AppSlider',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Basic Continuous',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_slider_stories
+                        .appSliderBasicContinuous,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Custom Formatter',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_slider_stories
+                        .appSliderCustomFormatter,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Disabled State',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_slider_stories
+                        .appSliderDisabled,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Discrete with Divisions',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_slider_stories
+                        .appSliderDiscrete,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Range Slider',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_slider_stories
+                        .appSliderRange,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Real-World Examples',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_slider_stories
+                        .appSliderRealWorld,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Min/Max Indicators',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_slider_stories
+                        .appSliderMinMaxIndicators,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Value Labels',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_slider_stories
+                        .appSliderValueLabels,
               ),
             ],
           ),

--- a/widgetbook_kit/lib/stories/core_kit/widgets/chips/app_filter_chip_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/chips/app_filter_chip_stories.dart
@@ -1,2 +1,659 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+// ignore_for_file: deprecated_member_use
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/widgets/chips/app_filter_chip.dart';
+
+// 1. Basic Filter Chip - Unselected State
+@widgetbook.UseCase(name: 'Basic Unselected', type: AppFilterChip)
+Widget basicFilterChip(BuildContext context) {
+  final label = context.knobs.string(label: 'Label', initialValue: 'Shoes');
+
+  return Center(
+    child: AppFilterChip(
+      label: label,
+      selected: false,
+      onSelected: (selected) {
+        debugPrint('Filter chip selected: $selected');
+      },
+    ),
+  );
+}
+
+// 2. Selected Filter Chip with Checkmark
+@widgetbook.UseCase(name: 'Selected State', type: AppFilterChip)
+Widget selectedFilterChip(BuildContext context) {
+  final label = context.knobs.string(
+    label: 'Label',
+    initialValue: 'Electronics',
+  );
+
+  return Center(
+    child: AppFilterChip(
+      label: label,
+      selected: true,
+      onSelected: (selected) {
+        debugPrint('Filter chip selected: $selected');
+      },
+    ),
+  );
+}
+
+// 3. Filter Chip with Custom Icon
+@widgetbook.UseCase(name: 'With Icon', type: AppFilterChip)
+Widget filterChipWithIcon(BuildContext context) {
+  final label = context.knobs.string(
+    label: 'Label',
+    initialValue: 'New Arrivals',
+  );
+
+  final selected = context.knobs.boolean(
+    label: 'Selected',
+    initialValue: false,
+  );
+
+  final iconType = context.knobs.list(
+    label: 'Icon',
+    options: ['fiber_new', 'local_offer', 'star', 'favorite', 'category'],
+    labelBuilder: (option) => option,
+  );
+
+  IconData getIcon(String name) {
+    switch (name) {
+      case 'fiber_new':
+        return Icons.fiber_new;
+      case 'local_offer':
+        return Icons.local_offer;
+      case 'star':
+        return Icons.star;
+      case 'favorite':
+        return Icons.favorite;
+      case 'category':
+        return Icons.category;
+      default:
+        return Icons.filter_alt;
+    }
+  }
+
+  return Center(
+    child: AppFilterChip(
+      label: label,
+      icon: getIcon(iconType),
+      selected: selected,
+      onSelected: (value) {
+        debugPrint('Filter chip selected: $value');
+      },
+    ),
+  );
+}
+
+// 4. Disabled Filter Chip
+@widgetbook.UseCase(name: 'Disabled State', type: AppFilterChip)
+Widget disabledFilterChip(BuildContext context) {
+  final label = context.knobs.string(label: 'Label', initialValue: 'Disabled');
+
+  final selected = context.knobs.boolean(
+    label: 'Selected (Visual Only)',
+    initialValue: false,
+  );
+
+  return Center(
+    child: AppFilterChip(
+      label: label,
+      selected: selected,
+      enabled: false,
+      onSelected: (value) {
+        debugPrint('This should not print');
+      },
+    ),
+  );
+}
+
+// 5. Filter Chip Group - Interactive multi-selection demo
+@widgetbook.UseCase(name: 'Filter Group Demo', type: AppFilterChip)
+Widget filterChipGroup(BuildContext context) {
+  return const _FilterGroupDemo();
+}
+
+class _FilterGroupDemo extends StatefulWidget {
+  const _FilterGroupDemo();
+
+  @override
+  State<_FilterGroupDemo> createState() => _FilterGroupDemoState();
+}
+
+class _FilterGroupDemoState extends State<_FilterGroupDemo> {
+  final Set<String> _selectedFilters = {};
+
+  @override
+  Widget build(BuildContext context) {
+    final categories = {
+      'electronics': 'Electronics',
+      'clothing': 'Clothing',
+      'books': 'Books',
+      'home': 'Home & Garden',
+      'sports': 'Sports',
+    };
+
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Product Categories',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Multi-selection enabled - tap to toggle',
+            style: TextStyle(fontSize: 12, fontStyle: FontStyle.italic),
+          ),
+          const SizedBox(height: 16),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: categories.entries.map((entry) {
+              return AppFilterChip(
+                label: entry.value,
+                selected: _selectedFilters.contains(entry.key),
+                onSelected: (selected) {
+                  setState(() {
+                    if (selected) {
+                      _selectedFilters.add(entry.key);
+                    } else {
+                      _selectedFilters.remove(entry.key);
+                    }
+                  });
+                },
+              );
+            }).toList(),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'Selected: ${_selectedFilters.isEmpty ? 'None' : _selectedFilters.map((key) => categories[key]).join(', ')}',
+            style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 12),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// 6. Filter Chip with Avatar - Single component showing avatar behavior
+@widgetbook.UseCase(name: 'With Avatar', type: AppFilterChip)
+Widget filterChipWithAvatar(BuildContext context) {
+  final label = context.knobs.string(label: 'Label', initialValue: 'John Doe');
+
+  final selected = context.knobs.boolean(
+    label: 'Selected',
+    initialValue: false,
+  );
+
+  final avatarText = context.knobs.string(
+    label: 'Avatar Text',
+    initialValue: 'JD',
+  );
+
+  final avatarColorOption = context.knobs.list(
+    label: 'Avatar Color',
+    options: ['Blue', 'Purple', 'Green', 'Orange', 'Pink'],
+    labelBuilder: (option) => option,
+  );
+
+  Color getAvatarColor(String color) {
+    switch (color) {
+      case 'Blue':
+        return Colors.blue.shade100;
+      case 'Purple':
+        return Colors.purple.shade100;
+      case 'Green':
+        return Colors.green.shade100;
+      case 'Orange':
+        return Colors.orange.shade100;
+      case 'Pink':
+        return Colors.pink.shade100;
+      default:
+        return Colors.blue.shade100;
+    }
+  }
+
+  Color getAvatarTextColor(String color) {
+    switch (color) {
+      case 'Blue':
+        return Colors.blue.shade900;
+      case 'Purple':
+        return Colors.purple.shade900;
+      case 'Green':
+        return Colors.green.shade900;
+      case 'Orange':
+        return Colors.orange.shade900;
+      case 'Pink':
+        return Colors.pink.shade900;
+      default:
+        return Colors.blue.shade900;
+    }
+  }
+
+  return Center(
+    child: AppFilterChip(
+      label: label,
+      avatar: CircleAvatar(
+        backgroundColor: getAvatarColor(avatarColorOption),
+        radius: 12,
+        child: Text(
+          avatarText,
+          style: TextStyle(
+            color: getAvatarTextColor(avatarColorOption),
+            fontSize: 10,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+      selected: selected,
+      onSelected: (value) {
+        debugPrint('Filter chip selected: $value');
+      },
+    ),
+  );
+}
+
+// 6. Filter Chip with Custom Colors - Single component
+@widgetbook.UseCase(name: 'Custom Colors', type: AppFilterChip)
+Widget filterChipCustomColors(BuildContext context) {
+  final label = context.knobs.string(
+    label: 'Label',
+    initialValue: 'Custom Theme',
+  );
+
+  final selected = context.knobs.boolean(label: 'Selected', initialValue: true);
+
+  final colorScheme = context.knobs.list(
+    label: 'Color Scheme',
+    options: ['Purple', 'Green', 'Orange', 'Blue', 'Pink', 'Teal'],
+    labelBuilder: (option) => option,
+  );
+
+  Color getSelectedColor(String scheme) {
+    switch (scheme) {
+      case 'Purple':
+        return Colors.purple.shade100;
+      case 'Green':
+        return Colors.green.shade100;
+      case 'Orange':
+        return Colors.orange.shade100;
+      case 'Blue':
+        return Colors.blue.shade100;
+      case 'Pink':
+        return Colors.pink.shade100;
+      case 'Teal':
+        return Colors.teal.shade100;
+      default:
+        return Colors.purple.shade100;
+    }
+  }
+
+  Color getCheckmarkColor(String scheme) {
+    switch (scheme) {
+      case 'Purple':
+        return Colors.purple.shade900;
+      case 'Green':
+        return Colors.green.shade900;
+      case 'Orange':
+        return Colors.orange.shade900;
+      case 'Blue':
+        return Colors.blue.shade900;
+      case 'Pink':
+        return Colors.pink.shade900;
+      case 'Teal':
+        return Colors.teal.shade900;
+      default:
+        return Colors.purple.shade900;
+    }
+  }
+
+  return Center(
+    child: AppFilterChip(
+      label: label,
+      selected: selected,
+      selectedColor: getSelectedColor(colorScheme),
+      checkmarkColor: getCheckmarkColor(colorScheme),
+      onSelected: (value) {
+        debugPrint('Filter chip selected: $value');
+      },
+    ),
+  );
+}
+
+// 7. Filter Chip with Tooltip - Single component
+@widgetbook.UseCase(name: 'With Tooltip', type: AppFilterChip)
+Widget withTooltipChip(BuildContext context) {
+  final label = context.knobs.string(label: 'Label', initialValue: 'Hover Me');
+
+  final tooltipText = context.knobs.string(
+    label: 'Tooltip Text',
+    initialValue: 'Tap to filter by this category',
+  );
+
+  final selected = context.knobs.boolean(
+    label: 'Selected',
+    initialValue: false,
+  );
+
+  return Center(
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const Text(
+          'Long-press or hover to see tooltip',
+          style: TextStyle(fontSize: 12, fontStyle: FontStyle.italic),
+        ),
+        const SizedBox(height: 16),
+        AppFilterChip(
+          label: label,
+          tooltip: tooltipText,
+          selected: selected,
+          onSelected: (value) {
+            debugPrint('Filter chip selected: $value');
+          },
+        ),
+      ],
+    ),
+  );
+}
+
+// 8. Interactive Playground - Full Customization with Knobs
+@widgetbook.UseCase(name: 'Interactive Playground', type: AppFilterChip)
+Widget filterChipPlayground(BuildContext context) {
+  // ========== Text Content ==========
+  final label = context.knobs.string(
+    label: 'Label Text',
+    initialValue: 'Filter Chip',
+  );
+
+  final showTooltip = context.knobs.boolean(
+    label: 'Show Tooltip',
+    initialValue: false,
+  );
+
+  final tooltipText = context.knobs.string(
+    label: 'Tooltip Text',
+    initialValue: 'Tap to filter by this category',
+  );
+
+  // ========== State Management ==========
+  final selected = context.knobs.boolean(
+    label: 'Selected State',
+    initialValue: false,
+  );
+
+  final enabled = context.knobs.boolean(label: 'Enabled', initialValue: true);
+
+  // ========== Leading Widget Options ==========
+  final leadingType = context.knobs.list(
+    label: 'Leading Widget',
+    options: ['None', 'Icon', 'Avatar'],
+    labelBuilder: (option) => option,
+  );
+
+  final iconType = context.knobs.list(
+    label: 'Icon Type',
+    options: [
+      'fiber_new',
+      'local_offer',
+      'star',
+      'favorite',
+      'category',
+      'label',
+      'sell',
+      'shopping_bag',
+    ],
+    labelBuilder: (option) => option,
+  );
+
+  final avatarText = context.knobs.string(
+    label: 'Avatar Text',
+    initialValue: 'AB',
+  );
+
+  // ========== Color Customization ==========
+  final useCustomColors = context.knobs.boolean(
+    label: 'Custom Colors',
+    initialValue: false,
+  );
+
+  final selectedColorOption = context.knobs.list(
+    label: 'Selected BG',
+    options: ['Default', 'Purple', 'Green', 'Orange', 'Blue', 'Pink', 'Teal'],
+    labelBuilder: (option) => option,
+  );
+
+  final checkmarkColorOption = context.knobs.list(
+    label: 'Checkmark',
+    options: [
+      'Default',
+      'Purple',
+      'Green',
+      'Orange',
+      'Blue',
+      'Pink',
+      'Teal',
+      'White',
+      'Black',
+    ],
+    labelBuilder: (option) => option,
+  );
+
+  // ========== Advanced Styling ==========
+  final elevation = context.knobs.double.slider(
+    label: 'Elevation',
+    initialValue: 0.0,
+    min: 0.0,
+    max: 8.0,
+  );
+
+  final pressElevation = context.knobs.double.slider(
+    label: 'Press Elevation',
+    initialValue: 0.0,
+    min: 0.0,
+    max: 8.0,
+  );
+
+  final horizontalPadding = context.knobs.double.slider(
+    label: 'H-Padding',
+    initialValue: 16.0,
+    min: 4.0,
+    max: 32.0,
+  );
+
+  final verticalPadding = context.knobs.double.slider(
+    label: 'V-Padding',
+    initialValue: 0.0,
+    min: 0.0,
+    max: 16.0,
+  );
+
+  final fontSize = context.knobs.double.slider(
+    label: 'Font Size',
+    initialValue: 14.0,
+    min: 10.0,
+    max: 20.0,
+  );
+
+  final fontWeightOption = context.knobs.list(
+    label: 'Font Weight',
+    options: ['Normal', 'Medium', 'Semibold', 'Bold'],
+    labelBuilder: (option) => option,
+  );
+
+  FontWeight getFontWeight(String option) {
+    switch (option) {
+      case 'Medium':
+        return FontWeight.w500;
+      case 'Semibold':
+        return FontWeight.w600;
+      case 'Bold':
+        return FontWeight.bold;
+      default:
+        return FontWeight.normal;
+    }
+  }
+
+  final borderRadius = context.knobs.double.slider(
+    label: 'Border Radius',
+    initialValue: 16.0,
+    min: 0.0,
+    max: 32.0,
+  );
+
+  final visualDensityOption = context.knobs.list(
+    label: 'Visual Density',
+    options: ['Standard', 'Comfortable', 'Compact', 'Adaptive'],
+    labelBuilder: (option) => option,
+  );
+
+  VisualDensity getVisualDensity(String option) {
+    switch (option) {
+      case 'Comfortable':
+        return VisualDensity.comfortable;
+      case 'Compact':
+        return VisualDensity.compact;
+      case 'Adaptive':
+        return VisualDensity.adaptivePlatformDensity;
+      default:
+        return VisualDensity.standard;
+    }
+  }
+
+  // ========== Build Leading Widget ==========
+  IconData? icon;
+  Widget? avatar;
+
+  if (leadingType == 'Icon') {
+    icon = _getIconData(iconType);
+  } else if (leadingType == 'Avatar') {
+    avatar = CircleAvatar(
+      backgroundColor: _getAvatarColor(avatarText),
+      radius: 12,
+      child: Text(
+        avatarText.isNotEmpty ? avatarText.substring(0, 2).toUpperCase() : 'AB',
+        style: const TextStyle(
+          fontSize: 10,
+          fontWeight: FontWeight.bold,
+          color: Colors.white,
+        ),
+      ),
+    );
+  }
+
+  // ========== Build Color Values ==========
+  Color? selectedColor;
+  Color? checkmarkColor;
+
+  if (useCustomColors && selectedColorOption != 'Default') {
+    selectedColor = _getColorFromOption(selectedColorOption, isLight: true);
+  }
+
+  if (useCustomColors && checkmarkColorOption != 'Default') {
+    checkmarkColor = _getColorFromOption(checkmarkColorOption, isLight: false);
+  }
+
+  return Center(
+    child: AppFilterChip(
+      label: label,
+      selected: selected,
+      enabled: enabled,
+      icon: icon,
+      avatar: avatar,
+      selectedColor: selectedColor,
+      checkmarkColor: checkmarkColor,
+      padding: EdgeInsets.symmetric(
+        horizontal: horizontalPadding,
+        vertical: verticalPadding,
+      ),
+      elevation: elevation,
+      pressElevation: pressElevation,
+      visualDensity: getVisualDensity(visualDensityOption),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(borderRadius),
+      ),
+      tooltip: showTooltip ? tooltipText : null,
+      labelStyle: TextStyle(
+        fontSize: fontSize,
+        fontWeight: getFontWeight(fontWeightOption),
+      ),
+      onSelected: enabled
+          ? (value) {
+              debugPrint('Filter chip selected: $value');
+            }
+          : null,
+    ),
+  );
+}
+
+// Helper function to get IconData from string
+IconData _getIconData(String iconName) {
+  switch (iconName) {
+    case 'fiber_new':
+      return Icons.fiber_new;
+    case 'local_offer':
+      return Icons.local_offer;
+    case 'star':
+      return Icons.star;
+    case 'favorite':
+      return Icons.favorite;
+    case 'category':
+      return Icons.category;
+    case 'label':
+      return Icons.label;
+    case 'sell':
+      return Icons.sell;
+    case 'shopping_bag':
+      return Icons.shopping_bag;
+    default:
+      return Icons.filter_alt;
+  }
+}
+
+// Helper function to get avatar color based on text
+Color _getAvatarColor(String text) {
+  final colors = [
+    Colors.blue,
+    Colors.purple,
+    Colors.green,
+    Colors.orange,
+    Colors.pink,
+    Colors.teal,
+  ];
+  final index = text.isNotEmpty ? text.codeUnitAt(0) % colors.length : 0;
+  return colors[index];
+}
+
+// Helper function to get color from option
+Color? _getColorFromOption(String option, {required bool isLight}) {
+  switch (option) {
+    case 'Purple':
+      return isLight ? Colors.purple.shade100 : Colors.purple.shade900;
+    case 'Green':
+      return isLight ? Colors.green.shade100 : Colors.green.shade900;
+    case 'Orange':
+      return isLight ? Colors.orange.shade100 : Colors.orange.shade900;
+    case 'Blue':
+      return isLight ? Colors.blue.shade100 : Colors.blue.shade900;
+    case 'Pink':
+      return isLight ? Colors.pink.shade100 : Colors.pink.shade900;
+    case 'Teal':
+      return isLight ? Colors.teal.shade100 : Colors.teal.shade900;
+    case 'White':
+      return Colors.white;
+    case 'Black':
+      return Colors.black;
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
# Pull Request

## 📄 Summary


This pull request introduces a new reusable Material Design 3 filter chip widget (`AppFilterChip`) to the core UI kit and adds comprehensive Widgetbook stories for both the new chip and the existing slider component. These changes enhance the design system by providing a customizable, accessible filter chip and improving component documentation and testing coverage through Widgetbook.

**Core Kit Enhancements**
- Added a new `AppFilterChip` widget, implementing a Material Design 3 filter chip with support for selection, custom icons, avatars, disabled state, theming, and accessibility features. The widget includes extensive documentation and usage examples.
- Exported `AppFilterChip` from `core_kit.dart` for public use in the design system.

**Widgetbook Integration**
- Registered Widgetbook stories for `AppFilterChip`, demonstrating all key states and customization options (basic, selected, disabled, with avatar, with icon, custom colors, tooltips, filter group, and playground). [[1]](diffhunk://#diff-c0bcce5523f19a884f9e01d6ef361f44d02d024e03a463bee7c14636e341cc7aR28-R29) [[2]](diffhunk://#diff-c0bcce5523f19a884f9e01d6ef361f44d02d024e03a463bee7c14636e341cc7aR518-R581)

Closes #130 

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Packages (packages/*)
- [x] Widgetbook Kit (widgetbook_kit/)
- [ ] Documentation (docs/)
- [ ] CI / Infra (.github/)

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: <type>/<short-description> (e.g., feat/login-screen)
- [x] My PR title starts with one of the approved types listed above
- [x] My Dart code is formatted (dart format . or flutter format .)
- [x] I ran static analysis (flutter analyze) and resolved warnings
- [x] I ran tests successfully (flutter test)
- [x] I updated / checked pubspec.yaml and pubspec.lock for dependency changes
- [x] For UI changes, I added screenshots and/or updated golden tests (if applicable)
- [x] I linked related issues using keywords like Closes #130 
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

```text
Closes #130 
```

---

## 💬 Additional Notes (Optional)

- Checkmark manually implemented as avatar for consistent visibility
- Interactive Playground with 15+ customization knobs
- Single-focus story approach for better testing experience
- All Material Design 3 specifications verified and implemented
- Widgetbook deprecated list knob warning suppressed (functional)
