### PR TITLE
feat(core-kit): add AppErrorState component with Material Design 3 error handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,12 @@ jobs:
           channel: 'stable'
           cache: true
 
+      - name: Install Melos
+        run: dart pub global activate melos
+
+      - name: Bootstrap packages
+        run: melos bootstrap
+
       - name: Check Dart formatting
         run: dart format --set-exit-if-changed .
 
@@ -78,12 +84,6 @@ jobs:
           flutter-version: '3.x'
           channel: 'stable'
           cache: true
-
-      - name: Install Melos
-        run: dart pub global activate melos
-
-      - name: Bootstrap packages
-        run: melos bootstrap
 
       - name: Run tests
         run: melos run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,6 @@ jobs:
           channel: 'stable'
           cache: true
 
-      - name: Install Melos
-        run: dart pub global activate melos
-
-      - name: Bootstrap packages
-        run: melos bootstrap
-
       - name: Run Flutter analyze
         run: melos run analyze
 

--- a/.github/workflows/widgetbook-deploy.yml
+++ b/.github/workflows/widgetbook-deploy.yml
@@ -4,15 +4,13 @@
 name: 📚 Deploy Widgetbook to GitHub Pages
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - develop
     paths:
       - 'widgetbook_kit/**'
-      - 'packages/**'
+      - 'packages/**'      
       - '.github/workflows/widgetbook-deploy.yml'
-  workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -29,7 +27,7 @@ concurrency:
 jobs:
   # Build job
   build:
-    name: Build Widgetbook
+    name: Build Widgetbook (hexaMobileShare)
     runs-on: ubuntu-latest
     # Only run on merged PRs or manual workflow dispatch
     if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true)
@@ -37,6 +35,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: develop
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -65,7 +65,7 @@ jobs:
 
   # Deployment job
   deploy:
-    name: Deploy to GitHub Pages
+    name: Deploy to GitHub Pages (hexaMobileShare)
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/widgetbook-deploy.yml
+++ b/.github/workflows/widgetbook-deploy.yml
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 
 name: 📚 Deploy Widgetbook to GitHub Pages
-
 on:
   push:
     branches:
@@ -11,58 +10,45 @@ on:
       - 'widgetbook_kit/**'
       - 'packages/**'      
       - '.github/workflows/widgetbook-deploy.yml'
-
+  workflow_dispatch:
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
-
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
-
 jobs:
   # Build job
   build:
     name: Build Widgetbook (hexaMobileShare)
     runs-on: ubuntu-latest
-    # Only run on merged PRs or manual workflow dispatch
-    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true)
     timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: develop
-
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.x'
           channel: 'stable'
           cache: true
-
       - name: Install Melos
         run: dart pub global activate melos
-
       - name: Bootstrap packages
         run: melos bootstrap
-
       - name: Build Widgetbook for web
         working-directory: widgetbook_kit
         run: flutter build web --release --base-href "/hexaMobileShare/"
-
       - name: Setup Pages
         uses: actions/configure-pages@v5
-
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: widgetbook_kit/build/web
-
   # Deployment job
   deploy:
     name: Deploy to GitHub Pages (hexaMobileShare)
@@ -75,7 +61,6 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-
       - name: Deployment summary
         run: |
           echo "### 🎉 Widgetbook Deployment Successful!" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/widgetbook-deploy.yml
+++ b/.github/workflows/widgetbook-deploy.yml
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2025 hexaTune LLC
+# SPDX-License-Identifier: MIT
+
+name: 📚 Deploy Widgetbook to GitHub Pages
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - develop
+    paths:
+      - 'widgetbook_kit/**'
+      - 'packages/**'
+      - '.github/workflows/widgetbook-deploy.yml'
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    name: Build Widgetbook
+    runs-on: ubuntu-latest
+    # Only run on merged PRs or manual workflow dispatch
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true)
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.x'
+          channel: 'stable'
+          cache: true
+
+      - name: Install Melos
+        run: dart pub global activate melos
+
+      - name: Bootstrap packages
+        run: melos bootstrap
+
+      - name: Build Widgetbook for web
+        working-directory: widgetbook_kit
+        run: flutter build web --release --base-href "/hexaMobileShare/"
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: widgetbook_kit/build/web
+
+  # Deployment job
+  deploy:
+    name: Deploy to GitHub Pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+      - name: Deployment summary
+        run: |
+          echo "### 🎉 Widgetbook Deployment Successful!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Live Preview:** https://story.mobile.dev.hexatune.com" >> $GITHUB_STEP_SUMMARY
+          echo "**GitHub Pages URL:** ${{ steps.deployment.outputs.page_url }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The Widgetbook catalog is now available with 218+ interactive component stories." >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ SPDX-License-Identifier: MIT
 [![Flutter](https://img.shields.io/badge/Flutter-3.x-02569B?logo=flutter)](https://flutter.dev)
 [![Dart](https://img.shields.io/badge/Dart-3.x-0175C2?logo=dart)](https://dart.dev)
 
-[**Documentation**](docs/SUMMARY.md) • [**Getting Started**](docs/GETTING_STARTED.md) • [**Contributing**](docs/CONTRIBUTING.md) • [**Widgetbook**](widgetbook_kit/)
+[**Documentation**](docs/SUMMARY.md) • [**Getting Started**](docs/GETTING_STARTED.md) • [**Contributing**](docs/CONTRIBUTING.md) • [**Widgetbook**](https://story.mobile.dev.hexatune.com)
 
 </div>
 
@@ -29,7 +29,7 @@ SPDX-License-Identifier: MIT
 
 - 📦 **11 Modular Kits** – Analytics, Auth, Core UI, Data, Forms, Localization, Media, Monetization, Navigation, Notifications, Storage
 - 🎨 **Material Design 3** – Beautiful, themeable widgets following Material Design 3 guidelines
-- 📖 **Widgetbook Integration** – Interactive component catalog with 218 story files (1-to-1 mapping)
+- 📖 **Widgetbook Integration** – Interactive component catalog with 218 story files ([Live Preview](https://story.mobile.dev.hexatune.com))
 - 🔐 **Type-Safe** – Leveraging Dart's strong type system
 - ♿ **Accessibility-First** – Built with screen readers and inclusive design in mind
 - 🚀 **Production-Ready** – Tested, documented, and optimized for performance
@@ -63,7 +63,7 @@ The monorepo contains 11 specialized kits organized for maximum modularity:
 
 | Tool | Description |
 |------|-------------|
-| **[widgetbook_kit](widgetbook_kit/)** | Interactive component catalog with 218 stories for rapid UI development and documentation |
+| **[widgetbook_kit](widgetbook_kit/)** | Interactive component catalog with 218 stories ([Live Preview](https://story.mobile.dev.hexatune.com)) |
 
 ---
 
@@ -102,6 +102,8 @@ The monorepo contains 11 specialized kits organized for maximum modularity:
    pnpm storybook
    ```
    Opens at [http://localhost:8080](http://localhost:8080)
+   
+   **Live Preview:** [https://story.mobile.dev.hexatune.com](https://story.mobile.dev.hexatune.com)
 
 ### Installation (As a Dependency)
 
@@ -281,6 +283,7 @@ Comprehensive documentation is available in the [`docs/`](docs/) directory:
 - [**Architecture**](docs/ARCHITECTURE.md) – System design, widget architecture, technology stack
 - [**Project Structure**](docs/PROJECT_STRUCTURE.md) – Directory organization, file layout
 - [**Configuration**](docs/CONFIGURATION.md) – Configuration files and settings
+- [**Widgetbook Deployment**](docs/WIDGETBOOK_DEPLOYMENT.md) – GitHub Pages deployment guide
 
 ### Development
 - [**Development Guide**](docs/DEVELOPMENT_GUIDE.md) – Workflow, best practices, tooling
@@ -359,7 +362,7 @@ cd packages/auth_kit && flutter test
 
 - ✅ **REUSE Compliant** – All 912 files have proper SPDX licensing
 - ✅ **CI/CD Pipeline** – Automated testing, formatting, analysis, and builds
-- ✅ **Widgetbook Integration** – 218 interactive component stories
+- ✅ **Widgetbook Integration** – 218 interactive component stories ([Live Preview](https://story.mobile.dev.hexatune.com))
 - ✅ **Comprehensive Documentation** – 20+ documentation files
 - 🚧 **Active Development** – New kits and features in progress
 

--- a/docs/WIDGETBOOK_DEPLOYMENT.md
+++ b/docs/WIDGETBOOK_DEPLOYMENT.md
@@ -1,0 +1,386 @@
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
+
+# Widgetbook Deployment Guide
+
+This document explains how the hexaMobileShare Widgetbook is automatically deployed to GitHub Pages, providing a live preview of all 218+ component stories.
+
+---
+
+## 📌 Table of Contents
+
+- [Overview](#overview)
+- [Live Preview URL](#live-preview-url)
+- [Deployment Workflow](#deployment-workflow)
+- [Custom Domain Configuration](#custom-domain-configuration)
+- [Manual Deployment](#manual-deployment)
+- [Troubleshooting](#troubleshooting)
+- [CI/CD Pipeline Details](#cicd-pipeline-details)
+
+---
+
+## Overview
+
+The **Widgetbook** is our interactive component catalog built with the `widgetbook_kit` package. It contains 218+ story files showcasing all widgets, utilities, and services from the 11 modular kits in hexaMobileShare.
+
+**Key Features:**
+- 🎨 Visual component library
+- 🔍 Interactive props/knobs for testing widgets
+- 📱 Responsive preview modes (mobile, tablet, desktop)
+- 🌙 Dark/light mode support
+- ♿ Accessibility testing
+- 📖 Documentation alongside components
+
+---
+
+## Live Preview URL
+
+The Widgetbook is automatically deployed to:
+
+**🔗 https://story.mobile.dev.hexatune.com**
+
+This URL is updated automatically when PRs are merged to the `develop` branch.
+
+---
+
+## Deployment Workflow
+
+### Automatic Deployment
+
+The Widgetbook is deployed automatically using GitHub Actions. The workflow is triggered when:
+
+1. **A Pull Request is merged to `develop`** (if it modifies Widgetbook or package files)
+2. **Manual workflow dispatch** (via GitHub Actions UI)
+
+### Deployment Trigger Conditions
+
+The workflow runs when:
+- PRs are **merged** (not just opened or closed without merging) into `develop`
+- Changes are made to:
+  - `widgetbook_kit/**` (Widgetbook app code)
+  - `packages/**` (Any kit changes that affect stories)
+  - `.github/workflows/widgetbook-deploy.yml` (Workflow configuration)
+
+### Workflow Steps
+
+The deployment process consists of two jobs:
+
+#### 1. **Build Job**
+```yaml
+- Checkout repository
+- Setup Flutter 3.x (stable channel)
+- Install Melos (monorepo tool)
+- Bootstrap all packages
+- Build Widgetbook for web (--release mode)
+- Upload build artifacts to GitHub Pages
+```
+
+#### 2. **Deploy Job**
+```yaml
+- Deploy artifacts to GitHub Pages
+- Output deployment URL
+- Generate deployment summary
+```
+
+---
+
+## Custom Domain Configuration
+
+### GitHub Pages Settings
+
+To configure the custom domain `story.mobile.dev.hexatune.com`:
+
+1. **Repository Settings:**
+   - Navigate to: `Settings > Pages`
+   - **Source:** Deploy from a branch
+   - **Branch:** `gh-pages` (auto-created by workflow)
+   - **Custom domain:** `story.mobile.dev.hexatune.com`
+   - Enable **Enforce HTTPS**
+
+2. **DNS Configuration:**
+   
+   Add the following DNS records at your domain provider (for `hexatune.com`):
+
+   ```
+   Type:  CNAME
+   Name:  story.mobile.dev
+   Value: htuneSys.github.io
+   TTL:   3600 (or default)
+   ```
+
+3. **Verification:**
+   
+   Wait for DNS propagation (5-60 minutes), then verify:
+   ```bash
+   dig story.mobile.dev.hexatune.com +short
+   # Should return: htuneSys.github.io
+   ```
+
+4. **HTTPS Certificate:**
+   
+   GitHub Pages will automatically provision an SSL certificate via Let's Encrypt once DNS is verified.
+
+### Base HREF Configuration
+
+The Widgetbook build uses `--base-href "/hexaMobileShare/"` to ensure assets load correctly:
+
+```bash
+flutter build web --release --base-href "/hexaMobileShare/"
+```
+
+**Note:** If using a custom domain at the root (e.g., `https://story.mobile.dev.hexatune.com`), the base-href should be `/` instead. Update the workflow if needed:
+
+```yaml
+# For root domain deployment
+run: flutter build web --release --base-href "/"
+```
+
+---
+
+## Manual Deployment
+
+### Option 1: Via GitHub Actions UI
+
+1. Go to: `Actions > Deploy Widgetbook to GitHub Pages`
+2. Click **Run workflow**
+3. Select branch: `develop`
+4. Click **Run workflow**
+
+### Option 2: Via Local Build + Manual Upload
+
+```bash
+# 1. Build Widgetbook locally
+cd widgetbook_kit
+flutter build web --release --base-href "/hexaMobileShare/"
+
+# 2. The build output is in: widgetbook_kit/build/web
+# Manually upload this directory to GitHub Pages or hosting provider
+```
+
+### Option 3: Via pnpm Script
+
+```bash
+# Build Widgetbook for deployment
+pnpm build-storybook
+
+# Output: widgetbook_kit/build/web
+```
+
+---
+
+## Troubleshooting
+
+### Issue: Deployment fails with "No such file or directory"
+
+**Cause:** Build artifacts not found in `widgetbook_kit/build/web`
+
+**Solution:**
+1. Check Flutter build logs for errors
+2. Ensure `melos bootstrap` ran successfully
+3. Verify all package dependencies are installed
+4. Run locally to reproduce:
+   ```bash
+   cd widgetbook_kit
+   flutter build web --release
+   ```
+
+### Issue: Assets not loading (404 errors)
+
+**Cause:** Incorrect `--base-href` configuration
+
+**Solution:**
+- For GitHub Pages with repository path: `--base-href "/hexaMobileShare/"`
+- For custom domain at root: `--base-href "/"`
+
+Update `.github/workflows/widgetbook-deploy.yml` accordingly.
+
+### Issue: Custom domain shows 404
+
+**Cause:** DNS not configured or CNAME file missing
+
+**Solution:**
+1. Verify DNS records:
+   ```bash
+   dig story.mobile.dev.hexatune.com +short
+   ```
+2. Check GitHub Pages settings for custom domain
+3. Ensure `CNAME` file exists in `gh-pages` branch (auto-created by workflow)
+
+### Issue: Deployment successful but site not updating
+
+**Cause:** Browser cache or CDN caching old version
+
+**Solution:**
+1. Hard refresh: `Ctrl+Shift+R` (Windows/Linux) or `Cmd+Shift+R` (Mac)
+2. Clear browser cache
+3. Wait 5-10 minutes for GitHub Pages CDN to propagate changes
+4. Check deployment timestamp in GitHub Actions logs
+
+### Issue: Workflow doesn't trigger on merged PR
+
+**Cause:** PR didn't modify watched paths or wasn't properly merged
+
+**Solution:**
+1. Verify PR was **merged** (not just closed)
+2. Check if changes affected:
+   - `widgetbook_kit/**`
+   - `packages/**`
+   - `.github/workflows/widgetbook-deploy.yml`
+3. Manually trigger workflow via Actions UI
+
+---
+
+## CI/CD Pipeline Details
+
+### Workflow File
+
+**Location:** `.github/workflows/widgetbook-deploy.yml`
+
+### Permissions
+
+The workflow requires:
+- `contents: read` – Read repository contents
+- `pages: write` – Deploy to GitHub Pages
+- `id-token: write` – OIDC token for secure deployment
+
+### Concurrency Control
+
+```yaml
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+```
+
+This ensures:
+- Only one deployment runs at a time
+- In-progress deployments complete (not cancelled)
+- Queued deployments wait for current to finish
+
+### Build Configuration
+
+**Flutter Version:** 3.x (stable channel)
+**Build Mode:** `--release` (optimized for production)
+**Target Platform:** Web
+**Cache:** Enabled for faster builds
+
+### Artifact Upload
+
+Build artifacts are uploaded using `actions/upload-pages-artifact@v3`:
+- **Source:** `widgetbook_kit/build/web`
+- **Retention:** 90 days (GitHub default)
+
+### Deployment Environment
+
+```yaml
+environment:
+  name: github-pages
+  url: ${{ steps.deployment.outputs.page_url }}
+```
+
+This creates a deployment record visible in:
+- Repository **Environments** tab
+- PR **Deployments** section
+
+---
+
+## Monitoring Deployments
+
+### Via GitHub Actions
+
+1. Go to: `Actions > Deploy Widgetbook to GitHub Pages`
+2. View recent workflow runs
+3. Check logs for build/deploy details
+
+### Via Deployment Summary
+
+After successful deployment, the workflow outputs a summary:
+
+```
+🎉 Widgetbook Deployment Successful!
+
+Live Preview: https://story.mobile.dev.hexatune.com
+GitHub Pages URL: https://htuneSys.github.io/hexaMobileShare/
+
+The Widgetbook catalog is now available with 218+ interactive component stories.
+```
+
+### Via Repository Environments
+
+1. Go to: `Settings > Environments > github-pages`
+2. View deployment history
+3. Check deployment status and timestamps
+
+---
+
+## Best Practices
+
+### 1. Test Before Merging
+
+Always test Widgetbook changes locally before merging:
+
+```bash
+pnpm storybook
+# Verify all stories render correctly at http://localhost:8080
+```
+
+### 2. Review Build Logs
+
+Check GitHub Actions logs after deployment to ensure:
+- No Flutter build warnings
+- All assets compiled correctly
+- Deployment completed successfully
+
+### 3. Update Stories with Code Changes
+
+When modifying packages, update corresponding Widgetbook stories:
+- Add new story files for new components
+- Update existing stories when widget APIs change
+- Remove deprecated story files
+
+### 4. Monitor Performance
+
+Widgetbook builds can be large. Optimize by:
+- Using `--release` mode (done automatically)
+- Enabling web optimizations in `flutter build web`
+- Monitoring build artifact size
+
+### 5. Keep Dependencies Updated
+
+Regularly update Widgetbook dependencies:
+
+```bash
+cd widgetbook_kit
+flutter pub upgrade
+```
+
+Run tests after updates:
+
+```bash
+flutter test
+```
+
+---
+
+## Related Documentation
+
+- **[Getting Started](GETTING_STARTED.md)** – Project setup guide
+- **[Development Guide](DEVELOPMENT_GUIDE.md)** – Development workflow
+- **[CI Strategy](../AGENTS.md#contribution-workflow)** – CI/CD overview
+- **[Project Structure](PROJECT_STRUCTURE.md)** – Repository organization
+
+---
+
+## Support
+
+For deployment issues or questions:
+
+- **GitHub Issues:** [hTuneSys/hexaMobileShare/issues](https://github.com/hTuneSys/hexaMobileShare/issues)
+- **Discussions:** [GitHub Discussions](https://github.com/hTuneSys/hexaMobileShare/discussions)
+- **Email:** info@hexatune.com
+
+---
+
+**Last Updated:** 2025-12-05  
+**Maintained by:** hexaTune LLC

--- a/packages/analytics_kit/lib/analytics/screen_tracking_mixin.dart
+++ b/packages/analytics_kit/lib/analytics/screen_tracking_mixin.dart
@@ -1,6 +1,242 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class ScreenTrackingMixin {
-  const ScreenTrackingMixin();
+import 'package:flutter/widgets.dart';
+
+/// A mixin for automatically tracking screen views in Flutter applications.
+///
+/// Mix this into your [State] class to enable automatic screen view tracking
+/// when the widget is displayed. The mixin tracks:
+/// - Screen name (from route or manual override)
+/// - Screen parameters
+/// - Time spent on screen
+/// - Screen entry/exit events
+///
+/// ## Usage
+///
+/// ### Basic Usage
+///
+/// ```dart
+/// class MyScreen extends StatefulWidget {
+///   const MyScreen({super.key});
+///
+///   @override
+///   State<MyScreen> createState() => _MyScreenState();
+/// }
+///
+/// class _MyScreenState extends State<MyScreen> with ScreenTrackingMixin {
+///   @override
+///   Widget build(BuildContext context) {
+///     return Scaffold(
+///       appBar: AppBar(title: const Text('My Screen')),
+///       body: const Center(child: Text('Content')),
+///     );
+///   }
+/// }
+/// ```
+///
+/// ### With Custom Screen Name
+///
+/// ```dart
+/// class _MyScreenState extends State<MyScreen> with ScreenTrackingMixin {
+///   @override
+///   String get screenName => 'custom_screen_name';
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return Scaffold(
+///       appBar: AppBar(title: const Text('My Screen')),
+///       body: const Center(child: Text('Content')),
+///     );
+///   }
+/// }
+/// ```
+///
+/// ### With Screen Parameters
+///
+/// ```dart
+/// class ProductDetailScreen extends StatefulWidget {
+///   const ProductDetailScreen({super.key, required this.productId});
+///
+///   final String productId;
+///
+///   @override
+///   State<ProductDetailScreen> createState() => _ProductDetailScreenState();
+/// }
+///
+/// class _ProductDetailScreenState extends State<ProductDetailScreen>
+///     with ScreenTrackingMixin {
+///   @override
+///   String get screenName => 'product_detail';
+///
+///   @override
+///   Map<String, dynamic> get screenParameters => {
+///         'product_id': widget.productId,
+///         'source': 'direct',
+///       };
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return Scaffold(
+///       appBar: AppBar(title: const Text('Product Details')),
+///       body: Center(child: Text('Product: ${widget.productId}')),
+///     );
+///   }
+/// }
+/// ```
+///
+/// ## How It Works
+///
+/// 1. **Automatic Tracking**: Screen views are tracked automatically when the
+///    widget is inserted into the widget tree.
+/// 2. **Screen Name Detection**: By default, the screen name is extracted from
+///    the route name. Override [screenName] for custom names.
+/// 3. **Time Tracking**: The mixin records when the screen was first shown and
+///    calculates time-on-screen when the widget is disposed.
+/// 4. **Parameters**: Additional screen parameters can be tracked by overriding
+///    [screenParameters].
+///
+/// ## Best Practices
+///
+/// - Use snake_case for screen names (e.g., `home_screen`, `product_detail`)
+/// - Keep screen names consistent across platforms
+/// - Include relevant parameters for better analytics insights
+/// - Avoid tracking sensitive user data in parameters
+///
+/// See also:
+/// - [AnalyticsService] for manual event tracking
+/// - [AnalyticsEvent] for custom analytics events
+mixin ScreenTrackingMixin<T extends StatefulWidget> on State<T> {
+  /// The timestamp when the screen was first displayed.
+  DateTime? _screenEntryTime;
+
+  /// The name of the screen to track.
+  ///
+  /// By default, this extracts the route name from [ModalRoute].
+  /// Override this getter to provide a custom screen name.
+  ///
+  /// Example:
+  /// ```dart
+  /// @override
+  /// String get screenName => 'home_screen';
+  /// ```
+  String get screenName {
+    final route = ModalRoute.of(context);
+    if (route != null && route.settings.name != null) {
+      return route.settings.name!;
+    }
+    return runtimeType.toString();
+  }
+
+  /// Additional parameters to track with the screen view.
+  ///
+  /// Override this getter to provide custom parameters that describe
+  /// the current state or context of the screen.
+  ///
+  /// Example:
+  /// ```dart
+  /// @override
+  /// Map<String, dynamic> get screenParameters => {
+  ///   'user_id': currentUserId,
+  ///   'category': selectedCategory,
+  ///   'filter': activeFilter,
+  /// };
+  /// ```
+  Map<String, dynamic> get screenParameters => {};
+
+  /// Whether to enable debug logging for screen tracking.
+  ///
+  /// When true, screen tracking events will be logged to the console.
+  /// Useful for debugging and verifying tracking implementation.
+  bool get enableDebugLogging => false;
+
+  @override
+  void initState() {
+    super.initState();
+    _screenEntryTime = DateTime.now();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    // Track screen view when dependencies change (first time widget is built)
+    if (_screenEntryTime != null) {
+      _trackScreenView();
+    }
+  }
+
+  @override
+  void dispose() {
+    _trackScreenExit();
+    super.dispose();
+  }
+
+  /// Tracks the screen view event.
+  ///
+  /// This is called automatically when the widget is first displayed.
+  /// Can be called manually to re-track the screen view if needed.
+  void _trackScreenView() {
+    final parameters = <String, dynamic>{
+      ...screenParameters,
+      'screen_name': screenName,
+      'timestamp': _screenEntryTime?.toIso8601String(),
+    };
+
+    if (enableDebugLogging) {
+      debugPrint('📊 Screen View: $screenName');
+      debugPrint('   Parameters: $parameters');
+    }
+
+    // TODO: Integrate with actual analytics service
+    // AnalyticsService.instance.logScreenView(
+    //   screenName: screenName,
+    //   parameters: parameters,
+    // );
+  }
+
+  /// Tracks the screen exit event with time-on-screen.
+  ///
+  /// This is called automatically when the widget is disposed.
+  void _trackScreenExit() {
+    if (_screenEntryTime == null) return;
+
+    final timeOnScreen = DateTime.now().difference(_screenEntryTime!);
+    final parameters = <String, dynamic>{
+      ...screenParameters,
+      'screen_name': screenName,
+      'time_on_screen_seconds': timeOnScreen.inSeconds,
+      'time_on_screen_milliseconds': timeOnScreen.inMilliseconds,
+    };
+
+    if (enableDebugLogging) {
+      debugPrint('📊 Screen Exit: $screenName');
+      debugPrint('   Time on screen: ${timeOnScreen.inSeconds}s');
+      debugPrint('   Parameters: $parameters');
+    }
+
+    // TODO: Integrate with actual analytics service
+    // AnalyticsService.instance.logEvent(
+    //   name: 'screen_exit',
+    //   parameters: parameters,
+    // );
+  }
+
+  /// Manually track a screen view.
+  ///
+  /// This can be useful if you need to re-track the screen view
+  /// after a significant state change.
+  ///
+  /// Example:
+  /// ```dart
+  /// void onTabChanged(int tabIndex) {
+  ///   setState(() {
+  ///     _currentTab = tabIndex;
+  ///   });
+  ///   trackScreenView(); // Re-track with updated parameters
+  /// }
+  /// ```
+  void trackScreenView() {
+    _trackScreenView();
+  }
 }

--- a/packages/core_kit/lib/core_kit.dart
+++ b/packages/core_kit/lib/core_kit.dart
@@ -11,4 +11,5 @@ export 'theme/app_shadows.dart';
 
 // Widget exports
 export 'widgets/buttons/app_button.dart';
+export 'widgets/inputs/app_checkbox.dart';
 export 'widgets/buttons/app_text_button.dart';

--- a/packages/core_kit/lib/core_kit.dart
+++ b/packages/core_kit/lib/core_kit.dart
@@ -13,3 +13,4 @@ export 'theme/app_shadows.dart';
 export 'widgets/buttons/app_button.dart';
 export 'widgets/inputs/app_checkbox.dart';
 export 'widgets/buttons/app_text_button.dart';
+export 'widgets/surfaces/app_list_tile.dart';

--- a/packages/core_kit/lib/core_kit.dart
+++ b/packages/core_kit/lib/core_kit.dart
@@ -20,3 +20,4 @@ export 'widgets/inputs/app_dropdown.dart';
 export 'widgets/inputs/app_search_field.dart';
 export 'widgets/surfaces/app_list_tile.dart';
 export 'widgets/inputs/app_radio_group.dart';
+export 'widgets/inputs/app_slider.dart';

--- a/packages/core_kit/lib/core_kit.dart
+++ b/packages/core_kit/lib/core_kit.dart
@@ -14,6 +14,7 @@ export 'widgets/buttons/app_button.dart';
 export 'widgets/buttons/app_text_button.dart';
 export 'widgets/surfaces/app_section_header.dart';
 export 'widgets/inputs/app_checkbox.dart';
+export 'widgets/inputs/app_dropdown.dart';
 export 'widgets/inputs/app_search_field.dart';
 export 'widgets/inputs/app_text_field.dart';
 export 'widgets/surfaces/app_list_tile.dart';

--- a/packages/core_kit/lib/core_kit.dart
+++ b/packages/core_kit/lib/core_kit.dart
@@ -18,3 +18,4 @@ export 'widgets/inputs/app_dropdown.dart';
 export 'widgets/inputs/app_search_field.dart';
 export 'widgets/inputs/app_text_field.dart';
 export 'widgets/surfaces/app_list_tile.dart';
+export 'widgets/inputs/app_radio_group.dart';

--- a/packages/core_kit/lib/core_kit.dart
+++ b/packages/core_kit/lib/core_kit.dart
@@ -11,6 +11,8 @@ export 'theme/app_shadows.dart';
 
 // Widget exports
 export 'widgets/buttons/app_button.dart';
-export 'widgets/inputs/app_checkbox.dart';
 export 'widgets/buttons/app_text_button.dart';
+export 'widgets/inputs/app_checkbox.dart';
+export 'widgets/inputs/app_search_field.dart';
+export 'widgets/inputs/app_text_field.dart';
 export 'widgets/surfaces/app_list_tile.dart';

--- a/packages/core_kit/lib/core_kit.dart
+++ b/packages/core_kit/lib/core_kit.dart
@@ -12,6 +12,7 @@ export 'theme/app_shadows.dart';
 // Widget exports
 export 'widgets/buttons/app_button.dart';
 export 'widgets/buttons/app_text_button.dart';
+export 'widgets/surfaces/app_section_header.dart';
 export 'widgets/inputs/app_checkbox.dart';
 export 'widgets/inputs/app_search_field.dart';
 export 'widgets/inputs/app_text_field.dart';

--- a/packages/core_kit/lib/core_kit.dart
+++ b/packages/core_kit/lib/core_kit.dart
@@ -11,3 +11,4 @@ export 'theme/app_shadows.dart';
 
 // Widget exports
 export 'widgets/buttons/app_button.dart';
+export 'widgets/buttons/app_text_button.dart';

--- a/packages/core_kit/lib/core_kit.dart
+++ b/packages/core_kit/lib/core_kit.dart
@@ -11,11 +11,12 @@ export 'theme/app_shadows.dart';
 
 // Widget exports
 export 'widgets/buttons/app_button.dart';
+export 'widgets/inputs/app_checkbox.dart';
+export 'widgets/inputs/app_password_field.dart';
+export 'widgets/inputs/app_text_field.dart';
 export 'widgets/buttons/app_text_button.dart';
 export 'widgets/surfaces/app_section_header.dart';
-export 'widgets/inputs/app_checkbox.dart';
 export 'widgets/inputs/app_dropdown.dart';
 export 'widgets/inputs/app_search_field.dart';
-export 'widgets/inputs/app_text_field.dart';
 export 'widgets/surfaces/app_list_tile.dart';
 export 'widgets/inputs/app_radio_group.dart';

--- a/packages/core_kit/lib/widgets/buttons/app_button.dart
+++ b/packages/core_kit/lib/widgets/buttons/app_button.dart
@@ -3,28 +3,99 @@
 
 import 'package:flutter/material.dart';
 
-/// A customizable Material Design 3 button widget.
-/// Supports multiple variants: filled, outlined, text, and elevated.
+/// A customizable Material Design 3 button widget that provides a consistent
+/// button experience across the application.
+///
+/// The [AppButton] component supports four visual variants (filled, outlined,
+/// text, and elevated) and includes built-in support for loading states, icons,
+/// and full-width layouts. All variants follow Material Design 3 guidelines
+/// and automatically adapt to the app's theme.
+///
+/// ## Usage
+///
+/// ```dart
+/// // Basic filled button
+/// AppButton.filled(
+///   label: 'Continue',
+///   onPressed: () => print('Button pressed'),
+/// )
+///
+/// // Button with icon
+/// AppButton.filled(
+///   label: 'Add to Cart',
+///   icon: Icons.shopping_cart,
+///   onPressed: () => print('Added to cart'),
+/// )
+///
+/// // Loading state
+/// AppButton.filled(
+///   label: 'Processing',
+///   isLoading: true,
+///   onPressed: () {}, // Disabled during loading
+/// )
+///
+/// // Full-width button
+/// AppButton.filled(
+///   label: 'Sign In',
+///   fullWidth: true,
+///   onPressed: () => print('Signing in'),
+/// )
+/// ```
+///
+/// ## When to Use Each Variant
+///
+/// **Filled Button** ([AppButton.filled]):
+/// - Primary actions that require high emphasis
+/// - Call-to-action buttons (e.g., "Sign In", "Submit", "Continue")
+/// - Final step in a flow (e.g., "Complete Purchase")
+///
+/// **Outlined Button** ([AppButton.outlined]):
+/// - Medium-emphasis actions
+/// - Secondary actions that need less prominence than filled buttons
+/// - Alternative options (e.g., "Cancel" alongside a filled "Submit")
+///
+/// **Text Button** ([AppButton.text]):
+/// - Low-emphasis actions
+/// - Tertiary actions or less important options
+/// - Dialog actions (e.g., "Cancel", "Learn More")
+/// - Inline actions that shouldn't dominate the interface
+///
+/// **Elevated Button** ([AppButton.elevated]):
+/// - Actions that need to stand out from the background
+/// - Use sparingly when visual separation is needed
+/// - Best on surfaces with busy backgrounds or images
+///
+/// ## Accessibility
+///
+/// This component automatically provides proper accessibility support:
+/// - Minimum touch target size of 48x48dp (enforced by Material buttons)
+/// - Semantic labels for screen readers
+/// - Proper disabled state announcements
+/// - Loading state excludes from accessibility tree during processing
+///
+/// ## Material Design 3 Compliance
+///
+/// This component follows MD3 specifications:
+/// - Button height: 40dp standard (48dp minimum touch target enforced)
+/// - Horizontal padding: Follows MD3 guidelines per button type
+/// - Typography: Uses theme's `labelLarge` text style
+/// - Colors: Automatically uses theme's color scheme tokens
+/// - Border radius: Follows Material Design 3 defaults
+///
+/// See also:
+/// - [Material Design 3 Buttons](https://m3.material.io/components/buttons)
+/// - [AppButtonVariant] for available button styles
 class AppButton extends StatelessWidget {
-  /// The button's label text
-  final String label;
-
-  /// Callback when the button is pressed
-  final VoidCallback? onPressed;
-
-  /// Optional leading icon
-  final IconData? icon;
-
-  /// Button variant style
-  final AppButtonVariant variant;
-
-  /// Whether the button should take full width
-  final bool fullWidth;
-
-  /// Whether the button is in loading state
-  final bool isLoading;
-
-  /// Creates an AppButton
+  /// Creates a customizable button widget.
+  ///
+  /// The [label] parameter is required and specifies the text displayed on
+  /// the button. The [variant] parameter defaults to [AppButtonVariant.filled].
+  ///
+  /// When [isLoading] is true, the button displays a loading indicator and
+  /// the [onPressed] callback is disabled regardless of its value.
+  ///
+  /// Set [fullWidth] to true to make the button expand to fill its parent's
+  /// width (useful for form layouts and mobile interfaces).
   const AppButton({
     required this.label,
     this.onPressed,
@@ -35,7 +106,18 @@ class AppButton extends StatelessWidget {
     super.key,
   });
 
-  /// Creates a filled button (default)
+  /// Creates a filled button variant (high emphasis).
+  ///
+  /// Filled buttons have the highest visual impact and should be used for
+  /// primary actions. They use the theme's primary color for the background.
+  ///
+  /// Example:
+  /// ```dart
+  /// AppButton.filled(
+  ///   label: 'Submit Form',
+  ///   onPressed: () => submitForm(),
+  /// )
+  /// ```
   const AppButton.filled({
     required this.label,
     this.onPressed,
@@ -45,7 +127,18 @@ class AppButton extends StatelessWidget {
     super.key,
   }) : variant = AppButtonVariant.filled;
 
-  /// Creates an outlined button
+  /// Creates an outlined button variant (medium emphasis).
+  ///
+  /// Outlined buttons are medium-emphasis buttons that contain actions that
+  /// are important but not primary. They pair well with filled buttons.
+  ///
+  /// Example:
+  /// ```dart
+  /// AppButton.outlined(
+  ///   label: 'Cancel',
+  ///   onPressed: () => Navigator.pop(context),
+  /// )
+  /// ```
   const AppButton.outlined({
     required this.label,
     this.onPressed,
@@ -55,7 +148,19 @@ class AppButton extends StatelessWidget {
     super.key,
   }) : variant = AppButtonVariant.outlined;
 
-  /// Creates a text button
+  /// Creates a text button variant (low emphasis).
+  ///
+  /// Text buttons are low-emphasis buttons used for less important actions.
+  /// They work well in dialogs and cards where button emphasis would be
+  /// too strong.
+  ///
+  /// Example:
+  /// ```dart
+  /// AppButton.text(
+  ///   label: 'Learn More',
+  ///   onPressed: () => showInfoDialog(),
+  /// )
+  /// ```
   const AppButton.text({
     required this.label,
     this.onPressed,
@@ -65,7 +170,19 @@ class AppButton extends StatelessWidget {
     super.key,
   }) : variant = AppButtonVariant.text;
 
-  /// Creates an elevated button
+  /// Creates an elevated button variant (elevated emphasis).
+  ///
+  /// Elevated buttons have a shadow to provide depth. Use them when you need
+  /// the button to stand out from surfaces with patterns or images.
+  ///
+  /// Example:
+  /// ```dart
+  /// AppButton.elevated(
+  ///   label: 'Get Started',
+  ///   icon: Icons.arrow_forward,
+  ///   onPressed: () => startOnboarding(),
+  /// )
+  /// ```
   const AppButton.elevated({
     required this.label,
     this.onPressed,
@@ -75,8 +192,50 @@ class AppButton extends StatelessWidget {
     super.key,
   }) : variant = AppButtonVariant.elevated;
 
+  /// The text displayed on the button.
+  ///
+  /// This text is required and will be displayed using the theme's
+  /// `labelLarge` text style.
+  final String label;
+
+  /// Callback invoked when the button is pressed.
+  ///
+  /// If null, the button will be disabled. If [isLoading] is true,
+  /// this callback will not be triggered even when the button is tapped.
+  final VoidCallback? onPressed;
+
+  /// Optional icon displayed before the label.
+  ///
+  /// When provided, the button will use the appropriate `.icon` constructor
+  /// of the underlying Material button (e.g., [FilledButton.icon]).
+  final IconData? icon;
+
+  /// The visual style variant of the button.
+  ///
+  /// Defaults to [AppButtonVariant.filled]. See [AppButtonVariant] for
+  /// available options and usage guidelines.
+  final AppButtonVariant variant;
+
+  /// Whether the button should expand to fill its parent's width.
+  ///
+  /// When true, the button is wrapped in a [SizedBox] with
+  /// `width: double.infinity`. Useful for full-width form buttons.
+  ///
+  /// Defaults to false.
+  final bool fullWidth;
+
+  /// Whether the button is in a loading state.
+  ///
+  /// When true, displays a [CircularProgressIndicator] and disables
+  /// the [onPressed] callback. The button remains disabled until
+  /// [isLoading] is set to false.
+  ///
+  /// Defaults to false.
+  final bool isLoading;
+
   @override
   Widget build(BuildContext context) {
+    // Determine button content: loading indicator or label
     final child = isLoading
         ? const SizedBox(
             height: 20,
@@ -85,9 +244,10 @@ class AppButton extends StatelessWidget {
           )
         : _buildButtonContent();
 
+    // Build appropriate button variant
     final button = switch (variant) {
       AppButtonVariant.filled =>
-        icon != null
+        icon != null && !isLoading
             ? FilledButton.icon(
                 onPressed: isLoading ? null : onPressed,
                 icon: Icon(icon),
@@ -98,7 +258,7 @@ class AppButton extends StatelessWidget {
                 child: child,
               ),
       AppButtonVariant.outlined =>
-        icon != null
+        icon != null && !isLoading
             ? OutlinedButton.icon(
                 onPressed: isLoading ? null : onPressed,
                 icon: Icon(icon),
@@ -109,7 +269,7 @@ class AppButton extends StatelessWidget {
                 child: child,
               ),
       AppButtonVariant.text =>
-        icon != null
+        icon != null && !isLoading
             ? TextButton.icon(
                 onPressed: isLoading ? null : onPressed,
                 icon: Icon(icon),
@@ -117,7 +277,7 @@ class AppButton extends StatelessWidget {
               )
             : TextButton(onPressed: isLoading ? null : onPressed, child: child),
       AppButtonVariant.elevated =>
-        icon != null
+        icon != null && !isLoading
             ? ElevatedButton.icon(
                 onPressed: isLoading ? null : onPressed,
                 icon: Icon(icon),
@@ -129,32 +289,58 @@ class AppButton extends StatelessWidget {
               ),
     };
 
+    // Wrap with accessibility and layout
+    final accessibleButton = Semantics(
+      button: true,
+      enabled: !isLoading && onPressed != null,
+      label: isLoading ? '$label, loading' : label,
+      excludeSemantics: isLoading,
+      child: button,
+    );
+
+    // Apply full-width layout if requested
     if (fullWidth) {
-      return SizedBox(width: double.infinity, child: button);
+      return SizedBox(width: double.infinity, child: accessibleButton);
     }
 
-    return button;
+    return accessibleButton;
   }
 
+  /// Builds the button's child content.
+  ///
+  /// Returns a [Text] widget with the button's label. This method exists
+  /// to provide a consistent content builder for buttons without icons.
   Widget _buildButtonContent() {
-    if (icon != null) {
-      return Text(label);
-    }
     return Text(label);
   }
 }
 
-/// Button variant styles
+/// Visual style variants for [AppButton].
+///
+/// Each variant provides different visual emphasis and should be used
+/// according to the action's importance in the interface hierarchy.
 enum AppButtonVariant {
-  /// Filled button with background color
+  /// Filled button with solid background color (high emphasis).
+  ///
+  /// Use for primary, high-emphasis actions like form submissions,
+  /// confirmations, or the main call-to-action on a screen.
   filled,
 
-  /// Outlined button with border
+  /// Outlined button with border, no background fill (medium emphasis).
+  ///
+  /// Use for secondary actions that are important but not primary,
+  /// such as "Cancel" buttons or alternative options.
   outlined,
 
-  /// Text-only button without background
+  /// Text-only button without background or border (low emphasis).
+  ///
+  /// Use for tertiary actions, less important options, or when
+  /// button emphasis would overwhelm the interface (e.g., in dialogs).
   text,
 
-  /// Elevated button with shadow
+  /// Elevated button with shadow for depth (elevated emphasis).
+  ///
+  /// Use when the button needs to stand out from busy backgrounds
+  /// or patterned surfaces. Use sparingly for visual hierarchy.
   elevated,
 }

--- a/packages/core_kit/lib/widgets/buttons/app_fab.dart
+++ b/packages/core_kit/lib/widgets/buttons/app_fab.dart
@@ -1,6 +1,370 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppFab {
-  const AppFab();
+import 'package:flutter/material.dart';
+import '../../theme/app_radius.dart';
+import '../../theme/app_typography.dart';
+
+/// Floating Action Button following Material Design 3.
+///
+/// Variants:
+/// - Default (56x56)
+/// - Small (40x40)
+/// - Large (96x96)
+/// - Extended (48 height with label)
+class AppFab extends StatelessWidget {
+  /// Default FAB: 56x56
+  const AppFab({
+    required this.icon,
+    this.iconWrapper,
+    this.onPressed,
+    this.tooltip,
+    this.backgroundColor,
+    this.foregroundColor,
+    this.elevation,
+    this.heroTag,
+    this.shape,
+    super.key,
+  }) : _variant = _FabVariant.defaultFab,
+       label = null,
+       trailingIcon = null;
+
+  /// Small FAB: 40x40
+  const AppFab.small({
+    required this.icon,
+    this.iconWrapper,
+    this.onPressed,
+    this.tooltip,
+    this.backgroundColor,
+    this.foregroundColor,
+    this.elevation,
+    this.heroTag,
+    this.shape,
+    super.key,
+  }) : _variant = _FabVariant.small,
+       label = null,
+       trailingIcon = null;
+
+  /// Large FAB: 96x96
+  const AppFab.large({
+    required this.icon,
+    this.iconWrapper,
+    this.onPressed,
+    this.tooltip,
+    this.backgroundColor,
+    this.foregroundColor,
+    this.elevation,
+    this.heroTag,
+    this.shape,
+    super.key,
+  }) : _variant = _FabVariant.large,
+       label = null,
+       trailingIcon = null;
+
+  /// Extended FAB with label (48dp height)
+  const AppFab.extended({
+    required this.icon,
+    required this.label,
+    this.trailingIcon,
+    this.iconWrapper,
+    this.onPressed,
+    this.tooltip,
+    this.backgroundColor,
+    this.foregroundColor,
+    this.elevation,
+    this.heroTag,
+    this.shape,
+    super.key,
+  }) : _variant = _FabVariant.extended;
+
+  /// Icon to display.
+  final IconData icon;
+
+  /// Optional trailing icon for extended variant.
+  final IconData? trailingIcon;
+
+  /// Optional wrapper to decorate/animate the icon widget (e.g., rotation for loading).
+  final Widget Function(Widget icon)? iconWrapper;
+
+  /// Tap handler. Null disables the FAB.
+  final VoidCallback? onPressed;
+
+  /// Accessibility tooltip.
+  final String? tooltip;
+
+  /// Background color override.
+  final Color? backgroundColor;
+
+  /// Foreground (icon/label) color override.
+  final Color? foregroundColor;
+
+  /// Elevation override.
+  final double? elevation;
+
+  /// Hero tag for navigation transitions.
+  final Object? heroTag;
+
+  /// Custom shape override.
+  final ShapeBorder? shape;
+
+  /// Label for extended variant.
+  final String? label;
+
+  final _FabVariant _variant;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+
+    // Derive MD3-compliant defaults from AppColorScheme/AppRadius/AppTypography
+    final Color bg = backgroundColor ?? colors.primaryContainer;
+    final Color fg = foregroundColor ?? colors.onPrimaryContainer;
+    final WidgetStateProperty<double?> elevProp =
+        WidgetStateProperty.resolveWith<double?>((states) {
+          if (states.contains(WidgetState.hovered) ||
+              states.contains(WidgetState.focused)) {
+            return (elevation ?? 12.0);
+          }
+          return (elevation ?? 6.0);
+        });
+
+    final ShapeBorder defaultShape = RoundedRectangleBorder(
+      borderRadius: _variant == _FabVariant.extended
+          ? AppRadius
+                .xlRadius // 28dp for extended
+          : AppRadius.lgRadius, // 16dp for regular
+    );
+
+    Widget childIcon = Icon(icon, size: _iconSizeFor(_variant));
+    if (iconWrapper != null) {
+      childIcon = iconWrapper!(childIcon);
+    }
+
+    Widget result;
+    switch (_variant) {
+      case _FabVariant.small:
+        result = FloatingActionButton.small(
+          heroTag: heroTag,
+          onPressed: onPressed,
+          tooltip: tooltip,
+          backgroundColor: bg,
+          foregroundColor: fg,
+          elevation: elevProp.resolve(const {}),
+          shape: shape ?? defaultShape,
+          child: childIcon,
+        );
+        break;
+      case _FabVariant.large:
+        result = FloatingActionButton.large(
+          heroTag: heroTag,
+          onPressed: onPressed,
+          tooltip: tooltip,
+          backgroundColor: bg,
+          foregroundColor: fg,
+          elevation: elevProp.resolve(const {}),
+          shape: shape ?? defaultShape,
+          child: childIcon,
+        );
+        break;
+      case _FabVariant.extended:
+        // Compose label with optional trailing icon using MD3 spacing
+        final Widget labelWidget = Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              label ?? '',
+              style: AppTypography.textTheme().labelLarge?.copyWith(color: fg),
+            ),
+            if (trailingIcon != null) ...[
+              const SizedBox(width: 8),
+              Icon(trailingIcon, size: _iconSizeFor(_variant), color: fg),
+            ],
+          ],
+        );
+
+        result = FloatingActionButton.extended(
+          heroTag: heroTag,
+          onPressed: onPressed,
+          tooltip: tooltip,
+          backgroundColor: bg,
+          foregroundColor: fg,
+          elevation: elevProp.resolve(const {}),
+          shape: shape ?? defaultShape,
+          label: labelWidget,
+          icon: iconWrapper != null
+              ? iconWrapper!(Icon(icon, size: _iconSizeFor(_variant)))
+              : Icon(icon, size: _iconSizeFor(_variant)),
+        );
+        break;
+      case _FabVariant.defaultFab:
+        result = FloatingActionButton(
+          heroTag: heroTag,
+          onPressed: onPressed,
+          tooltip: tooltip,
+          backgroundColor: bg,
+          foregroundColor: fg,
+          elevation: elevProp.resolve(const {}),
+          shape: shape ?? defaultShape,
+          child: childIcon,
+        );
+        break;
+    }
+
+    // Accessibility semantics wrapper and ensure min touch target
+    return Semantics(
+      button: true,
+      enabled: onPressed != null,
+      label: tooltip,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minWidth: 48, minHeight: 48),
+        child: result,
+      ),
+    );
+  }
+
+  double _iconSizeFor(_FabVariant v) {
+    switch (v) {
+      case _FabVariant.large:
+        return 36; // MD3 large icon size
+      case _FabVariant.small:
+        return 24; // MD3 small uses 24dp icon by spec requirement
+      case _FabVariant.extended:
+        return 24; // Extended uses 24dp icon
+      case _FabVariant.defaultFab:
+        return 24; // MD3 default uses 24dp icon size
+    }
+  }
+}
+
+enum _FabVariant { defaultFab, small, large, extended }
+
+/// Internal helper to augment extended FAB with a trailing icon while
+/// preserving Material behavior and ripple.
+// Removed overlay helper; trailing icon is integrated into the extended label row for correct layout.
+
+/// Animated switchable FAB to transition smoothly between extended and default.
+///
+/// This wrapper helps animate between an extended FAB (with label) and a
+/// regular FAB using AnimatedSwitcher for a smooth cross-fade/size transition.
+class AppFabSwitchable extends StatelessWidget {
+  const AppFabSwitchable({
+    required this.isExtended,
+    required this.icon,
+    this.label,
+    this.trailingIcon,
+    this.onPressed,
+    this.tooltip,
+    this.backgroundColor,
+    this.foregroundColor,
+    this.elevation,
+    this.heroTag,
+    this.shape,
+    this.duration = const Duration(milliseconds: 200),
+    super.key,
+  });
+
+  final bool isExtended;
+  final IconData icon;
+  final String? label;
+  final IconData? trailingIcon;
+  final VoidCallback? onPressed;
+  final String? tooltip;
+  final Color? backgroundColor;
+  final Color? foregroundColor;
+  final double? elevation;
+  final Object? heroTag;
+  final ShapeBorder? shape;
+  final Duration duration;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: duration,
+      switchInCurve: Curves.easeOut,
+      switchOutCurve: Curves.easeIn,
+      child: isExtended
+          ? AppFab.extended(
+              key: const ValueKey('extended'),
+              icon: icon,
+              label: label ?? '',
+              trailingIcon: trailingIcon,
+              onPressed: onPressed,
+              tooltip: tooltip,
+              backgroundColor: backgroundColor,
+              foregroundColor: foregroundColor,
+              elevation: elevation,
+              heroTag: heroTag,
+              shape: shape,
+            )
+          : AppFab(
+              key: const ValueKey('default'),
+              icon: icon,
+              onPressed: onPressed,
+              tooltip: tooltip,
+              backgroundColor: backgroundColor,
+              foregroundColor: foregroundColor,
+              elevation: elevation,
+              heroTag: heroTag,
+              shape: shape,
+            ),
+    );
+  }
+}
+
+/// Helper widget to hide/show FAB based on scroll direction using AnimatedSlide.
+class AppFabHideOnScroll extends StatefulWidget {
+  const AppFabHideOnScroll({
+    required this.scrollController,
+    required this.fab,
+    this.offset = const Offset(0, 1),
+    this.duration = const Duration(milliseconds: 200),
+    super.key,
+  });
+
+  final ScrollController scrollController;
+  final Widget fab;
+  final Offset offset;
+  final Duration duration;
+
+  @override
+  State<AppFabHideOnScroll> createState() => _AppFabHideOnScrollState();
+}
+
+class _AppFabHideOnScrollState extends State<AppFabHideOnScroll> {
+  double _last = 0;
+  bool _hidden = false;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.scrollController.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    widget.scrollController.removeListener(_onScroll);
+    super.dispose();
+  }
+
+  void _onScroll() {
+    final current = widget.scrollController.position.pixels;
+    final goingDown = current > _last;
+    _last = current;
+    if (goingDown && !_hidden) {
+      setState(() => _hidden = true);
+    } else if (!goingDown && _hidden) {
+      setState(() => _hidden = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSlide(
+      offset: _hidden ? widget.offset : Offset.zero,
+      duration: widget.duration,
+      curve: Curves.easeInOut,
+      child: widget.fab,
+    );
+  }
 }

--- a/packages/core_kit/lib/widgets/buttons/app_icon_button.dart
+++ b/packages/core_kit/lib/widgets/buttons/app_icon_button.dart
@@ -1,6 +1,185 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppIconButton {
-  const AppIconButton();
+import 'package:flutter/material.dart';
+
+/// AppIconButton: MD3-compliant icon-only button with variants and accessibility.
+class AppIconButton extends StatelessWidget {
+  /// Standard icon button (no background).
+  const AppIconButton({
+    super.key,
+    required this.icon,
+    required this.tooltip,
+    this.onPressed,
+    this.iconSize = 24.0,
+    this.color,
+    this.padding,
+    this.style,
+    this.isSelected = false,
+  }) : _variant = _AppIconButtonVariant.standard;
+
+  /// Filled icon button (primary emphasis).
+  const AppIconButton.filled({
+    super.key,
+    required this.icon,
+    required this.tooltip,
+    this.onPressed,
+    this.iconSize = 24.0,
+    this.color,
+    this.padding,
+    this.style,
+    this.isSelected = false,
+  }) : _variant = _AppIconButtonVariant.filled;
+
+  /// Filled tonal icon button (secondary/tonal emphasis).
+  const AppIconButton.filledTonal({
+    super.key,
+    required this.icon,
+    required this.tooltip,
+    this.onPressed,
+    this.iconSize = 24.0,
+    this.color,
+    this.padding,
+    this.style,
+    this.isSelected = false,
+  }) : _variant = _AppIconButtonVariant.filledTonal;
+
+  /// Outlined icon button (medium emphasis, with border).
+  const AppIconButton.outlined({
+    super.key,
+    required this.icon,
+    required this.tooltip,
+    this.onPressed,
+    this.iconSize = 24.0,
+    this.color,
+    this.padding,
+    this.style,
+    this.isSelected = false,
+  }) : _variant = _AppIconButtonVariant.outlined;
+
+  final IconData icon;
+  final VoidCallback? onPressed;
+  final String tooltip;
+  final double iconSize;
+  final Color? color;
+  final EdgeInsetsGeometry? padding;
+  final ButtonStyle? style;
+  final bool isSelected;
+
+  final _AppIconButtonVariant _variant;
+
+  @override
+  Widget build(BuildContext context) {
+    // MD3: minimum 48x48dp touch target even if visually smaller.
+    final Widget child = _buildVariantButton(context);
+
+    return Semantics(
+      button: true,
+      selected: isSelected,
+      enabled: onPressed != null,
+      label: tooltip,
+      child: SizedBox(width: 48, height: 48, child: child),
+    );
+  }
+
+  Widget _buildVariantButton(BuildContext context) {
+    final ColorScheme cs = Theme.of(context).colorScheme;
+
+    // Icon color defaults per variant using MD3 tokens.
+    final Color defaultIconColor = switch (_variant) {
+      _AppIconButtonVariant.standard => cs.onSurfaceVariant,
+      _AppIconButtonVariant.filled => cs.onPrimary,
+      _AppIconButtonVariant.filledTonal => cs.onSecondaryContainer,
+      _AppIconButtonVariant.outlined => cs.onSurfaceVariant,
+    };
+
+    final ButtonStyle baseStyle = switch (_variant) {
+      _AppIconButtonVariant.standard => const ButtonStyle(),
+      _AppIconButtonVariant.filled => ButtonStyle(
+        backgroundColor: WidgetStateProperty.resolveWith((states) {
+          if (states.contains(WidgetState.disabled)) {
+            return cs.onSurface.withValues(alpha: 0.12);
+          }
+          return cs.primary;
+        }),
+      ),
+      _AppIconButtonVariant.filledTonal => ButtonStyle(
+        backgroundColor: WidgetStateProperty.resolveWith((states) {
+          if (states.contains(WidgetState.disabled)) {
+            return cs.onSurface.withValues(alpha: 0.12);
+          }
+          return cs.secondaryContainer;
+        }),
+      ),
+      _AppIconButtonVariant.outlined => ButtonStyle(
+        side: WidgetStateProperty.resolveWith((states) {
+          final Color outline = cs.outline;
+          final Color disabledOutline = outline.withValues(alpha: 0.12);
+          return BorderSide(
+            color: states.contains(WidgetState.disabled)
+                ? disabledOutline
+                : outline,
+          );
+        }),
+      ),
+    };
+
+    final ButtonStyle mergedStyle = baseStyle.merge(style);
+
+    final EdgeInsetsGeometry effectivePadding =
+        padding ?? const EdgeInsets.all(12); // 48 container with 24 icon
+
+    final Icon iconWidget = Icon(
+      icon,
+      size: iconSize,
+      color: color ?? defaultIconColor,
+    );
+
+    // Toggle visual hint.
+    final Icon effectiveIcon = isSelected
+        ? Icon(
+            iconWidget.icon,
+            size: iconWidget.size,
+            color: (color ?? defaultIconColor).withValues(alpha: 1.0),
+          )
+        : iconWidget;
+
+    // Choose base IconButton class by variant for MD3 behavior.
+    return switch (_variant) {
+      _AppIconButtonVariant.standard => IconButton(
+        icon: effectiveIcon,
+        tooltip: tooltip,
+        isSelected: isSelected,
+        onPressed: onPressed,
+        style: mergedStyle,
+        padding: effectivePadding,
+      ),
+      _AppIconButtonVariant.filled => IconButton.filled(
+        icon: effectiveIcon,
+        tooltip: tooltip,
+        isSelected: isSelected,
+        onPressed: onPressed,
+        style: mergedStyle,
+        padding: effectivePadding,
+      ),
+      _AppIconButtonVariant.filledTonal => IconButton.filledTonal(
+        icon: effectiveIcon,
+        tooltip: tooltip,
+        isSelected: isSelected,
+        onPressed: onPressed,
+        style: mergedStyle,
+        padding: effectivePadding,
+      ),
+      _AppIconButtonVariant.outlined => IconButton.outlined(
+        icon: effectiveIcon,
+        tooltip: tooltip,
+        isSelected: isSelected,
+        onPressed: onPressed,
+        style: mergedStyle,
+        padding: effectivePadding,
+      ),
+    };
+  }
 }
+
+enum _AppIconButtonVariant { standard, filled, filledTonal, outlined }

--- a/packages/core_kit/lib/widgets/buttons/app_outlined_button.dart
+++ b/packages/core_kit/lib/widgets/buttons/app_outlined_button.dart
@@ -1,6 +1,35 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppOutlinedButton {
-  const AppOutlinedButton();
+import 'package:flutter/material.dart';
+import 'package:core_kit/widgets/buttons/app_button.dart';
+
+/// A convenience wrapper that delegates to AppButton.outlined().
+/// Use for secondary actions requiring an outlined style.
+class AppOutlinedButton extends StatelessWidget {
+  final String label;
+  final VoidCallback? onPressed;
+  final IconData? icon;
+  final bool fullWidth;
+  final bool isLoading;
+
+  const AppOutlinedButton({
+    required this.label,
+    this.onPressed,
+    this.icon,
+    this.fullWidth = false,
+    this.isLoading = false,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AppButton.outlined(
+      label: label,
+      onPressed: onPressed,
+      icon: icon,
+      fullWidth: fullWidth,
+      isLoading: isLoading,
+    );
+  }
 }

--- a/packages/core_kit/lib/widgets/buttons/app_text_button.dart
+++ b/packages/core_kit/lib/widgets/buttons/app_text_button.dart
@@ -1,6 +1,178 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppTextButton {
-  const AppTextButton();
+import 'package:flutter/material.dart';
+import 'package:core_kit/core_kit.dart';
+
+/// A low-emphasis text button that displays text without a background or border.
+///
+/// [AppTextButton] is a convenient wrapper around [AppButton.text] that provides
+/// a dedicated API for text-only buttons. Text buttons are the most subtle button
+/// variant and should be used for tertiary actions, inline links, and less
+/// important operations.
+///
+/// This component delegates all functionality to [AppButton.text], ensuring
+/// consistent behavior while providing developers with an alternative,
+/// component-specific naming convention.
+///
+/// ## When to Use AppTextButton
+///
+/// Text buttons have the lowest visual emphasis and are best suited for:
+///
+/// - **Tertiary Actions**: The least important actions in a set of options
+/// - **Dialog Actions**: Dismissive actions like "Cancel", "Not now", "Skip"
+/// - **Inline Actions**: Links within text such as "Learn more", "Show details"
+/// - **Navigation Links**: In-app navigation that should look like text
+/// - **Dense Layouts**: Where space is limited and visual weight must be minimal
+///
+/// ## Usage
+///
+/// ```dart
+/// // Basic text button
+/// AppTextButton(
+///   label: 'Learn More',
+///   onPressed: () => showInfoDialog(),
+/// )
+///
+/// // Text button with icon
+/// AppTextButton(
+///   label: 'Add item',
+///   icon: Icons.add,
+///   onPressed: () => addItem(),
+/// )
+///
+/// // In a dialog
+/// AlertDialog(
+///   actions: [
+///     AppTextButton(
+///       label: 'Not now',
+///       onPressed: () => Navigator.pop(context),
+///     ),
+///     AppButton.filled(
+///       label: 'Continue',
+///       onPressed: () => continueAction(),
+///     ),
+///   ],
+/// )
+///
+/// // As an inline link
+/// Text.rich(
+///   TextSpan(
+///     text: 'By continuing, you agree to our terms. ',
+///     children: [
+///       WidgetSpan(
+///         child: AppTextButton(
+///           label: 'Learn more',
+///           onPressed: () => showTerms(),
+///         ),
+///       ),
+///     ],
+///   ),
+/// )
+/// ```
+///
+/// ## Material Design 3 Compliance
+///
+/// This component follows Material Design 3 specifications for text buttons:
+/// - **Height**: 40dp standard (48dp minimum touch target enforced)
+/// - **Padding**: 12dp horizontal minimum
+/// - **Typography**: Uses theme's `labelLarge` text style
+/// - **Text Color**: `primary` (enabled), `onSurface` 38% opacity (disabled)
+/// - **Background**: None (text-only)
+/// - **Border**: None
+/// - **State Layer**: 40dp ripple effect
+/// - **Emphasis**: Lowest visual weight
+///
+/// ## Accessibility
+///
+/// Text buttons automatically provide proper accessibility support:
+/// - Minimum touch target size of 48x48dp
+/// - Semantic labels for screen readers
+/// - Proper disabled state announcements
+/// - Loading state excludes from accessibility tree
+///
+/// ## AppTextButton vs AppButton.text()
+///
+/// Both approaches are equivalent and produce identical results:
+///
+/// ```dart
+/// // Using AppTextButton (component-specific API)
+/// AppTextButton(label: 'Example', onPressed: () {})
+///
+/// // Using AppButton.text() (variant-based API)
+/// AppButton.text(label: 'Example', onPressed: () {})
+/// ```
+///
+/// Use whichever style you prefer. [AppTextButton] is provided as a convenience
+/// for developers who prefer dedicated component names.
+///
+/// See also:
+/// - [AppButton] for other button variants (filled, outlined, elevated)
+/// - [Material Design 3 Buttons](https://m3.material.io/components/buttons)
+class AppTextButton extends StatelessWidget {
+  /// Creates a text button widget.
+  ///
+  /// The [label] parameter is required and specifies the text displayed on
+  /// the button.
+  ///
+  /// When [isLoading] is true, the button displays a loading indicator and
+  /// the [onPressed] callback is disabled.
+  ///
+  /// Set [fullWidth] to true to make the button expand to fill its parent's
+  /// width.
+  const AppTextButton({
+    required this.label,
+    this.onPressed,
+    this.icon,
+    this.fullWidth = false,
+    this.isLoading = false,
+    super.key,
+  });
+
+  /// The text displayed on the button.
+  ///
+  /// This text is required and will be displayed using the theme's
+  /// `labelLarge` text style.
+  final String label;
+
+  /// Callback invoked when the button is pressed.
+  ///
+  /// If null, the button will be disabled. If [isLoading] is true,
+  /// this callback will not be triggered even when the button is tapped.
+  final VoidCallback? onPressed;
+
+  /// Optional icon displayed before the label.
+  ///
+  /// When provided, the button will display the icon to the left of the
+  /// label text.
+  final IconData? icon;
+
+  /// Whether the button should expand to fill its parent's width.
+  ///
+  /// When true, the button is wrapped in a [SizedBox] with
+  /// `width: double.infinity`. Useful for full-width layouts.
+  ///
+  /// Defaults to false.
+  final bool fullWidth;
+
+  /// Whether the button is in a loading state.
+  ///
+  /// When true, displays a [CircularProgressIndicator] and disables
+  /// the [onPressed] callback. The button remains disabled until
+  /// [isLoading] is set to false.
+  ///
+  /// Defaults to false.
+  final bool isLoading;
+
+  @override
+  Widget build(BuildContext context) {
+    // Delegate to AppButton.text() for consistent implementation
+    return AppButton.text(
+      label: label,
+      onPressed: onPressed,
+      icon: icon,
+      fullWidth: fullWidth,
+      isLoading: isLoading,
+    );
+  }
 }

--- a/packages/core_kit/lib/widgets/inputs/app_checkbox.dart
+++ b/packages/core_kit/lib/widgets/inputs/app_checkbox.dart
@@ -1,6 +1,258 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppCheckbox {
-  const AppCheckbox();
+import 'package:flutter/material.dart';
+
+/// A Material Design 3 checkbox widget that provides consistent checkbox
+/// experience across the application.
+///
+/// The [AppCheckbox] component supports:
+/// - Standard checked/unchecked states
+/// - Tristate mode (checked/unchecked/indeterminate)
+/// - Optional text labels
+/// - Error state styling
+/// - Material Design 3 theming
+/// - Accessibility features
+///
+/// ## Basic Usage
+///
+/// ```dart
+/// bool isChecked = false;
+///
+/// AppCheckbox(
+///   value: isChecked,
+///   label: 'Accept terms and conditions',
+///   onChanged: (value) {
+///     setState(() {
+///       isChecked = value ?? false;
+///     });
+///   },
+/// )
+/// ```
+///
+/// ## Tristate Mode
+///
+/// Enable tristate mode to support indeterminate state (useful for "select all"
+/// functionality):
+///
+/// ```dart
+/// bool? selectAll = null;
+///
+/// AppCheckbox(
+///   value: selectAll,
+///   label: 'Select all items',
+///   tristate: true,
+///   onChanged: (value) {
+///     setState(() {
+///       selectAll = value;
+///     });
+///   },
+/// )
+/// ```
+///
+/// ## Error State
+///
+/// Display error state with custom error message:
+///
+/// ```dart
+/// AppCheckbox(
+///   value: false,
+///   label: 'I agree to the terms',
+///   error: true,
+///   errorText: 'You must accept the terms to continue',
+///   onChanged: (value) {},
+/// )
+/// ```
+///
+/// ## Material Design 3 Specifications
+///
+/// - Visual size: 18x18dp
+/// - Touch target: 48x48dp (minimum for accessibility)
+/// - Border: 2dp outline when unchecked
+/// - Border radius: 2dp
+/// - Animation: 200ms smooth transition
+/// - Colors: Uses theme's [ColorScheme] tokens
+///
+/// ## Accessibility
+///
+/// - Minimum touch target of 48x48dp
+/// - Semantic labels from [label] property
+/// - State changes announced to screen readers
+/// - Keyboard navigation support (Space to toggle)
+///
+/// See also:
+/// - [Material Design 3 Checkbox](https://m3.material.io/components/checkbox)
+/// - [Checkbox] - Flutter's base checkbox widget
+class AppCheckbox extends StatelessWidget {
+  /// Creates a Material Design 3 checkbox.
+  ///
+  /// The [value] and [onChanged] parameters must not be null unless
+  /// [enabled] is false.
+  const AppCheckbox({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    this.label,
+    this.tristate = false,
+    this.activeColor,
+    this.checkColor,
+    this.error = false,
+    this.errorText,
+    this.enabled = true,
+  });
+
+  /// The current value of the checkbox.
+  ///
+  /// When [tristate] is false, this value must be either true or false.
+  /// When [tristate] is true, this value can be true, false, or null
+  /// (representing the indeterminate state).
+  final bool? value;
+
+  /// Called when the user toggles the checkbox.
+  ///
+  /// The checkbox passes the new value to the callback but does not actually
+  /// change state until the parent widget rebuilds the checkbox with the new
+  /// value.
+  ///
+  /// If this callback is null, the checkbox will be displayed as disabled.
+  final ValueChanged<bool?>? onChanged;
+
+  /// Optional text label displayed next to the checkbox.
+  ///
+  /// When null, only the checkbox is displayed.
+  final String? label;
+
+  /// If true, the checkbox's [value] can be true, false, or null.
+  ///
+  /// When [tristate] is true and [value] is null, the checkbox displays
+  /// a dash (indeterminate state).
+  ///
+  /// Defaults to false.
+  final bool tristate;
+
+  /// The color to use when this checkbox is checked.
+  ///
+  /// If null, uses the theme's primary color.
+  final Color? activeColor;
+
+  /// The color to use for the checkmark when this checkbox is checked.
+  ///
+  /// If null, uses the theme's onPrimary color.
+  final Color? checkColor;
+
+  /// Whether to display the checkbox in an error state.
+  ///
+  /// When true, the checkbox uses error color styling.
+  ///
+  /// Defaults to false.
+  final bool error;
+
+  /// Error message to display below the checkbox when [error] is true.
+  ///
+  /// If null, no error message is displayed even if [error] is true.
+  final String? errorText;
+
+  /// Whether the checkbox is enabled for interaction.
+  ///
+  /// When false, the checkbox is displayed with reduced opacity and does not
+  /// respond to touch.
+  ///
+  /// Defaults to true.
+  final bool enabled;
+
+  /// Whether this checkbox is currently enabled.
+  ///
+  /// A checkbox is considered enabled if [enabled] is true and [onChanged]
+  /// is not null.
+  bool get _isEnabled => enabled && onChanged != null;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    // Determine checkbox colors based on state
+    final Color effectiveActiveColor = error
+        ? colorScheme.error
+        : (activeColor ?? colorScheme.primary);
+
+    final Color effectiveCheckColor = checkColor ?? colorScheme.onPrimary;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Main checkbox row
+        InkWell(
+          onTap: _isEnabled
+              ? () {
+                  if (tristate) {
+                    // Cycle through: unchecked → checked → indeterminate → unchecked
+                    if (value == false) {
+                      onChanged?.call(true);
+                    } else if (value == true) {
+                      onChanged?.call(null);
+                    } else {
+                      onChanged?.call(false);
+                    }
+                  } else {
+                    // Toggle between checked and unchecked
+                    onChanged?.call(!(value ?? false));
+                  }
+                }
+              : null,
+          borderRadius: BorderRadius.circular(4),
+          child: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                // Checkbox widget
+                SizedBox(
+                  width: 40,
+                  height: 40,
+                  child: Checkbox(
+                    value: value,
+                    tristate: tristate,
+                    onChanged: _isEnabled ? onChanged : null,
+                    activeColor: effectiveActiveColor,
+                    checkColor: effectiveCheckColor,
+                    materialTapTargetSize: MaterialTapTargetSize.padded,
+                  ),
+                ),
+                // Label (if provided)
+                if (label != null) ...[
+                  const SizedBox(width: 8),
+                  Flexible(
+                    child: Text(
+                      label!,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: _isEnabled
+                            ? (error
+                                  ? colorScheme.error
+                                  : colorScheme.onSurface)
+                            : colorScheme.onSurface.withValues(alpha: 0.38),
+                      ),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+        // Error text (if provided)
+        if (error && errorText != null) ...[
+          Padding(
+            padding: const EdgeInsets.only(left: 56.0, top: 4.0),
+            child: Text(
+              errorText!,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: colorScheme.error,
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
 }

--- a/packages/core_kit/lib/widgets/inputs/app_dropdown.dart
+++ b/packages/core_kit/lib/widgets/inputs/app_dropdown.dart
@@ -1,6 +1,239 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppDropdown {
-  const AppDropdown();
+import 'package:flutter/material.dart';
+
+/// A Material Design 3 dropdown menu component for selecting a single value
+/// from a list of options.
+///
+/// Wraps Flutter's [DropdownMenu] with consistent theming and enhanced
+/// functionality like search, custom item rendering, and validation.
+///
+/// Example usage:
+/// ```dart
+/// AppDropdown<String>(
+///   items: ['Option 1', 'Option 2', 'Option 3'],
+///   value: selectedValue,
+///   onChanged: (value) => setState(() => selectedValue = value),
+///   label: 'Select an option',
+///   hint: 'Choose...',
+/// )
+/// ```
+class AppDropdown<T> extends StatelessWidget {
+  /// List of items to display in the dropdown
+  final List<T> items;
+
+  /// Currently selected value
+  final T? value;
+
+  /// Callback when a new value is selected
+  final ValueChanged<T?>? onChanged;
+
+  /// Function to convert item to display string
+  final String Function(T) itemLabelBuilder;
+
+  /// Label text displayed above the field
+  final String? label;
+
+  /// Hint text displayed when no value is selected
+  final String? hint;
+
+  /// Helper text displayed below the field
+  final String? helperText;
+
+  /// Error text displayed below the field with error styling
+  final String? errorText;
+
+  /// Leading icon for the dropdown field
+  final IconData? leadingIcon;
+
+  /// Whether the dropdown is enabled
+  final bool enabled;
+
+  /// Enable search/filter functionality for items
+  final bool enableSearch;
+
+  /// Width of the dropdown menu
+  final double? width;
+
+  /// Custom function to extract searchable text from item
+  /// If null, uses itemLabelBuilder
+  final String Function(T)? searchMatcher;
+
+  /// Custom widget builder for dropdown menu entries
+  /// Allows rich content like icons and subtitles
+  final Widget Function(T)? customItemBuilder;
+
+  /// Creates a Material Design 3 dropdown component
+  const AppDropdown({
+    required this.items,
+    required this.itemLabelBuilder,
+    this.value,
+    this.onChanged,
+    this.label,
+    this.hint,
+    this.helperText,
+    this.errorText,
+    this.leadingIcon,
+    this.enabled = true,
+    this.enableSearch = false,
+    this.width,
+    this.searchMatcher,
+    this.customItemBuilder,
+    super.key,
+  });
+
+  /// Creates a dropdown with search enabled
+  const AppDropdown.withSearch({
+    required this.items,
+    required this.itemLabelBuilder,
+    this.value,
+    this.onChanged,
+    this.label,
+    this.hint,
+    this.helperText,
+    this.errorText,
+    this.leadingIcon,
+    this.enabled = true,
+    this.width,
+    this.searchMatcher,
+    this.customItemBuilder,
+    super.key,
+  }) : enableSearch = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final hasError = errorText != null && errorText!.isNotEmpty;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        DropdownMenu<T>(
+          initialSelection: value,
+          enabled: enabled,
+          width: width,
+          label: label != null ? Text(label!) : null,
+          hintText: hint,
+          leadingIcon: leadingIcon != null ? Icon(leadingIcon) : null,
+          enableSearch: enableSearch,
+          enableFilter: enableSearch,
+          errorText: errorText,
+          dropdownMenuEntries: items.map((item) {
+            return DropdownMenuEntry<T>(
+              value: item,
+              label: itemLabelBuilder(item),
+              enabled: enabled,
+              // Use custom builder if provided
+              labelWidget: customItemBuilder != null
+                  ? customItemBuilder!(item)
+                  : null,
+            );
+          }).toList(),
+          onSelected: enabled ? onChanged : null,
+          inputDecorationTheme: InputDecorationTheme(
+            border: hasError
+                ? OutlineInputBorder(
+                    borderSide: BorderSide(color: theme.colorScheme.error),
+                  )
+                : null,
+            enabledBorder: hasError
+                ? OutlineInputBorder(
+                    borderSide: BorderSide(color: theme.colorScheme.error),
+                  )
+                : null,
+          ),
+        ),
+        if (helperText != null && !hasError) ...[
+          const SizedBox(height: 4),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Text(
+              helperText!,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+/// A helper class for creating dropdown items with rich content
+///
+/// Use this when you need dropdown items with icons, subtitles,
+/// or other complex layouts.
+///
+/// Example:
+/// ```dart
+/// final items = [
+///   AppDropdownItem(
+///     value: 'us',
+///     label: 'United States',
+///     icon: Icons.flag,
+///     subtitle: 'USA',
+///   ),
+/// ];
+/// ```
+class AppDropdownItem<T> {
+  /// The actual value of this item
+  final T value;
+
+  /// Display label for the item
+  final String label;
+
+  /// Optional icon to display
+  final IconData? icon;
+
+  /// Optional subtitle text
+  final String? subtitle;
+
+  /// Creates a dropdown item with rich content
+  const AppDropdownItem({
+    required this.value,
+    required this.label,
+    this.icon,
+    this.subtitle,
+  });
+
+  /// Builds the widget representation of this item
+  Widget buildWidget(BuildContext context) {
+    return Row(
+      children: [
+        if (icon != null) ...[Icon(icon, size: 20), const SizedBox(width: 12)],
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(label),
+              if (subtitle != null)
+                Text(
+                  subtitle!,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AppDropdownItem<T> &&
+          runtimeType == other.runtimeType &&
+          value == other.value;
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
+  String toString() => 'AppDropdownItem(value: $value, label: $label)';
 }

--- a/packages/core_kit/lib/widgets/inputs/app_password_field.dart
+++ b/packages/core_kit/lib/widgets/inputs/app_password_field.dart
@@ -1,6 +1,304 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppPasswordField {
-  const AppPasswordField();
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Password strength level enumeration
+enum PasswordStrength {
+  /// Weak password (length < 8 or simple patterns)
+  weak,
+
+  /// Medium password (meets basic requirements)
+  medium,
+
+  /// Strong password (meets all requirements with complexity)
+  strong,
+}
+
+/// A Material Design 3 password input field with security features.
+///
+/// This specialized text field extends the standard text input with
+/// password-specific functionality including:
+/// - Obscured text display with visibility toggle
+/// - Password strength indicator
+/// - Copy/paste prevention option
+/// - Integration with password validators
+/// - Accessibility support for screen readers
+///
+/// Security Best Practices:
+/// - Use [preventCopyPaste] carefully: while it enhances security by
+///   preventing clipboard access, it may impact user experience,
+///   especially for users relying on password managers. Consider
+///   disabling it for login forms and enabling it only for critical
+///   operations like password creation or admin actions.
+/// - Enable [showStrengthIndicator] for password creation flows to
+///   guide users toward creating stronger passwords.
+///
+/// Example:
+/// ```dart
+/// AppPasswordField(
+///   label: 'Password',
+///   onChanged: (value) => print('Password: $value'),
+///   showStrengthIndicator: true,
+/// )
+/// ```
+class AppPasswordField extends StatefulWidget {
+  /// Controller for the password field
+  final TextEditingController? controller;
+
+  /// Label text displayed above the field
+  final String? label;
+
+  /// Hint text displayed when field is empty
+  final String? hint;
+
+  /// Helper text displayed below the field
+  final String? helperText;
+
+  /// Error text displayed below the field
+  final String? errorText;
+
+  /// Callback when password changes
+  final ValueChanged<String>? onChanged;
+
+  /// Callback when field is submitted
+  final ValueChanged<String>? onSubmitted;
+
+  /// Whether the field is enabled
+  final bool enabled;
+
+  /// Whether to show password strength indicator
+  final bool showStrengthIndicator;
+
+  /// Whether to prevent copy/paste operations
+  final bool preventCopyPaste;
+
+  /// Whether to show visibility toggle icon
+  final bool showVisibilityToggle;
+
+  /// Whether to show lock prefix icon
+  final bool showLockIcon;
+
+  /// Autofocus the field
+  final bool autofocus;
+
+  /// Text input action
+  final TextInputAction? textInputAction;
+
+  /// Auto-fill hints for browser/OS integration
+  final Iterable<String>? autofillHints;
+
+  /// Creates an AppPasswordField
+  const AppPasswordField({
+    this.controller,
+    this.label,
+    this.hint,
+    this.helperText,
+    this.errorText,
+    this.onChanged,
+    this.onSubmitted,
+    this.enabled = true,
+    this.showStrengthIndicator = false,
+    this.preventCopyPaste = false,
+    this.showVisibilityToggle = true,
+    this.showLockIcon = false,
+    this.autofocus = false,
+    this.textInputAction,
+    this.autofillHints,
+    super.key,
+  });
+
+  @override
+  State<AppPasswordField> createState() => _AppPasswordFieldState();
+}
+
+class _AppPasswordFieldState extends State<AppPasswordField> {
+  late TextEditingController _controller;
+  bool _obscureText = true;
+  PasswordStrength _strength = PasswordStrength.weak;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = widget.controller ?? TextEditingController();
+    _controller.addListener(_updatePasswordStrength);
+  }
+
+  @override
+  void dispose() {
+    if (widget.controller == null) {
+      _controller.dispose();
+    }
+    super.dispose();
+  }
+
+  void _updatePasswordStrength() {
+    if (widget.showStrengthIndicator) {
+      setState(() {
+        _strength = _calculatePasswordStrength(_controller.text);
+      });
+    }
+  }
+
+  /// Calculates password strength based on various criteria
+  PasswordStrength _calculatePasswordStrength(String password) {
+    if (password.isEmpty) {
+      return PasswordStrength.weak;
+    }
+
+    int score = 0;
+
+    // Length check
+    if (password.length >= 8) score++;
+    if (password.length >= 12) score++;
+
+    // Character variety checks
+    if (RegExp(r'[a-z]').hasMatch(password)) score++; // lowercase
+    if (RegExp(r'[A-Z]').hasMatch(password)) score++; // uppercase
+    if (RegExp(r'[0-9]').hasMatch(password)) score++; // numbers
+    if (RegExp(r'[!@#$%^&*(),.?":{}|<>]').hasMatch(password)) {
+      score++; // special chars
+    }
+
+    // Calculate strength
+    if (score >= 5) {
+      return PasswordStrength.strong;
+    } else if (score >= 3) {
+      return PasswordStrength.medium;
+    } else {
+      return PasswordStrength.weak;
+    }
+  }
+
+  void _toggleVisibility() {
+    setState(() {
+      _obscureText = !_obscureText;
+    });
+  }
+
+  Color _getStrengthColor(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    switch (_strength) {
+      case PasswordStrength.weak:
+        return colorScheme.error;
+      case PasswordStrength.medium:
+        return colorScheme.tertiary;
+      case PasswordStrength.strong:
+        return colorScheme.primary;
+    }
+  }
+
+  String _getStrengthText() {
+    switch (_strength) {
+      case PasswordStrength.weak:
+        return 'Weak';
+      case PasswordStrength.medium:
+        return 'Medium';
+      case PasswordStrength.strong:
+        return 'Strong';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Semantics(
+          label: widget.label ?? 'Password field',
+          hint: _obscureText
+              ? 'Password is hidden. Tap eye icon to show password.'
+              : 'Password is visible. Tap eye icon to hide password.',
+          child: TextField(
+            controller: _controller,
+            obscureText: _obscureText,
+            enabled: widget.enabled,
+            autofocus: widget.autofocus,
+            keyboardType: TextInputType.visiblePassword,
+            textInputAction: widget.textInputAction ?? TextInputAction.done,
+            autofillHints: widget.autofillHints ?? [AutofillHints.password],
+            enableInteractiveSelection: !widget.preventCopyPaste,
+            contextMenuBuilder: widget.preventCopyPaste
+                ? (context, editableTextState) => const SizedBox.shrink()
+                : null,
+            inputFormatters: widget.preventCopyPaste
+                ? [
+                    FilteringTextInputFormatter.deny(
+                      RegExp(r'[\u0000-\u001F\u007F-\u009F]'),
+                    ),
+                  ]
+                : null,
+            decoration: InputDecoration(
+              labelText: widget.label,
+              hintText: widget.hint,
+              helperText: widget.helperText,
+              errorText: widget.errorText,
+              prefixIcon: widget.showLockIcon
+                  ? Icon(
+                      Icons.lock_outline,
+                      semanticLabel: 'Password lock icon',
+                    )
+                  : null,
+              suffixIcon: widget.showVisibilityToggle
+                  ? Semantics(
+                      label: _obscureText ? 'Show password' : 'Hide password',
+                      child: IconButton(
+                        icon: Icon(
+                          _obscureText
+                              ? Icons.visibility_off_outlined
+                              : Icons.visibility_outlined,
+                        ),
+                        onPressed: widget.enabled ? _toggleVisibility : null,
+                        tooltip: _obscureText
+                            ? 'Show password'
+                            : 'Hide password',
+                      ),
+                    )
+                  : null,
+            ),
+            onChanged: widget.onChanged,
+            onSubmitted: widget.onSubmitted,
+          ),
+        ),
+        if (widget.showStrengthIndicator &&
+            _controller.text.isNotEmpty &&
+            widget.errorText == null)
+          Padding(
+            padding: const EdgeInsets.only(top: 8.0, left: 12.0),
+            child: Row(
+              children: [
+                // Strength bars
+                for (int i = 0; i < 3; i++)
+                  Expanded(
+                    child: Container(
+                      height: 4,
+                      margin: EdgeInsets.only(right: i < 2 ? 4.0 : 0),
+                      decoration: BoxDecoration(
+                        color: i <= _strength.index
+                            ? _getStrengthColor(context)
+                            : colorScheme.surfaceContainerHighest,
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                  ),
+                const SizedBox(width: 8),
+                // Strength text
+                Text(
+                  _getStrengthText(),
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: _getStrengthColor(context),
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
 }

--- a/packages/core_kit/lib/widgets/inputs/app_radio_group.dart
+++ b/packages/core_kit/lib/widgets/inputs/app_radio_group.dart
@@ -1,6 +1,450 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppRadioGroup {
-  const AppRadioGroup();
+import 'package:flutter/material.dart';
+
+/// A model class representing a single option in an [AppRadioGroup].
+///
+/// Each option has a [value] of type [T], a [label] for display,
+/// and optional [description], [icon], and [enabled] state.
+///
+/// ## Example
+///
+/// ```dart
+/// final options = [
+///   RadioOption(value: 'male', label: 'Male', icon: Icons.male),
+///   RadioOption(value: 'female', label: 'Female', icon: Icons.female),
+///   RadioOption(value: 'other', label: 'Other'),
+/// ];
+/// ```
+class RadioOption<T> {
+  /// Creates a radio option with the given properties.
+  const RadioOption({
+    required this.value,
+    required this.label,
+    this.description,
+    this.icon,
+    this.enabled = true,
+  });
+
+  /// The value associated with this option.
+  ///
+  /// This value is passed to [AppRadioGroup.onChanged] when selected.
+  final T value;
+
+  /// The text label displayed for this option.
+  final String label;
+
+  /// An optional description displayed below the label.
+  ///
+  /// Useful for providing additional context about the option.
+  final String? description;
+
+  /// An optional icon displayed before the radio button.
+  final IconData? icon;
+
+  /// Whether this individual option is enabled for selection.
+  ///
+  /// Defaults to true.
+  final bool enabled;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is RadioOption<T> &&
+        other.value == value &&
+        other.label == label;
+  }
+
+  @override
+  int get hashCode => value.hashCode ^ label.hashCode;
+}
+
+/// A signature for building custom radio option widgets.
+///
+/// The [context] is the build context, [option] is the radio option data,
+/// [isSelected] indicates if this option is currently selected, and
+/// [isEnabled] indicates if the option can be interacted with.
+typedef RadioOptionBuilder<T> =
+    Widget Function(
+      BuildContext context,
+      RadioOption<T> option,
+      bool isSelected,
+      bool isEnabled,
+    );
+
+/// A Material Design 3 radio button group widget that allows users to select
+/// exactly one option from a set of mutually exclusive choices.
+///
+/// The [AppRadioGroup] component supports:
+/// - Single-selection logic with mutually exclusive options
+/// - Vertical and horizontal layout variants
+/// - Optional group label/title
+/// - Disabled state for entire group or individual options
+/// - Error state with validation messages
+/// - Custom option builder for complex items
+/// - Icons and descriptions per option
+/// - Material Design 3 theming
+/// - Accessibility features
+///
+/// ## Basic Usage
+///
+/// ```dart
+/// String? selectedGender;
+///
+/// AppRadioGroup<String>(
+///   label: 'Select Gender',
+///   value: selectedGender,
+///   options: [
+///     RadioOption(value: 'male', label: 'Male'),
+///     RadioOption(value: 'female', label: 'Female'),
+///     RadioOption(value: 'other', label: 'Other'),
+///   ],
+///   onChanged: (value) {
+///     setState(() {
+///       selectedGender = value;
+///     });
+///   },
+/// )
+/// ```
+///
+/// ## Horizontal Layout
+///
+/// ```dart
+/// AppRadioGroup<String>(
+///   direction: Axis.horizontal,
+///   value: selectedOption,
+///   options: options,
+///   onChanged: (value) {},
+/// )
+/// ```
+///
+/// ## With Icons and Descriptions
+///
+/// ```dart
+/// AppRadioGroup<String>(
+///   label: 'Payment Method',
+///   value: selectedPayment,
+///   options: [
+///     RadioOption(
+///       value: 'card',
+///       label: 'Credit Card',
+///       description: 'Pay with Visa/Mastercard',
+///       icon: Icons.credit_card,
+///     ),
+///     RadioOption(
+///       value: 'paypal',
+///       label: 'PayPal',
+///       description: 'Fast and secure',
+///       icon: Icons.paypal,
+///     ),
+///   ],
+///   onChanged: (value) {},
+/// )
+/// ```
+///
+/// ## Error State
+///
+/// ```dart
+/// AppRadioGroup<String>(
+///   label: 'Select an option',
+///   value: null,
+///   options: options,
+///   error: true,
+///   errorText: 'Please select an option',
+///   onChanged: (value) {},
+/// )
+/// ```
+///
+/// ## Material Design 3 Specifications
+///
+/// - Radio size: 20dp diameter
+/// - Touch target: 48dp minimum
+/// - Vertical spacing: 12dp between options
+/// - Horizontal spacing: 16dp between options
+/// - Label spacing: 12dp from radio button to label text
+/// - Colors: Uses theme's [ColorScheme] tokens
+///
+/// ## Accessibility
+///
+/// - Minimum touch target of 48dp
+/// - Semantic labels for screen readers
+/// - Group semantics for radio button sets
+/// - Keyboard navigation support
+///
+/// See also:
+/// - [Material Design 3 Radio](https://m3.material.io/components/radio-button)
+/// - [Radio] - Flutter's base radio button widget
+/// - [RadioGroup] - Flutter 3.32+ grouping widget for radio buttons
+class AppRadioGroup<T> extends StatelessWidget {
+  /// Creates a Material Design 3 radio button group.
+  ///
+  /// The [options] list must not be empty.
+  const AppRadioGroup({
+    super.key,
+    required this.options,
+    required this.onChanged,
+    this.value,
+    this.label,
+    this.direction = Axis.vertical,
+    this.enabled = true,
+    this.error = false,
+    this.errorText,
+    this.optionBuilder,
+    this.activeColor,
+    this.spacing,
+  });
+
+  /// The list of available options to choose from.
+  ///
+  /// Must contain at least one option.
+  final List<RadioOption<T>> options;
+
+  /// The currently selected value.
+  ///
+  /// If null, no option is selected.
+  final T? value;
+
+  /// Called when the user selects an option.
+  ///
+  /// The radio group passes the selected value to the callback.
+  /// If null, the entire group is disabled.
+  final ValueChanged<T?>? onChanged;
+
+  /// Optional label displayed above the radio group.
+  ///
+  /// Uses titleMedium typography.
+  final String? label;
+
+  /// The layout direction for the options.
+  ///
+  /// Use [Axis.vertical] for stacked options (default) or
+  /// [Axis.horizontal] for side-by-side options.
+  final Axis direction;
+
+  /// Whether the entire radio group is enabled.
+  ///
+  /// When false, all options are disabled regardless of their
+  /// individual [RadioOption.enabled] state.
+  ///
+  /// Defaults to true.
+  final bool enabled;
+
+  /// Whether to display the radio group in an error state.
+  ///
+  /// When true, the group uses error color styling.
+  ///
+  /// Defaults to false.
+  final bool error;
+
+  /// Error message to display below the group when [error] is true.
+  ///
+  /// If null, no error message is displayed even if [error] is true.
+  final String? errorText;
+
+  /// Optional custom builder for rendering each option.
+  ///
+  /// When provided, this builder is used instead of the default option layout.
+  /// The builder receives the option data, selection state, and enabled state.
+  final RadioOptionBuilder<T>? optionBuilder;
+
+  /// The color to use when an option is selected.
+  ///
+  /// If null, uses the theme's primary color.
+  final Color? activeColor;
+
+  /// The spacing between options.
+  ///
+  /// If null, uses 12dp for vertical and 16dp for horizontal layouts.
+  final double? spacing;
+
+  /// Whether this radio group is currently enabled.
+  bool get _isGroupEnabled => enabled && onChanged != null;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    // Determine active color based on state
+    final effectiveActiveColor = error
+        ? colorScheme.error
+        : (activeColor ?? colorScheme.primary);
+
+    // Determine spacing based on direction
+    final effectiveSpacing =
+        spacing ?? (direction == Axis.vertical ? 12.0 : 16.0);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Group label
+        if (label != null) ...[
+          Text(
+            label!,
+            style: theme.textTheme.titleMedium?.copyWith(
+              color: error
+                  ? colorScheme.error
+                  : (_isGroupEnabled
+                        ? colorScheme.onSurface
+                        : colorScheme.onSurface.withValues(alpha: 0.38)),
+            ),
+          ),
+          const SizedBox(height: 8),
+        ],
+
+        // Radio options with RadioGroup wrapper for Flutter 3.32+
+        IgnorePointer(
+          ignoring: !_isGroupEnabled,
+          child: RadioGroup<T>(
+            groupValue: value,
+            onChanged: onChanged ?? (_) {},
+            child: _buildOptionsLayout(
+              context,
+              effectiveActiveColor,
+              effectiveSpacing,
+            ),
+          ),
+        ),
+
+        // Error text
+        if (error && errorText != null) ...[
+          const SizedBox(height: 4),
+          Padding(
+            padding: const EdgeInsets.only(left: 12.0),
+            child: Text(
+              errorText!,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: colorScheme.error,
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  /// Builds the options layout based on [direction].
+  Widget _buildOptionsLayout(
+    BuildContext context,
+    Color activeColor,
+    double spacing,
+  ) {
+    final optionWidgets = options.map((option) {
+      return _buildOptionTile(context, option, activeColor);
+    }).toList();
+
+    if (direction == Axis.horizontal) {
+      return Wrap(
+        spacing: spacing,
+        runSpacing: spacing,
+        children: optionWidgets,
+      );
+    }
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (int i = 0; i < optionWidgets.length; i++) ...[
+          optionWidgets[i],
+          if (i < optionWidgets.length - 1) SizedBox(height: spacing),
+        ],
+      ],
+    );
+  }
+
+  /// Builds a single radio option tile.
+  Widget _buildOptionTile(
+    BuildContext context,
+    RadioOption<T> option,
+    Color activeColor,
+  ) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    final isSelected = value == option.value;
+    final isOptionEnabled = _isGroupEnabled && option.enabled;
+
+    // Use custom builder if provided
+    if (optionBuilder != null) {
+      return GestureDetector(
+        onTap: isOptionEnabled ? () => onChanged?.call(option.value) : null,
+        child: optionBuilder!(context, option, isSelected, isOptionEnabled),
+      );
+    }
+
+    // Default option layout
+    return InkWell(
+      onTap: isOptionEnabled ? () => onChanged?.call(option.value) : null,
+      borderRadius: BorderRadius.circular(8),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4.0),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: option.description != null
+              ? CrossAxisAlignment.start
+              : CrossAxisAlignment.center,
+          children: [
+            // Icon (if provided)
+            if (option.icon != null) ...[
+              Icon(
+                option.icon,
+                size: 24,
+                color: isOptionEnabled
+                    ? (isSelected ? activeColor : colorScheme.onSurfaceVariant)
+                    : colorScheme.onSurface.withValues(alpha: 0.38),
+              ),
+              const SizedBox(width: 8),
+            ],
+
+            // Radio button - wrapped in IgnorePointer to prevent double-trigger
+            // since InkWell handles the tap and RadioGroup manages the state
+            IgnorePointer(
+              child: SizedBox(
+                width: 48,
+                height: 48,
+                child: Radio<T>.adaptive(
+                  value: option.value,
+                  toggleable: false,
+                  activeColor: activeColor,
+                  materialTapTargetSize: MaterialTapTargetSize.padded,
+                ),
+              ),
+            ),
+
+            // Label and description
+            Flexible(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    option.label,
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      color: isOptionEnabled
+                          ? colorScheme.onSurface
+                          : colorScheme.onSurface.withValues(alpha: 0.38),
+                    ),
+                  ),
+                  if (option.description != null) ...[
+                    const SizedBox(height: 2),
+                    Text(
+                      option.description!,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: isOptionEnabled
+                            ? colorScheme.onSurfaceVariant
+                            : colorScheme.onSurface.withValues(alpha: 0.38),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }

--- a/packages/core_kit/lib/widgets/inputs/app_search_field.dart
+++ b/packages/core_kit/lib/widgets/inputs/app_search_field.dart
@@ -1,6 +1,233 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppSearchField {
-  const AppSearchField();
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+/// A Material Design 3 search field with debounced input and search-specific features.
+///
+/// AppSearchField extends the standard text field with search-optimized functionality:
+/// - Debounced input to reduce unnecessary API calls
+/// - Clear button that appears when text is entered
+/// - Search icon prefix for visual clarity
+/// - Loading indicator support for async operations
+/// - Configurable debounce delay (default 300ms)
+///
+/// Example:
+/// ```dart
+/// AppSearchField(
+///   hint: 'Search products...',
+///   onSearchChanged: (query) {
+///     // Triggered after debounce delay
+///     performSearch(query);
+///   },
+///   onSearchSubmitted: (query) {
+///     // Triggered immediately on submit
+///     executeSearch(query);
+///   },
+/// )
+/// ```
+class AppSearchField extends StatefulWidget {
+  /// Controller for the search field
+  final TextEditingController? controller;
+
+  /// Hint text displayed when field is empty
+  final String? hint;
+
+  /// Callback triggered after debounce delay when text changes
+  final ValueChanged<String>? onSearchChanged;
+
+  /// Callback triggered immediately when search is submitted
+  final ValueChanged<String>? onSearchSubmitted;
+
+  /// Whether to show loading indicator
+  final bool isLoading;
+
+  /// Whether the field is enabled
+  final bool enabled;
+
+  /// Whether to auto-focus on mount
+  final bool autofocus;
+
+  /// Debounce delay in milliseconds (default 300ms)
+  final int debounceDelay;
+
+  /// Whether to clear field on submit
+  final bool clearOnSubmit;
+
+  /// Creates an AppSearchField
+  const AppSearchField({
+    this.controller,
+    this.hint,
+    this.onSearchChanged,
+    this.onSearchSubmitted,
+    this.isLoading = false,
+    this.enabled = true,
+    this.autofocus = false,
+    this.debounceDelay = 300,
+    this.clearOnSubmit = false,
+    super.key,
+  });
+
+  @override
+  State<AppSearchField> createState() => _AppSearchFieldState();
+}
+
+class _AppSearchFieldState extends State<AppSearchField> {
+  late TextEditingController _controller;
+  Timer? _debounceTimer;
+  bool _isControllerInternal = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = widget.controller ?? TextEditingController();
+    _isControllerInternal = widget.controller == null;
+  }
+
+  @override
+  void didUpdateWidget(AppSearchField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.controller != oldWidget.controller) {
+      if (_isControllerInternal) {
+        _controller.dispose();
+      }
+      _controller = widget.controller ?? TextEditingController();
+      _isControllerInternal = widget.controller == null;
+    }
+  }
+
+  @override
+  void dispose() {
+    _debounceTimer?.cancel();
+    if (_isControllerInternal) {
+      _controller.dispose();
+    }
+    super.dispose();
+  }
+
+  void _onTextChanged(String query) {
+    // Cancel previous timer
+    _debounceTimer?.cancel();
+
+    // Start new debounce timer
+    _debounceTimer = Timer(Duration(milliseconds: widget.debounceDelay), () {
+      if (widget.onSearchChanged != null) {
+        widget.onSearchChanged!(query);
+      }
+    });
+
+    // Trigger setState to show/hide clear button
+    setState(() {});
+  }
+
+  void _onSubmitted(String query) {
+    // Cancel debounce timer on submit
+    _debounceTimer?.cancel();
+
+    // Immediately trigger submit callback
+    if (widget.onSearchSubmitted != null) {
+      widget.onSearchSubmitted!(query);
+    }
+
+    // Clear field if configured
+    if (widget.clearOnSubmit) {
+      _controller.clear();
+      setState(() {});
+    }
+  }
+
+  void _onClearTapped() {
+    _controller.clear();
+    _debounceTimer?.cancel();
+
+    // Notify listeners about empty query
+    if (widget.onSearchChanged != null) {
+      widget.onSearchChanged!('');
+    }
+
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final textTheme = theme.textTheme;
+
+    return TextField(
+      controller: _controller,
+      enabled: widget.enabled,
+      autofocus: widget.autofocus,
+      keyboardType: TextInputType.text,
+      textInputAction: TextInputAction.search,
+      onChanged: _onTextChanged,
+      onSubmitted: _onSubmitted,
+      style: textTheme.bodyLarge,
+      decoration: InputDecoration(
+        hintText: widget.hint ?? 'Search...',
+        hintStyle: textTheme.bodyLarge?.copyWith(
+          color: colorScheme.onSurfaceVariant.withValues(alpha: 0.6),
+        ),
+        prefixIcon: Icon(Icons.search, color: colorScheme.onSurfaceVariant),
+        suffixIcon: _buildSuffixIcon(),
+        filled: true,
+        fillColor: colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(28),
+          borderSide: BorderSide(color: colorScheme.outline),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(28),
+          borderSide: BorderSide(color: colorScheme.outline),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(28),
+          borderSide: BorderSide(color: colorScheme.primary, width: 2),
+        ),
+        disabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(28),
+          borderSide: BorderSide(
+            color: colorScheme.onSurface.withValues(alpha: 0.12),
+          ),
+        ),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 12,
+        ),
+      ),
+    );
+  }
+
+  Widget? _buildSuffixIcon() {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    // Show loading indicator if loading
+    if (widget.isLoading) {
+      return Padding(
+        padding: const EdgeInsets.all(12),
+        child: SizedBox(
+          width: 20,
+          height: 20,
+          child: CircularProgressIndicator(
+            strokeWidth: 2,
+            color: colorScheme.primary,
+          ),
+        ),
+      );
+    }
+
+    // Show clear button if text is not empty
+    if (_controller.text.isNotEmpty) {
+      return IconButton(
+        icon: Icon(Icons.clear, color: colorScheme.onSurfaceVariant),
+        onPressed: widget.enabled ? _onClearTapped : null,
+        tooltip: 'Clear search',
+      );
+    }
+
+    // No suffix icon
+    return null;
+  }
 }

--- a/packages/core_kit/lib/widgets/inputs/app_slider.dart
+++ b/packages/core_kit/lib/widgets/inputs/app_slider.dart
@@ -1,6 +1,575 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppSlider {
-  const AppSlider();
+import 'package:flutter/material.dart';
+
+/// A Material Design 3 slider widget that provides consistent value selection
+/// experience across the application.
+///
+/// The [AppSlider] component supports:
+/// - Continuous value selection (smooth sliding)
+/// - Discrete value selection (snap to divisions)
+/// - Range selection (min/max with two thumbs)
+/// - Optional value labels
+/// - Custom label formatters
+/// - Material Design 3 theming
+/// - Accessibility features
+///
+/// ## Basic Usage (Continuous)
+///
+/// ```dart
+/// double value = 50;
+///
+/// AppSlider(
+///   value: value,
+///   min: 0,
+///   max: 100,
+///   label: 'Volume',
+///   onChanged: (newValue) {
+///     setState(() {
+///       value = newValue;
+///     });
+///   },
+/// )
+/// ```
+///
+/// ## Discrete Slider with Divisions
+///
+/// ```dart
+/// double rating = 3;
+///
+/// AppSlider(
+///   value: rating,
+///   min: 0,
+///   max: 5,
+///   divisions: 5,
+///   label: 'Rating',
+///   showValueLabel: true,
+///   onChanged: (value) {
+///     setState(() {
+///       rating = value;
+///     });
+///   },
+/// )
+/// ```
+///
+/// ## Range Slider
+///
+/// ```dart
+/// RangeValues priceRange = RangeValues(100, 500);
+///
+/// AppSlider.range(
+///   values: priceRange,
+///   min: 0,
+///   max: 1000,
+///   label: 'Price Range',
+///   onChanged: (RangeValues values) {
+///     setState(() {
+///       priceRange = values;
+///     });
+///   },
+/// )
+/// ```
+///
+/// ## Custom Label Formatter
+///
+/// ```dart
+/// AppSlider(
+///   value: price,
+///   min: 0,
+///   max: 1000,
+///   label: 'Price',
+///   showValueLabel: true,
+///   labelFormatter: (value) => '\$${value.toStringAsFixed(0)}',
+///   onChanged: (value) => setState(() => price = value),
+/// )
+/// ```
+///
+/// ## Material Design 3 Specifications
+///
+/// - Track height: 4dp default
+/// - Thumb size: 20dp diameter (24dp when pressed)
+/// - Track width: Full width minus padding
+/// - Division markers: 2dp circles on track
+/// - Value label: Pill shape above thumb
+/// - Minimum touch target: 48x48dp
+///
+/// ## Accessibility
+///
+/// - Semantic labels from [label] property
+/// - Keyboard navigation (arrow keys adjust value)
+/// - Value announcements to screen readers
+/// - Disabled state properly announced
+/// - Minimum touch target size
+///
+/// See also:
+/// - [Material Design 3 Slider](https://m3.material.io/components/sliders/overview)
+/// - [Slider] - Flutter's base slider widget
+/// - [RangeSlider] - Flutter's base range slider widget
+class AppSlider extends StatelessWidget {
+  /// Creates a continuous or discrete slider.
+  ///
+  /// The [value], [min], [max], and [onChanged] parameters must not be null
+  /// unless the slider is disabled.
+  const AppSlider({
+    super.key,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.onChanged,
+    this.onChangeEnd,
+    this.label,
+    this.showValueLabel = false,
+    this.labelFormatter,
+    this.divisions,
+    this.showMinMaxIndicators = false,
+    this.activeColor,
+    this.inactiveColor,
+    this.thumbColor,
+    this.enabled = true,
+  }) : values = null,
+       onRangeChanged = null,
+       onRangeChangeEnd = null,
+       _isRange = false;
+
+  /// Creates a range slider with two thumbs for min/max selection.
+  ///
+  /// The [values], [min], [max], and [onRangeChanged] parameters must not
+  /// be null unless the slider is disabled.
+  const AppSlider.range({
+    super.key,
+    required this.values,
+    required this.min,
+    required this.max,
+    required this.onRangeChanged,
+    this.onRangeChangeEnd,
+    this.label,
+    this.showValueLabel = false,
+    this.labelFormatter,
+    this.divisions,
+    this.showMinMaxIndicators = false,
+    this.activeColor,
+    this.inactiveColor,
+    this.thumbColor,
+    this.enabled = true,
+  }) : value = null,
+       onChanged = null,
+       onChangeEnd = null,
+       _isRange = true;
+
+  /// The current value of the slider (for single-value mode).
+  ///
+  /// Must be between [min] and [max].
+  final double? value;
+
+  /// The current values of the range slider (for range mode).
+  ///
+  /// Both start and end must be between [min] and [max].
+  final RangeValues? values;
+
+  /// The minimum value the slider can have.
+  final double min;
+
+  /// The maximum value the slider can have.
+  final double max;
+
+  /// Called when the user is selecting a new value by dragging (single value).
+  ///
+  /// The slider passes the new value to the callback but does not actually
+  /// change state until the parent widget rebuilds the slider with the new
+  /// value.
+  final ValueChanged<double>? onChanged;
+
+  /// Called when the user is selecting new values by dragging (range mode).
+  final ValueChanged<RangeValues>? onRangeChanged;
+
+  /// Called when the user is done selecting a new value (single value).
+  ///
+  /// This callback is called when the user stops dragging the slider.
+  final ValueChanged<double>? onChangeEnd;
+
+  /// Called when the user is done selecting new values (range mode).
+  final ValueChanged<RangeValues>? onRangeChangeEnd;
+
+  /// Optional text label displayed above the slider.
+  ///
+  /// Provides context for what the slider controls.
+  final String? label;
+
+  /// Whether to show the current value label above the thumb.
+  ///
+  /// When true, a label with the current value appears above the thumb
+  /// during interaction or always (depending on Material behavior).
+  ///
+  /// Defaults to false.
+  final bool showValueLabel;
+
+  /// Optional function to format the value label text.
+  ///
+  /// If null, the value is displayed as is with [toStringAsFixed(0)].
+  /// Use this to add currency symbols, percentages, or custom formatting.
+  ///
+  /// Example:
+  /// ```dart
+  /// labelFormatter: (value) => '\$${value.toStringAsFixed(2)}'
+  /// ```
+  final String Function(double)? labelFormatter;
+
+  /// The number of discrete divisions for the slider.
+  ///
+  /// If null, the slider is continuous. If not null, the slider snaps
+  /// to the nearest division point.
+  ///
+  /// Must be greater than 0 if provided.
+  final int? divisions;
+
+  /// Whether to show min/max value indicators below the slider.
+  ///
+  /// Displays the [min] and [max] values at the ends of the slider track.
+  ///
+  /// Defaults to false.
+  final bool showMinMaxIndicators;
+
+  /// The color to use for the active portion of the slider track.
+  ///
+  /// If null, uses the theme's primary color.
+  final Color? activeColor;
+
+  /// The color to use for the inactive portion of the slider track.
+  ///
+  /// If null, uses the theme's surface variant color.
+  final Color? inactiveColor;
+
+  /// The color to use for the slider thumb.
+  ///
+  /// If null, uses the theme's primary color.
+  final Color? thumbColor;
+
+  /// Whether the slider is enabled for interaction.
+  ///
+  /// When false, the slider is displayed with reduced opacity and does not
+  /// respond to touch.
+  ///
+  /// Defaults to true.
+  final bool enabled;
+
+  /// Internal flag to track if this is a range slider.
+  final bool _isRange;
+
+  /// Whether this slider is currently enabled.
+  ///
+  /// A slider is considered enabled if [enabled] is true and the appropriate
+  /// callback ([onChanged] or [onRangeChanged]) is not null.
+  bool get _isEnabled =>
+      enabled && (_isRange ? onRangeChanged != null : onChanged != null);
+
+  /// Formats a value for display using the custom formatter or default.
+  String _formatValue(double val) {
+    if (labelFormatter != null) {
+      return labelFormatter!(val);
+    }
+    return val.toStringAsFixed(divisions != null ? 0 : 1);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Label
+        if (label != null) ...[
+          Text(
+            label!,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: _isEnabled
+                  ? colorScheme.onSurface
+                  : colorScheme.onSurface.withValues(alpha: 0.38),
+            ),
+          ),
+          const SizedBox(height: 8),
+        ],
+
+        // Slider
+        if (_isRange)
+          _buildRangeSlider(context, theme, colorScheme)
+        else
+          _buildSlider(context, theme, colorScheme),
+
+        // Min/Max Indicators
+        if (showMinMaxIndicators) ...[
+          const SizedBox(height: 4),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                _formatValue(min),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: _isEnabled
+                      ? colorScheme.onSurfaceVariant
+                      : colorScheme.onSurfaceVariant.withValues(alpha: 0.38),
+                ),
+              ),
+              Text(
+                _formatValue(max),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: _isEnabled
+                      ? colorScheme.onSurfaceVariant
+                      : colorScheme.onSurfaceVariant.withValues(alpha: 0.38),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ],
+    );
+  }
+
+  /// Builds the single-value slider widget.
+  Widget _buildSlider(
+    BuildContext context,
+    ThemeData theme,
+    ColorScheme colorScheme,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16.0),
+      child: SliderTheme(
+        data: SliderTheme.of(context).copyWith(
+          trackHeight: 4.0,
+          overlayShape: const RoundSliderOverlayShape(overlayRadius: 24.0),
+          valueIndicatorShape: const _ForceValueIndicatorShape(),
+        ),
+        child: Slider(
+          value: value ?? min,
+          min: min,
+          max: max,
+          divisions: divisions,
+          label: showValueLabel ? _formatValue(value ?? min) : null,
+          onChanged: _isEnabled ? onChanged : null,
+          onChangeEnd: onChangeEnd,
+          activeColor: activeColor ?? colorScheme.primary,
+          inactiveColor: inactiveColor ?? colorScheme.surfaceContainerHighest,
+          thumbColor: thumbColor ?? colorScheme.primary,
+        ),
+      ),
+    );
+  }
+
+  /// Builds the range slider widget.
+  Widget _buildRangeSlider(
+    BuildContext context,
+    ThemeData theme,
+    ColorScheme colorScheme,
+  ) {
+    final rangeValues = values ?? RangeValues(min, max);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16.0),
+      child: SliderTheme(
+        data: SliderTheme.of(context).copyWith(
+          trackHeight: 4.0,
+          overlayShape: const RoundSliderOverlayShape(overlayRadius: 24.0),
+          rangeValueIndicatorShape: const _ForceRangeValueIndicatorShape(),
+        ),
+        child: RangeSlider(
+          values: rangeValues,
+          min: min,
+          max: max,
+          divisions: divisions,
+          labels: showValueLabel
+              ? RangeLabels(
+                  _formatValue(rangeValues.start),
+                  _formatValue(rangeValues.end),
+                )
+              : null,
+          onChanged: _isEnabled ? onRangeChanged : null,
+          onChangeEnd: onRangeChangeEnd,
+          activeColor: activeColor ?? colorScheme.primary,
+          inactiveColor: inactiveColor ?? colorScheme.surfaceContainerHighest,
+        ),
+      ),
+    );
+  }
+}
+
+/// A custom value indicator shape that forces the label to follow the thumb
+/// without being clamped by screen boundaries.
+class _ForceValueIndicatorShape extends SliderComponentShape {
+  const _ForceValueIndicatorShape();
+
+  @override
+  Size getPreferredSize(
+    bool isEnabled,
+    bool isDiscrete, {
+    TextPainter? labelPainter,
+  }) {
+    if (labelPainter != null) {
+      labelPainter.layout();
+      return Size(labelPainter.width + 24, 48);
+    }
+    return const Size(48, 48);
+  }
+
+  @override
+  void paint(
+    PaintingContext context,
+    Offset center, {
+    required Animation<double> activationAnimation,
+    required Animation<double> enableAnimation,
+    required bool isDiscrete,
+    required TextPainter labelPainter,
+    required RenderBox parentBox,
+    required SliderThemeData sliderTheme,
+    required TextDirection textDirection,
+    required double value,
+    required double textScaleFactor,
+    required Size sizeWithOverflow,
+  }) {
+    final Canvas canvas = context.canvas;
+    final double scale = activationAnimation.value;
+    if (scale == 0.0) return;
+
+    // Shift vertically to be above the thumb
+    // Standard Material 3 spacing
+    final Offset labelCenter = center - const Offset(0, 44);
+
+    canvas.save();
+    canvas.translate(labelCenter.dx, labelCenter.dy);
+    canvas.scale(scale, scale);
+
+    final Paint paint = Paint()..color = sliderTheme.valueIndicatorColor!;
+
+    // Calculate dynamic width based on text
+    labelPainter.layout();
+    final double textWidth = labelPainter.width;
+    final double bubbleWidth = textWidth + 24.0; // 12px padding on each side
+    final double bubbleHeight = 32.0;
+
+    // Draw bubble shape (inverted tear drop)
+    final Path path = Path();
+
+    // Main bubble body
+    path.addRRect(
+      RRect.fromRectAndRadius(
+        Rect.fromCenter(
+          center: Offset.zero,
+          width: bubbleWidth,
+          height: bubbleHeight,
+        ),
+        const Radius.circular(16),
+      ),
+    );
+
+    // Little triangle pointing down
+    path.moveTo(-6, bubbleHeight / 2);
+    path.lineTo(0, (bubbleHeight / 2) + 6);
+    path.lineTo(6, bubbleHeight / 2);
+    path.close();
+
+    canvas.drawPath(path, paint);
+
+    // Draw text
+    labelPainter.paint(
+      canvas,
+      Offset(-textWidth / 2, -labelPainter.height / 2),
+    );
+
+    canvas.restore();
+  }
+}
+
+/// A custom value indicator shape for RangeSlider that forces the label to follow,
+/// matching the single slider implementation.
+class _ForceRangeValueIndicatorShape extends RangeSliderValueIndicatorShape {
+  const _ForceRangeValueIndicatorShape();
+
+  @override
+  Size getPreferredSize(
+    bool isEnabled,
+    bool isDiscrete, {
+    required TextPainter labelPainter,
+    required double textScaleFactor,
+  }) {
+    labelPainter.layout();
+    return Size(labelPainter.width + 24, 48);
+  }
+
+  @override
+  double getHorizontalShift({
+    RenderBox? parentBox,
+    Offset? center,
+    TextPainter? labelPainter,
+    Animation<double>? activationAnimation,
+    double? scale,
+    double? textScaleFactor,
+    Size? sizeWithOverflow,
+  }) {
+    // Return 0 to prevent any automatic horizontal shifting/clamping
+    return 0;
+  }
+
+  @override
+  void paint(
+    PaintingContext context,
+    Offset center, {
+    required Animation<double> activationAnimation,
+    required Animation<double> enableAnimation,
+    bool isDiscrete = false,
+    bool isOnTop = false,
+    required TextPainter labelPainter,
+    double value = 0.0,
+    required RenderBox parentBox,
+    required SliderThemeData sliderTheme,
+    TextDirection textDirection = TextDirection.ltr,
+    Thumb thumb = Thumb.start,
+    bool? isPressed,
+    Size? sizeWithOverflow,
+    double? textScaleFactor,
+  }) {
+    final Canvas canvas = context.canvas;
+    final double scale = activationAnimation.value;
+    if (scale == 0.0) return;
+
+    final Offset labelCenter = center - const Offset(0, 44);
+
+    canvas.save();
+    canvas.translate(labelCenter.dx, labelCenter.dy);
+    canvas.scale(scale, scale);
+
+    final Paint paint = Paint()..color = sliderTheme.valueIndicatorColor!;
+
+    // Calculate dynamic width
+    labelPainter.layout();
+    final double textWidth = labelPainter.width;
+    final double bubbleWidth = textWidth + 24.0;
+    final double bubbleHeight = 32.0;
+
+    final Path path = Path();
+    path.addRRect(
+      RRect.fromRectAndRadius(
+        Rect.fromCenter(
+          center: Offset.zero,
+          width: bubbleWidth,
+          height: bubbleHeight,
+        ),
+        const Radius.circular(16),
+      ),
+    );
+    path.moveTo(-6, bubbleHeight / 2);
+    path.lineTo(0, (bubbleHeight / 2) + 6);
+    path.lineTo(6, bubbleHeight / 2);
+    path.close();
+
+    canvas.drawPath(path, paint);
+
+    labelPainter.paint(
+      canvas,
+      Offset(-textWidth / 2, -labelPainter.height / 2),
+    );
+
+    canvas.restore();
+  }
 }

--- a/packages/core_kit/lib/widgets/inputs/app_switch.dart
+++ b/packages/core_kit/lib/widgets/inputs/app_switch.dart
@@ -1,6 +1,277 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppSwitch {
-  const AppSwitch();
+import 'package:flutter/material.dart';
+
+/// A Material Design 3 switch widget that provides consistent toggle switch
+/// experience across the application.
+///
+/// The [AppSwitch] component supports:
+/// - Standard on/off states
+/// - Optional text labels and subtitles
+/// - Optional leading icons
+/// - Material Design 3 theming
+/// - Custom color overrides
+/// - Accessibility features
+///
+/// ## Basic Usage
+///
+/// ```dart
+/// bool isEnabled = false;
+///
+/// AppSwitch(
+///   value: isEnabled,
+///   label: 'Enable notifications',
+///   onChanged: (value) {
+///     setState(() {
+///       isEnabled = value;
+///     });
+///   },
+/// )
+/// ```
+///
+/// ## With Subtitle
+///
+/// Provide additional context with a subtitle:
+///
+/// ```dart
+/// AppSwitch(
+///   value: true,
+///   label: 'Dark mode',
+///   subtitle: 'Use dark theme across the app',
+///   onChanged: (value) {
+///     // Handle state change
+///   },
+/// )
+/// ```
+///
+/// ## With Icon
+///
+/// Add a leading icon for visual context:
+///
+/// ```dart
+/// AppSwitch(
+///   value: false,
+///   label: 'Bluetooth',
+///   icon: Icons.bluetooth,
+///   onChanged: (value) {
+///     // Handle state change
+///   },
+/// )
+/// ```
+///
+/// ## Custom Colors
+///
+/// Override default colors:
+///
+/// ```dart
+/// AppSwitch(
+///   value: true,
+///   label: 'Custom switch',
+///   activeColor: Colors.green,
+///   activeTrackColor: Colors.green.withOpacity(0.5),
+///   onChanged: (value) {},
+/// )
+/// ```
+///
+/// ## Material Design 3 Specifications
+///
+/// - Track size: 52x32dp (M3 standard)
+/// - Thumb size: 16dp (off) → 24dp (on)
+/// - Touch target: Minimum 48x48dp
+/// - Animation: 200ms smooth transition
+/// - Colors: Uses theme's [ColorScheme] tokens
+///
+/// ## Accessibility
+///
+/// - Minimum touch target of 48x48dp
+/// - Semantic labels from [label] property
+/// - State changes announced to screen readers ("On", "Off")
+/// - Keyboard navigation support (Space/Enter to toggle)
+/// - Disabled state announced to screen readers
+///
+/// See also:
+/// - [Material Design 3 Switch](https://m3.material.io/components/switch/overview)
+/// - [Switch] - Flutter's base switch widget
+class AppSwitch extends StatelessWidget {
+  /// Creates a Material Design 3 switch.
+  ///
+  /// The [value] and [onChanged] parameters must not be null unless
+  /// the switch is disabled.
+  const AppSwitch({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    this.label,
+    this.subtitle,
+    this.icon,
+    this.activeColor,
+    this.inactiveColor,
+    this.activeTrackColor,
+    this.inactiveTrackColor,
+    this.enabled = true,
+  });
+
+  /// The current value of the switch.
+  ///
+  /// When true, the switch is in the "on" position.
+  /// When false, the switch is in the "off" position.
+  final bool value;
+
+  /// Called when the user toggles the switch.
+  ///
+  /// The switch passes the new value to the callback but does not actually
+  /// change state until the parent widget rebuilds the switch with the new
+  /// value.
+  ///
+  /// If this callback is null, the switch will be displayed as disabled.
+  final ValueChanged<bool>? onChanged;
+
+  /// Optional text label displayed next to the switch.
+  ///
+  /// When null, only the switch is displayed.
+  final String? label;
+
+  /// Optional subtitle text displayed below the label.
+  ///
+  /// Provides additional context or description for the switch.
+  /// Only displayed when [label] is also provided.
+  final String? subtitle;
+
+  /// Optional leading icon displayed before the label.
+  ///
+  /// Provides visual context for the switch purpose.
+  final IconData? icon;
+
+  /// The color to use when this switch is on.
+  ///
+  /// If null, uses the theme's primary color for the thumb.
+  final Color? activeColor;
+
+  /// The color to use when this switch is off.
+  ///
+  /// If null, uses the theme's outline color for the thumb.
+  final Color? inactiveColor;
+
+  /// The color to use for the track when this switch is on.
+  ///
+  /// If null, uses the theme's primary color.
+  final Color? activeTrackColor;
+
+  /// The color to use for the track when this switch is off.
+  ///
+  /// If null, uses the theme's surfaceContainerHighest color.
+  final Color? inactiveTrackColor;
+
+  /// Whether the switch is enabled for interaction.
+  ///
+  /// When false, the switch is displayed with reduced opacity and does not
+  /// respond to touch.
+  ///
+  /// Defaults to true.
+  final bool enabled;
+
+  /// Whether this switch is currently enabled.
+  ///
+  /// A switch is considered enabled if [enabled] is true and [onChanged]
+  /// is not null.
+  bool get _isEnabled => enabled && onChanged != null;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    // If both label and subtitle are null, return just the switch
+    if (label == null && subtitle == null) {
+      return _buildSwitch(theme, colorScheme);
+    }
+
+    // If there's a label or subtitle, build the full layout
+    return InkWell(
+      onTap: _isEnabled
+          ? () {
+              onChanged?.call(!value);
+            }
+          : null,
+      borderRadius: BorderRadius.circular(8),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 4.0),
+        child: Row(
+          children: [
+            // Leading icon (if provided)
+            if (icon != null) ...[
+              Icon(
+                icon,
+                size: 24,
+                color: _isEnabled
+                    ? colorScheme.onSurface
+                    : colorScheme.onSurface.withValues(alpha: 0.38),
+              ),
+              const SizedBox(width: 16),
+            ],
+            // Label and subtitle
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (label != null)
+                    Text(
+                      label!,
+                      style: theme.textTheme.bodyLarge?.copyWith(
+                        color: _isEnabled
+                            ? colorScheme.onSurface
+                            : colorScheme.onSurface.withValues(alpha: 0.38),
+                      ),
+                    ),
+                  if (subtitle != null) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      subtitle!,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: _isEnabled
+                            ? colorScheme.onSurfaceVariant
+                            : colorScheme.onSurfaceVariant.withValues(
+                                alpha: 0.38,
+                              ),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            const SizedBox(width: 16),
+            // Switch
+            _buildSwitch(theme, colorScheme),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Builds the switch widget with proper theming.
+  Widget _buildSwitch(ThemeData theme, ColorScheme colorScheme) {
+    return Switch(
+      value: value,
+      onChanged: _isEnabled ? onChanged : null,
+      thumbColor: activeColor != null || inactiveColor != null
+          ? WidgetStateProperty.resolveWith<Color?>((states) {
+              if (states.contains(WidgetState.selected)) {
+                return activeColor;
+              }
+              return inactiveColor;
+            })
+          : null,
+      trackColor: activeTrackColor != null || inactiveTrackColor != null
+          ? WidgetStateProperty.resolveWith<Color?>((states) {
+              if (states.contains(WidgetState.selected)) {
+                return activeTrackColor;
+              }
+              return inactiveTrackColor;
+            })
+          : null,
+      materialTapTargetSize: MaterialTapTargetSize.padded,
+    );
+  }
 }

--- a/packages/core_kit/lib/widgets/inputs/app_text_field.dart
+++ b/packages/core_kit/lib/widgets/inputs/app_text_field.dart
@@ -4,73 +4,246 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-/// A Material Design 3 text field widget with consistent styling.
-/// Wraps TextField with common configurations and Material 3 theming.
+/// A Material Design 3 text input component with consistent styling and theming.
+///
+/// This component wraps Flutter's [TextField] widget with Material Design 3
+/// styling, providing a standardized, accessible way to collect text input
+/// from users with built-in validation support, prefix/suffix icons, and
+/// multiple input variants.
+///
+/// ## Features
+///
+/// - **Material Design 3 Theming**: Automatically uses theme colors, typography,
+///   and spacing following MD3 guidelines
+/// - **Validation Support**: Displays error text with proper styling and state
+/// - **Prefix/Suffix Icons**: Support for leading and trailing icons with tap callbacks
+/// - **Multiple Input Types**: Single-line, multiline, numeric, email, URL, phone
+/// - **Input Formatters**: Built-in support for custom input formatting
+/// - **Character Counter**: Optional character count display with max length
+/// - **Accessibility**: Proper semantic labels and screen reader support
+/// - **State Management**: Handles enabled, disabled, read-only, focused, and error states
+///
+/// ## Usage
+///
+/// ```dart
+/// // Basic text field
+/// AppTextField(
+///   label: 'Full Name',
+///   hint: 'Enter your full name',
+///   onChanged: (value) => print(value),
+/// )
+///
+/// // Text field with validation error
+/// AppTextField(
+///   label: 'Email',
+///   errorText: 'Please enter a valid email',
+///   keyboardType: TextInputType.emailAddress,
+/// )
+///
+/// // Multiline text area
+/// AppTextField.multiline(
+///   label: 'Description',
+///   hint: 'Enter a detailed description',
+///   maxLines: 5,
+/// )
+///
+/// // Text field with prefix and suffix icons
+/// AppTextField(
+///   label: 'Search',
+///   prefixIcon: Icons.search,
+///   suffixIcon: Icons.clear,
+///   onSuffixIconTap: () => controller.clear(),
+/// )
+///
+/// // Numeric input with formatter
+/// AppTextField.numeric(
+///   label: 'Phone Number',
+///   hint: '(123) 456-7890',
+/// )
+/// ```
+///
+/// ## Common Use Cases
+///
+/// **Registration/Login Forms**:
+/// - Name, email, username fields with appropriate keyboard types
+/// - Integration with form validation frameworks
+///
+/// **Comments & Descriptions**:
+/// - Multi-line text areas with character limits
+/// - Helper text for user guidance
+///
+/// **Numeric Input**:
+/// - Phone numbers, age, quantity with numeric keyboards
+/// - Input formatters for proper formatting
+///
+/// **Search Functionality**:
+/// - Search bars with search icons and clear buttons
+/// - Real-time search feedback
+///
+/// **Formatted Input**:
+/// - Credit card numbers, dates with input formatters
+/// - Custom pattern validation
+///
+/// ## Material Design 3 Specifications
+///
+/// **States**:
+/// - Enabled: Default interactive state with outlined border
+/// - Focused: Primary color border (2px width)
+/// - Error: Error color border with error text
+/// - Disabled: Reduced opacity (38%)
+/// - Read-only: Enabled appearance without editing
+///
+/// **Typography**:
+/// - Label: bodyLarge with floating label animation
+/// - Input text: bodyLarge
+/// - Helper/Error text: bodySmall
+/// - Character counter: bodySmall
+///
+/// **Spacing**:
+/// - Vertical padding: 16dp inside field
+/// - Horizontal padding: 16dp inside field
+/// - Label to input: 4dp when floating
+/// - Helper text margin: 4dp from bottom
+/// - Icon padding: 12dp from edges
+///
+/// **Border Radius**: 4dp (M3 small)
+///
+/// ## Accessibility
+///
+/// - Semantic labels automatically set from label text
+/// - Error announcements for screen readers
+/// - Proper keyboard navigation
+/// - Minimum touch target sizes enforced
+///
+/// See also:
+/// - [Material Design 3 Text Fields](https://m3.material.io/components/text-fields)
+/// - [AppPasswordField] for password-specific functionality
+/// - [AppSearchField] for search-optimized text fields
 class AppTextField extends StatelessWidget {
-  /// Controller for the text field
+  /// Controller for the text field.
+  ///
+  /// If null, a controller will be created internally.
   final TextEditingController? controller;
 
-  /// Label text displayed above the field
+  /// Label text displayed above the field (floats when focused or filled).
   final String? label;
 
-  /// Hint text displayed when field is empty
+  /// Hint text displayed when field is empty and not focused.
   final String? hint;
 
-  /// Helper text displayed below the field
+  /// Helper text displayed below the field.
+  ///
+  /// Provides guidance to the user about what to enter.
   final String? helperText;
 
-  /// Error text displayed below the field
+  /// Error text displayed below the field in error color.
+  ///
+  /// When not null, the field displays error state with appropriate styling.
   final String? errorText;
 
-  /// Prefix icon
+  /// Prefix icon displayed at the start of the field.
   final IconData? prefixIcon;
 
-  /// Suffix icon
+  /// Callback when prefix icon is tapped.
+  final VoidCallback? onPrefixIconTap;
+
+  /// Suffix icon displayed at the end of the field.
   final IconData? suffixIcon;
 
-  /// Callback when suffix icon is tapped
+  /// Callback when suffix icon is tapped.
   final VoidCallback? onSuffixIconTap;
 
-  /// Callback when text changes
+  /// Callback when text changes.
+  ///
+  /// Called for every character change in the field.
   final ValueChanged<String>? onChanged;
 
-  /// Callback when editing is complete
+  /// Callback when editing is complete.
+  ///
+  /// Called when user presses "done" or field loses focus.
   final VoidCallback? onEditingComplete;
 
-  /// Callback when field is submitted
+  /// Callback when field is submitted.
+  ///
+  /// Called when user presses keyboard action button (e.g., "done", "search").
   final ValueChanged<String>? onSubmitted;
 
-  /// Whether the field is obscured (for passwords)
+  /// Callback when field gains or loses focus.
+  final ValueChanged<bool>? onFocusChange;
+
+  /// Whether the field text is obscured (for passwords).
+  ///
+  /// When true, text is replaced with dots/asterisks.
   final bool obscureText;
 
-  /// Whether the field is enabled
+  /// Whether the field is enabled for user interaction.
+  ///
+  /// When false, the field appears disabled and cannot be edited.
   final bool enabled;
 
-  /// Whether the field is read-only
+  /// Whether the field is read-only.
+  ///
+  /// When true, the field displays text but cannot be edited.
+  /// Unlike disabled state, read-only fields can be focused and text can be selected.
   final bool readOnly;
 
-  /// Maximum number of lines
+  /// Maximum number of lines for the text field.
+  ///
+  /// Set to null for unlimited lines (auto-expanding field).
+  /// Must be null or greater than or equal to [minLines].
   final int? maxLines;
 
-  /// Minimum number of lines
+  /// Minimum number of lines for the text field.
+  ///
+  /// The field will have at least this many lines even if empty.
   final int? minLines;
 
-  /// Maximum length of text
+  /// Maximum length of text that can be entered.
+  ///
+  /// When set, a character counter is displayed below the field.
   final int? maxLength;
 
-  /// Keyboard type
+  /// Whether to show character counter.
+  ///
+  /// Only applies when [maxLength] is set.
+  final bool showCharacterCounter;
+
+  /// Keyboard type for the text input.
+  ///
+  /// Determines which keyboard layout is shown to the user.
   final TextInputType? keyboardType;
 
-  /// Text input action
+  /// Text input action button label.
+  ///
+  /// Determines the action button shown on the keyboard (e.g., "done", "next", "search").
   final TextInputAction? textInputAction;
 
-  /// Input formatters
+  /// Input formatters to apply to the text.
+  ///
+  /// Used to format text as user types (e.g., phone number formatting).
   final List<TextInputFormatter>? inputFormatters;
 
-  /// Autofocus
+  /// Whether to autofocus this field on widget creation.
   final bool autofocus;
 
-  /// Creates an AppTextField
+  /// Focus node for controlling focus programmatically.
+  final FocusNode? focusNode;
+
+  /// Text capitalization mode.
+  final TextCapitalization textCapitalization;
+
+  /// Text alignment within the field.
+  final TextAlign textAlign;
+
+  /// Semantic label for accessibility.
+  ///
+  /// If null, uses [label] text.
+  final String? semanticLabel;
+
+  /// Auto-fill hints for browser/OS integration.
+  final Iterable<String>? autofillHints;
+
+  /// Creates a Material Design 3 text field.
   const AppTextField({
     this.controller,
     this.label,
@@ -78,25 +251,36 @@ class AppTextField extends StatelessWidget {
     this.helperText,
     this.errorText,
     this.prefixIcon,
+    this.onPrefixIconTap,
     this.suffixIcon,
     this.onSuffixIconTap,
     this.onChanged,
     this.onEditingComplete,
     this.onSubmitted,
+    this.onFocusChange,
     this.obscureText = false,
     this.enabled = true,
     this.readOnly = false,
     this.maxLines = 1,
     this.minLines,
     this.maxLength,
+    this.showCharacterCounter = true,
     this.keyboardType,
     this.textInputAction,
     this.inputFormatters,
     this.autofocus = false,
+    this.focusNode,
+    this.textCapitalization = TextCapitalization.none,
+    this.textAlign = TextAlign.start,
+    this.semanticLabel,
+    this.autofillHints,
     super.key,
   });
 
-  /// Creates a multiline text field
+  /// Creates a multiline text field (text area).
+  ///
+  /// Optimized for longer text input with multiple lines.
+  /// Default configuration includes 3-5 visible lines.
   const AppTextField.multiline({
     this.controller,
     this.label,
@@ -104,50 +288,247 @@ class AppTextField extends StatelessWidget {
     this.helperText,
     this.errorText,
     this.prefixIcon,
+    this.onPrefixIconTap,
     this.suffixIcon,
     this.onSuffixIconTap,
     this.onChanged,
     this.onEditingComplete,
     this.onSubmitted,
+    this.onFocusChange,
     this.enabled = true,
     this.readOnly = false,
     this.maxLines = 5,
     this.minLines = 3,
     this.maxLength,
+    this.showCharacterCounter = true,
     this.inputFormatters,
     this.autofocus = false,
+    this.focusNode,
+    this.textCapitalization = TextCapitalization.sentences,
+    this.textAlign = TextAlign.start,
+    this.semanticLabel,
+    this.autofillHints,
     super.key,
   }) : obscureText = false,
        keyboardType = TextInputType.multiline,
        textInputAction = TextInputAction.newline;
 
+  /// Creates a numeric input text field.
+  ///
+  /// Optimized for numeric input with numeric keyboard and appropriate formatting.
+  const AppTextField.numeric({
+    this.controller,
+    this.label,
+    this.hint,
+    this.helperText,
+    this.errorText,
+    this.prefixIcon,
+    this.onPrefixIconTap,
+    this.suffixIcon,
+    this.onSuffixIconTap,
+    this.onChanged,
+    this.onEditingComplete,
+    this.onSubmitted,
+    this.onFocusChange,
+    this.enabled = true,
+    this.readOnly = false,
+    this.maxLength,
+    this.showCharacterCounter = true,
+    this.inputFormatters,
+    this.autofocus = false,
+    this.focusNode,
+    this.textAlign = TextAlign.start,
+    this.semanticLabel,
+    this.autofillHints,
+    super.key,
+  }) : obscureText = false,
+       keyboardType = TextInputType.number,
+       textInputAction = TextInputAction.done,
+       maxLines = 1,
+       minLines = null,
+       textCapitalization = TextCapitalization.none;
+
+  /// Creates an email input text field.
+  ///
+  /// Optimized for email addresses with email keyboard layout.
+  const AppTextField.email({
+    this.controller,
+    this.label,
+    this.hint,
+    this.helperText,
+    this.errorText,
+    this.prefixIcon,
+    this.onPrefixIconTap,
+    this.suffixIcon,
+    this.onSuffixIconTap,
+    this.onChanged,
+    this.onEditingComplete,
+    this.onSubmitted,
+    this.onFocusChange,
+    this.enabled = true,
+    this.readOnly = false,
+    this.maxLength,
+    this.showCharacterCounter = false,
+    this.inputFormatters,
+    this.autofocus = false,
+    this.focusNode,
+    this.textAlign = TextAlign.start,
+    this.semanticLabel,
+    super.key,
+  }) : obscureText = false,
+       keyboardType = TextInputType.emailAddress,
+       textInputAction = TextInputAction.next,
+       maxLines = 1,
+       minLines = null,
+       textCapitalization = TextCapitalization.none,
+       autofillHints = const [AutofillHints.email];
+
+  /// Creates a phone number input text field.
+  ///
+  /// Optimized for phone numbers with phone keyboard layout.
+  const AppTextField.phone({
+    this.controller,
+    this.label,
+    this.hint,
+    this.helperText,
+    this.errorText,
+    this.prefixIcon,
+    this.onPrefixIconTap,
+    this.suffixIcon,
+    this.onSuffixIconTap,
+    this.onChanged,
+    this.onEditingComplete,
+    this.onSubmitted,
+    this.onFocusChange,
+    this.enabled = true,
+    this.readOnly = false,
+    this.maxLength,
+    this.showCharacterCounter = false,
+    this.inputFormatters,
+    this.autofocus = false,
+    this.focusNode,
+    this.textAlign = TextAlign.start,
+    this.semanticLabel,
+    super.key,
+  }) : obscureText = false,
+       keyboardType = TextInputType.phone,
+       textInputAction = TextInputAction.done,
+       maxLines = 1,
+       minLines = null,
+       textCapitalization = TextCapitalization.none,
+       autofillHints = const [AutofillHints.telephoneNumber];
+
+  /// Creates a URL input text field.
+  ///
+  /// Optimized for web addresses with URL keyboard layout.
+  const AppTextField.url({
+    this.controller,
+    this.label,
+    this.hint,
+    this.helperText,
+    this.errorText,
+    this.prefixIcon,
+    this.onPrefixIconTap,
+    this.suffixIcon,
+    this.onSuffixIconTap,
+    this.onChanged,
+    this.onEditingComplete,
+    this.onSubmitted,
+    this.onFocusChange,
+    this.enabled = true,
+    this.readOnly = false,
+    this.maxLength,
+    this.showCharacterCounter = false,
+    this.inputFormatters,
+    this.autofocus = false,
+    this.focusNode,
+    this.textAlign = TextAlign.start,
+    this.semanticLabel,
+    super.key,
+  }) : obscureText = false,
+       keyboardType = TextInputType.url,
+       textInputAction = TextInputAction.done,
+       maxLines = 1,
+       minLines = null,
+       textCapitalization = TextCapitalization.none,
+       autofillHints = const [AutofillHints.url];
+
   @override
   Widget build(BuildContext context) {
-    return TextField(
-      controller: controller,
-      decoration: InputDecoration(
-        labelText: label,
-        hintText: hint,
-        helperText: helperText,
-        errorText: errorText,
-        prefixIcon: prefixIcon != null ? Icon(prefixIcon) : null,
-        suffixIcon: suffixIcon != null
-            ? IconButton(icon: Icon(suffixIcon), onPressed: onSuffixIconTap)
-            : null,
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Focus(
+      onFocusChange: onFocusChange,
+      child: TextField(
+        controller: controller,
+        focusNode: focusNode,
+        decoration: InputDecoration(
+          labelText: label,
+          hintText: hint,
+          helperText: helperText,
+          errorText: errorText,
+          prefixIcon: prefixIcon != null
+              ? IconButton(
+                  icon: Icon(prefixIcon),
+                  onPressed: onPrefixIconTap,
+                  color: errorText != null ? colorScheme.error : null,
+                )
+              : null,
+          suffixIcon: suffixIcon != null
+              ? IconButton(
+                  icon: Icon(suffixIcon),
+                  onPressed: onSuffixIconTap,
+                  color: errorText != null ? colorScheme.error : null,
+                )
+              : null,
+          counterText: showCharacterCounter ? null : '',
+          border: OutlineInputBorder(borderRadius: BorderRadius.circular(4.0)),
+          enabledBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(4.0),
+            borderSide: BorderSide(color: colorScheme.outline, width: 1.0),
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(4.0),
+            borderSide: BorderSide(color: colorScheme.primary, width: 2.0),
+          ),
+          errorBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(4.0),
+            borderSide: BorderSide(color: colorScheme.error, width: 1.0),
+          ),
+          focusedErrorBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(4.0),
+            borderSide: BorderSide(color: colorScheme.error, width: 2.0),
+          ),
+          disabledBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(4.0),
+            borderSide: BorderSide(
+              color: colorScheme.outline.withValues(alpha: 0.38),
+              width: 1.0,
+            ),
+          ),
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 16.0,
+            vertical: 16.0,
+          ),
+        ),
+        obscureText: obscureText,
+        enabled: enabled,
+        readOnly: readOnly,
+        maxLines: obscureText ? 1 : maxLines,
+        minLines: minLines,
+        maxLength: maxLength,
+        keyboardType: keyboardType,
+        textInputAction: textInputAction,
+        inputFormatters: inputFormatters,
+        autofocus: autofocus,
+        textCapitalization: textCapitalization,
+        textAlign: textAlign,
+        onChanged: onChanged,
+        onEditingComplete: onEditingComplete,
+        onSubmitted: onSubmitted,
+        autofillHints: autofillHints,
       ),
-      obscureText: obscureText,
-      enabled: enabled,
-      readOnly: readOnly,
-      maxLines: obscureText ? 1 : maxLines,
-      minLines: minLines,
-      maxLength: maxLength,
-      keyboardType: keyboardType,
-      textInputAction: textInputAction,
-      inputFormatters: inputFormatters,
-      autofocus: autofocus,
-      onChanged: onChanged,
-      onEditingComplete: onEditingComplete,
-      onSubmitted: onSubmitted,
     );
   }
 }

--- a/packages/core_kit/lib/widgets/surfaces/app_card.dart
+++ b/packages/core_kit/lib/widgets/surfaces/app_card.dart
@@ -3,73 +3,167 @@
 
 import 'package:flutter/material.dart';
 
+import '../../theme/app_radius.dart';
+
 /// A Material Design 3 card widget with consistent styling.
-/// Provides elevation, padding, and optional tap handling.
+///
+/// [AppCard] is a versatile surface container that groups related content and actions.
+/// It supports various styles including flat, elevated, and outlined variants.
+///
+/// Example:
+/// ```dart
+/// AppCard(
+///   onTap: () {},
+///   child: Text('Card Content'),
+/// )
+/// ```
 class AppCard extends StatelessWidget {
-  /// The widget to display inside the card
+  /// The widget to display inside the card.
   final Widget child;
 
-  /// Optional callback when the card is tapped
+  /// Optional callback when the card is tapped.
+  /// If provided, the card becomes interactive with a ripple effect.
   final VoidCallback? onTap;
 
-  /// Card elevation level (0-5)
+  /// Card elevation level.
+  /// - 0: Flat
+  /// - 1: Default
+  /// - 3: Elevated
   final double? elevation;
 
-  /// Internal padding of the card
+  /// Internal padding of the card.
   final EdgeInsetsGeometry? padding;
 
-  /// Card background color
+  /// Card background color.
   final Color? color;
 
-  /// Card border radius
-  final BorderRadius? borderRadius;
+  /// Card border radius. Defaults to [AppRadius.md] (12dp).
+  final BorderRadiusGeometry? borderRadius;
 
-  /// Creates an AppCard
+  /// External margin of the card.
+  final EdgeInsetsGeometry? margin;
+
+  /// Content clipping behavior.
+  final Clip? clipBehavior;
+
+  /// Color of the shadow when elevation is > 0.
+  final Color? shadowColor;
+
+  /// Overlay color for M3 elevation tint.
+  final Color? surfaceTintColor;
+
+  /// Whether to paint the border in front of the child.
+  final bool borderOnForeground;
+
+  /// Custom shape border.
+  final ShapeBorder? shape;
+
+  /// Creates a default [AppCard] with standard styling (1dp elevation).
   const AppCard({
     required this.child,
     this.onTap,
-    this.elevation,
+    this.elevation = 1.0,
     this.padding,
     this.color,
     this.borderRadius,
+    this.margin,
+    this.clipBehavior,
+    this.shadowColor,
+    this.surfaceTintColor,
+    this.borderOnForeground = true,
+    this.shape,
     super.key,
   });
 
-  /// Creates a flat card with minimal elevation
+  /// Creates a flat [AppCard] with no elevation (0dp).
+  /// Useful for grouping content on a surface without adding depth.
   const AppCard.flat({
     required this.child,
     this.onTap,
     this.padding,
     this.color,
     this.borderRadius,
+    this.margin,
+    this.clipBehavior,
+    this.shadowColor,
+    this.surfaceTintColor,
+    this.borderOnForeground = true,
+    this.shape,
     super.key,
   }) : elevation = 0;
 
-  /// Creates an elevated card with higher elevation
+  /// Creates an elevated [AppCard] with higher elevation (3dp).
+  /// Used for items that need more emphasis or separation.
   const AppCard.elevated({
     required this.child,
     this.onTap,
     this.padding,
     this.color,
     this.borderRadius,
+    this.margin,
+    this.clipBehavior,
+    this.shadowColor,
+    this.surfaceTintColor,
+    this.borderOnForeground = true,
+    this.shape,
     super.key,
-  }) : elevation = 4;
+  }) : elevation = 3;
+
+  /// Creates an outlined [AppCard] with a border and no elevation.
+  /// Useful for situations where elevation is not appropriate but separation is needed.
+  const AppCard.outlined({
+    required this.child,
+    this.onTap,
+    this.padding,
+    this.color,
+    this.borderRadius,
+    this.margin,
+    this.clipBehavior,
+    this.shadowColor,
+    this.surfaceTintColor,
+    this.borderOnForeground = true,
+    this.shape,
+    super.key,
+  }) : elevation = 0;
 
   @override
   Widget build(BuildContext context) {
-    final card = Card(
+    final theme = Theme.of(context);
+    final isOutlined = elevation == 0 && color == null && shape == null;
+
+    // Determine the shape with border radius
+    final effectiveShape =
+        shape ??
+        (isOutlined
+            ? RoundedRectangleBorder(
+                side: BorderSide(color: theme.colorScheme.outline),
+                borderRadius: borderRadius ?? AppRadius.mdRadius,
+              )
+            : RoundedRectangleBorder(
+                borderRadius: borderRadius ?? AppRadius.mdRadius,
+              ));
+
+    return Card(
       elevation: elevation,
       color: color,
-      shape: borderRadius != null
-          ? RoundedRectangleBorder(borderRadius: borderRadius!)
-          : null,
-      child: padding != null ? Padding(padding: padding!, child: child) : child,
+      shadowColor: shadowColor,
+      surfaceTintColor: surfaceTintColor,
+      margin: margin,
+      shape: effectiveShape,
+      clipBehavior: clipBehavior ?? Clip.hardEdge,
+      borderOnForeground: borderOnForeground,
+      child: onTap != null
+          ? InkWell(
+              onTap: onTap,
+              // Match the card's shape for the ripple
+              customBorder: effectiveShape,
+              child: padding != null
+                  ? Padding(padding: padding!, child: child)
+                  : child,
+            )
+          : (padding != null
+                ? Padding(padding: padding!, child: child)
+                : child),
     );
-
-    if (onTap != null) {
-      return InkWell(onTap: onTap, borderRadius: borderRadius, child: card);
-    }
-
-    return card;
   }
 }

--- a/packages/core_kit/lib/widgets/surfaces/app_list_tile.dart
+++ b/packages/core_kit/lib/widgets/surfaces/app_list_tile.dart
@@ -1,6 +1,218 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppListTile {
-  const AppListTile();
+import 'package:flutter/material.dart';
+import 'package:core_kit/theme/app_typography.dart';
+
+/// A Material Design 3 list tile widget.
+///
+/// A single fixed-height row that typically contains text, icons, and optional
+/// actions. List tiles provide a consistent layout with leading/trailing widgets
+/// and up to three lines of text.
+///
+/// The tile automatically adjusts its height based on:
+/// - One-line: 56dp (48dp if dense)
+/// - Two-line: 72dp (64dp if dense)
+/// - Three-line: 88dp (requires [isThreeLine] = true)
+///
+/// Example usage:
+///
+/// ```dart
+/// // Basic list tile
+/// AppListTile(
+///   leading: Icon(Icons.person),
+///   title: 'Profile',
+///   onTap: () => _openProfile(),
+/// )
+///
+/// // Two-line tile with subtitle
+/// AppListTile(
+///   leading: CircleAvatar(child: Icon(Icons.folder)),
+///   title: 'Documents',
+///   subtitle: '24 files',
+///   trailing: Icon(Icons.chevron_right),
+///   onTap: () => _openFolder(),
+/// )
+///
+/// // Settings tile with switch
+/// AppListTile(
+///   leading: Icon(Icons.notifications),
+///   title: 'Notifications',
+///   subtitle: 'Enable push notifications',
+///   trailing: Switch(value: _enabled, onChanged: _toggle),
+/// )
+/// ```
+///
+/// See also:
+/// - [ListTile], the underlying Material widget
+/// - Material Design 3 Lists: https://m3.material.io/components/lists
+class AppListTile extends StatelessWidget {
+  /// Creates a Material Design 3 list tile.
+  ///
+  /// The [title] parameter is required.
+  const AppListTile({
+    required this.title,
+    this.subtitle,
+    this.leading,
+    this.trailing,
+    this.onTap,
+    this.onLongPress,
+    this.selected = false,
+    this.enabled = true,
+    this.dense = false,
+    this.isThreeLine = false,
+    this.contentPadding,
+    this.tileColor,
+    this.selectedTileColor,
+    this.shape,
+    this.visualDensity,
+    super.key,
+  });
+
+  /// The primary content of the list tile.
+  ///
+  /// Displayed using Material Design 3 [AppTypography.bodyLarge] style
+  /// with [ColorScheme.onSurface] color (or [ColorScheme.onSecondaryContainer]
+  /// when selected).
+  final String title;
+
+  /// Additional content displayed below the title.
+  ///
+  /// Displayed using Material Design 3 [AppTypography.bodyMedium] style
+  /// with [ColorScheme.onSurfaceVariant] color.
+  /// For three-line layout, set [isThreeLine] to true.
+  final String? subtitle;
+
+  /// A widget to display before the title.
+  ///
+  /// Typically an [Icon] (24dp) or [CircleAvatar] (40dp).
+  final Widget? leading;
+
+  /// A widget to display after the title.
+  ///
+  /// Typically an [Icon], [Text], or interactive widget like [Switch].
+  final Widget? trailing;
+
+  /// Called when the user taps this list tile.
+  ///
+  /// If null and [enabled] is true, the tile is still interactive but
+  /// doesn't do anything when tapped.
+  final VoidCallback? onTap;
+
+  /// Called when the user long-presses on this list tile.
+  final VoidCallback? onLongPress;
+
+  /// Whether this list tile is part of a vertically dense list.
+  ///
+  /// Dense mode reduces the height:
+  /// - One-line: 56dp → 48dp
+  /// - Two-line: 72dp → 64dp
+  ///
+  /// Default is false.
+  final bool dense;
+
+  /// Whether this list tile is intended to display three lines of text.
+  ///
+  /// If true, the tile height increases to 88dp to accommodate the subtitle.
+  /// The subtitle should be limited to three lines of text.
+  ///
+  /// Default is false.
+  final bool isThreeLine;
+
+  /// Whether this list tile is currently selected.
+  ///
+  /// If true, the tile displays with [selectedTileColor] background and
+  /// appropriate text color from the theme.
+  ///
+  /// Default is false.
+  final bool selected;
+
+  /// Whether this list tile is interactive.
+  ///
+  /// If false, the tile appears disabled with reduced opacity and
+  /// [onTap] and [onLongPress] are ignored.
+  ///
+  /// Default is true.
+  final bool enabled;
+
+  /// The tile's internal padding.
+  ///
+  /// Default is EdgeInsets.symmetric(horizontal: 16.0).
+  final EdgeInsetsGeometry? contentPadding;
+
+  /// The tile's background color.
+  ///
+  /// If null, uses theme's surface color.
+  final Color? tileColor;
+
+  /// The tile's background color when [selected] is true.
+  ///
+  /// If null, uses theme's secondaryContainer color.
+  final Color? selectedTileColor;
+
+  /// The shape of the list tile's border.
+  ///
+  /// If null, no border is drawn.
+  final ShapeBorder? shape;
+
+  /// Defines how compact the tile's layout will be.
+  ///
+  /// This allows fine-tuning beyond the [dense] parameter.
+  final VisualDensity? visualDensity;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final textTheme = AppTypography.textTheme();
+
+    // Build title with proper typography and color
+    final titleWidget = Text(
+      title,
+      style: textTheme.bodyLarge?.copyWith(
+        color: selected
+            ? colorScheme.onSecondaryContainer
+            : colorScheme.onSurface,
+      ),
+    );
+
+    // Build subtitle with proper typography and color
+    final subtitleWidget = subtitle != null
+        ? Text(
+            subtitle!,
+            style: textTheme.bodyMedium?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+          )
+        : null;
+
+    return ListTile(
+      // Layout
+      contentPadding:
+          contentPadding ?? const EdgeInsets.symmetric(horizontal: 16.0),
+      dense: dense,
+      isThreeLine: isThreeLine,
+      visualDensity: visualDensity,
+
+      // Content
+      leading: leading,
+      title: titleWidget,
+      subtitle: subtitleWidget,
+      trailing: trailing,
+
+      // Interaction
+      onTap: enabled ? onTap : null,
+      onLongPress: enabled ? onLongPress : null,
+      enabled: enabled,
+      selected: selected,
+
+      // Styling
+      tileColor: tileColor,
+      selectedTileColor: selectedTileColor ?? colorScheme.secondaryContainer,
+      shape: shape,
+
+      // Ensure minimum 48dp touch target for accessibility
+      minVerticalPadding: dense ? 4.0 : 8.0,
+    );
+  }
 }

--- a/packages/core_kit/lib/widgets/surfaces/app_section_header.dart
+++ b/packages/core_kit/lib/widgets/surfaces/app_section_header.dart
@@ -1,6 +1,321 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppSectionHeader {
-  const AppSectionHeader();
+import 'package:flutter/material.dart';
+
+import '../../theme/app_spacing.dart';
+
+/// Defines the position of the divider relative to the section header.
+enum DividerPosition {
+  /// No divider is shown.
+  none,
+
+  /// Divider is shown above the section header.
+  above,
+
+  /// Divider is shown below the section header.
+  below,
+
+  /// Dividers are shown both above and below the section header.
+  both,
+}
+
+/// A Material Design 3 section header widget for organizing content.
+///
+/// [AppSectionHeader] is a visual divider that organizes content into logical
+/// groups by displaying a title and optional actions. It's commonly used in
+/// settings screens, forms, lists, and anywhere content needs to be categorized.
+///
+/// Section headers improve scannability and help users quickly find what they're
+/// looking for. They provide semantic structure for screen readers.
+///
+/// The widget follows M3 specifications:
+/// - Minimum height: 48dp (with single-line title)
+/// - Padding: 16dp horizontal, 8dp vertical (default)
+/// - Title: titleSmall (14sp, 500 weight)
+/// - Subtitle: bodySmall (12sp, regular weight)
+///
+/// Example:
+/// ```dart
+/// AppSectionHeader(
+///   title: 'Account Settings',
+/// )
+///
+/// AppSectionHeader(
+///   title: 'Privacy',
+///   subtitle: 'Manage your privacy and security settings',
+///   trailing: TextButton(
+///     onPressed: () {},
+///     child: Text('Edit'),
+///   ),
+/// )
+///
+/// // For sticky headers in scrollable content:
+/// CustomScrollView(
+///   slivers: [
+///     SliverPersistentHeader(
+///       pinned: true,
+///       delegate: SectionHeaderDelegate(
+///         child: AppSectionHeader(
+///           title: 'Pinned Section',
+///           backgroundColor: Theme.of(context).colorScheme.surface,
+///         ),
+///       ),
+///     ),
+///   ],
+/// )
+/// ```
+class AppSectionHeader extends StatelessWidget {
+  /// Creates a section header with the given [title].
+  ///
+  /// The [title] is the main text displayed in the section header.
+  const AppSectionHeader({
+    required this.title,
+    this.subtitle,
+    this.leading,
+    this.trailing,
+    this.padding,
+    this.showDivider = false,
+    this.dividerPosition = DividerPosition.below,
+    this.dividerIndent,
+    this.dividerEndIndent,
+    this.backgroundColor,
+    this.textStyle,
+    this.subtitleStyle,
+    this.isUpperCase = false,
+    this.minHeight = 48.0,
+    super.key,
+  });
+
+  /// The main title text of the section header.
+  ///
+  /// This is required and will be displayed prominently.
+  final String title;
+
+  /// An optional subtitle or description below the title.
+  ///
+  /// Use this to provide additional context about the section.
+  final String? subtitle;
+
+  /// An optional widget to display before the title.
+  ///
+  /// Typically an [Icon] widget.
+  final Widget? leading;
+
+  /// An optional widget to display after the title.
+  ///
+  /// Typically a [TextButton] or [IconButton] for section-level actions.
+  final Widget? trailing;
+
+  /// Custom padding for the section header.
+  ///
+  /// If null, defaults to horizontal 16dp and vertical 8dp padding.
+  final EdgeInsetsGeometry? padding;
+
+  /// Whether to show a divider.
+  ///
+  /// Defaults to false. When true, a divider is shown at the position
+  /// specified by [dividerPosition].
+  final bool showDivider;
+
+  /// The position of the divider relative to the section header content.
+  ///
+  /// Only applies when [showDivider] is true.
+  /// Defaults to [DividerPosition.below].
+  final DividerPosition dividerPosition;
+
+  /// The amount of empty space to the leading edge of the divider.
+  ///
+  /// If null, the divider extends to the edge of its parent.
+  final double? dividerIndent;
+
+  /// The amount of empty space to the trailing edge of the divider.
+  ///
+  /// If null, the divider extends to the edge of its parent.
+  final double? dividerEndIndent;
+
+  /// The background color of the section header.
+  ///
+  /// If null, the header has a transparent background.
+  /// Set this to an opaque color when using as a sticky header.
+  final Color? backgroundColor;
+
+  /// Custom text style for the title.
+  ///
+  /// If null, uses [TextTheme.titleSmall] with [ColorScheme.onSurfaceVariant].
+  final TextStyle? textStyle;
+
+  /// Custom text style for the subtitle.
+  ///
+  /// If null, uses [TextTheme.bodySmall] with [ColorScheme.onSurfaceVariant]
+  /// at 60% opacity.
+  final TextStyle? subtitleStyle;
+
+  /// Whether to display the title in uppercase.
+  ///
+  /// Defaults to false. M3 section headers often use uppercase styling.
+  final bool isUpperCase;
+
+  /// The minimum height of the section header.
+  ///
+  /// Defaults to 48dp as per Material Design 3 specifications.
+  final double minHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    // Build title text
+    final displayTitle = isUpperCase ? title.toUpperCase() : title;
+
+    final effectiveTitleStyle =
+        textStyle ??
+        theme.textTheme.titleSmall?.copyWith(
+          color: colorScheme.onSurfaceVariant,
+          fontWeight: FontWeight.w500,
+        );
+
+    final effectiveSubtitleStyle =
+        subtitleStyle ??
+        theme.textTheme.bodySmall?.copyWith(
+          color: colorScheme.onSurfaceVariant.withAlpha(153), // 60% opacity
+        );
+
+    final effectivePadding =
+        padding ??
+        const EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+          vertical: AppSpacing.sm,
+        );
+
+    // Build the content row with minimum height
+    Widget content = ConstrainedBox(
+      constraints: BoxConstraints(minHeight: minHeight),
+      child: Padding(
+        padding: effectivePadding,
+        child: Row(
+          children: [
+            if (leading != null) ...[
+              leading!,
+              const SizedBox(width: AppSpacing.sm),
+            ],
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(displayTitle, style: effectiveTitleStyle),
+                  if (subtitle != null) ...[
+                    const SizedBox(height: AppSpacing.xs / 2),
+                    Text(subtitle!, style: effectiveSubtitleStyle),
+                  ],
+                ],
+              ),
+            ),
+            if (trailing != null) trailing!,
+          ],
+        ),
+      ),
+    );
+
+    // Apply background color if specified
+    if (backgroundColor != null) {
+      content = ColoredBox(color: backgroundColor!, child: content);
+    }
+
+    // Build with dividers if needed
+    if (showDivider && dividerPosition != DividerPosition.none) {
+      final divider = Divider(
+        height: 1,
+        thickness: 1,
+        color: colorScheme.outlineVariant,
+        indent: dividerIndent,
+        endIndent: dividerEndIndent,
+      );
+
+      content = Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (dividerPosition == DividerPosition.above ||
+              dividerPosition == DividerPosition.both)
+            divider,
+          content,
+          if (dividerPosition == DividerPosition.below ||
+              dividerPosition == DividerPosition.both)
+            divider,
+        ],
+      );
+    }
+
+    // Wrap with semantics for accessibility
+    return Semantics(
+      header: true,
+      label: subtitle != null ? '$displayTitle, $subtitle' : displayTitle,
+      child: content,
+    );
+  }
+}
+
+/// A [SliverPersistentHeaderDelegate] for creating sticky section headers.
+///
+/// Use this delegate with [SliverPersistentHeader] to create section headers
+/// that stick to the top of the viewport when scrolling.
+///
+/// Example:
+/// ```dart
+/// CustomScrollView(
+///   slivers: [
+///     SliverPersistentHeader(
+///       pinned: true,
+///       delegate: SectionHeaderDelegate(
+///         child: AppSectionHeader(
+///           title: 'Pinned Section',
+///           backgroundColor: Theme.of(context).colorScheme.surface,
+///         ),
+///       ),
+///     ),
+///     SliverList(
+///       delegate: SliverChildListDelegate([
+///         // List items...
+///       ]),
+///     ),
+///   ],
+/// )
+/// ```
+class SectionHeaderDelegate extends SliverPersistentHeaderDelegate {
+  /// Creates a section header delegate.
+  ///
+  /// The [child] is typically an [AppSectionHeader] widget.
+  /// The [height] defaults to 48dp as per Material Design 3 specifications.
+  const SectionHeaderDelegate({required this.child, this.height = 48.0});
+
+  /// The widget to display as the section header.
+  final Widget child;
+
+  /// The height of the section header.
+  ///
+  /// Defaults to 48dp.
+  final double height;
+
+  @override
+  double get minExtent => height;
+
+  @override
+  double get maxExtent => height;
+
+  @override
+  Widget build(
+    BuildContext context,
+    double shrinkOffset,
+    bool overlapsContent,
+  ) {
+    return SizedBox.expand(child: child);
+  }
+
+  @override
+  bool shouldRebuild(SectionHeaderDelegate oldDelegate) {
+    return oldDelegate.child != child || oldDelegate.height != height;
+  }
 }

--- a/packages/core_kit/test/app_fab_test.dart
+++ b/packages/core_kit/test/app_fab_test.dart
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:core_kit/widgets/buttons/app_fab.dart';
+
+Widget _wrap(Widget child, {ThemeData? theme}) => MaterialApp(
+  theme: theme ?? ThemeData(useMaterial3: true),
+  home: Scaffold(body: Center(child: child)),
+);
+
+void main() {
+  group('AppFab', () {
+    testWidgets('default variant renders and is tappable', (tester) async {
+      int calls = 0;
+      await tester.pumpWidget(
+        _wrap(AppFab(icon: Icons.add, onPressed: () => calls++)),
+      );
+      expect(find.byType(FloatingActionButton), findsOneWidget);
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+      expect(calls, 1);
+    });
+
+    testWidgets('small/large/extended variants render', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          Wrap(
+            spacing: 8,
+            children: const [
+              AppFab.small(icon: Icons.filter_list),
+              AppFab.large(icon: Icons.camera_alt),
+              AppFab.extended(icon: Icons.edit, label: 'Compose'),
+            ],
+          ),
+        ),
+      );
+      expect(find.byType(FloatingActionButton), findsNWidgets(3));
+      expect(find.text('Compose'), findsOneWidget);
+    });
+
+    testWidgets('disabled state prevents interaction', (tester) async {
+      int calls = 0;
+      await tester.pumpWidget(_wrap(AppFab(icon: Icons.add, onPressed: null)));
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+      expect(calls, 0);
+    });
+
+    testWidgets('tooltip is applied and semantics label exists', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(AppFab(icon: Icons.add, onPressed: () {}, tooltip: 'Add item')),
+      );
+      // Long press to show tooltip
+      final fab = find.byType(FloatingActionButton);
+      await tester.longPress(fab);
+      await tester.pumpAndSettle(const Duration(milliseconds: 300));
+      expect(find.text('Add item'), findsOneWidget);
+    });
+
+    testWidgets('min touch target is at least 48x48', (tester) async {
+      await tester.pumpWidget(
+        _wrap(const AppFab.small(icon: Icons.filter_list)),
+      );
+      final renderBox =
+          tester.renderObject(find.byType(FloatingActionButton)) as RenderBox;
+      expect(renderBox.size.width >= 48, isTrue);
+      expect(renderBox.size.height >= 48, isTrue);
+    });
+
+    testWidgets('extended supports trailing icon and typography', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          AppFab.extended(
+            icon: Icons.edit,
+            label: 'Edit',
+            trailingIcon: Icons.arrow_forward,
+            onPressed: () {},
+          ),
+        ),
+      );
+      expect(find.text('Edit'), findsOneWidget);
+      expect(find.byIcon(Icons.arrow_forward), findsOneWidget);
+      expect(find.byIcon(Icons.edit), findsOneWidget);
+    });
+
+    testWidgets('hide on scroll slides out and back', (tester) async {
+      final controller = ScrollController();
+      await tester.pumpWidget(
+        _wrap(
+          SizedBox(
+            height: 300,
+            child: Stack(
+              children: [
+                ListView.builder(
+                  controller: controller,
+                  itemCount: 50,
+                  itemBuilder: (_, i) => ListTile(title: Text('Item $i')),
+                ),
+                Positioned(
+                  right: 16,
+                  bottom: 16,
+                  child: AppFabHideOnScroll(
+                    scrollController: controller,
+                    fab: AppFab(icon: Icons.add, onPressed: () {}),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Scroll down to hide
+      controller.jumpTo(200);
+      await tester.pumpAndSettle();
+      // FAB still in tree but slid; verify it exists
+      expect(find.byType(AppFab), findsOneWidget);
+
+      // Scroll up to show
+      controller.jumpTo(0);
+      await tester.pumpAndSettle();
+      expect(find.byType(AppFab), findsOneWidget);
+    });
+  });
+}

--- a/packages/core_kit/test/widgets/buttons/app_button_test.dart
+++ b/packages/core_kit/test/widgets/buttons/app_button_test.dart
@@ -1,0 +1,628 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:core_kit/core_kit.dart';
+
+void main() {
+  group('AppButton', () {
+    group('Variants', () {
+      testWidgets('renders filled button variant correctly', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.filled(label: 'Test Button', onPressed: () {}),
+            ),
+          ),
+        );
+
+        expect(find.text('Test Button'), findsOneWidget);
+        expect(find.byType(FilledButton), findsOneWidget);
+      });
+
+      testWidgets('renders outlined button variant correctly', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.outlined(label: 'Test Button', onPressed: () {}),
+            ),
+          ),
+        );
+
+        expect(find.text('Test Button'), findsOneWidget);
+        expect(find.byType(OutlinedButton), findsOneWidget);
+      });
+
+      testWidgets('renders text button variant correctly', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.text(label: 'Test Button', onPressed: () {}),
+            ),
+          ),
+        );
+
+        expect(find.text('Test Button'), findsOneWidget);
+        expect(find.byType(TextButton), findsOneWidget);
+      });
+
+      testWidgets('renders elevated button variant correctly', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.elevated(label: 'Test Button', onPressed: () {}),
+            ),
+          ),
+        );
+
+        expect(find.text('Test Button'), findsOneWidget);
+        expect(find.byType(ElevatedButton), findsOneWidget);
+      });
+    });
+
+    group('Loading State', () {
+      testWidgets('displays circular progress indicator when loading', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.filled(
+                label: 'Loading',
+                isLoading: true,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.text('Loading'), findsNothing);
+      });
+
+      testWidgets('disables onPressed callback when loading', (tester) async {
+        var callbackTriggered = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.filled(
+                label: 'Loading',
+                isLoading: true,
+                onPressed: () => callbackTriggered = true,
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.byType(FilledButton));
+        await tester.pump();
+
+        expect(callbackTriggered, isFalse);
+      });
+
+      testWidgets('shows label when not loading', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.filled(
+                label: 'Submit',
+                isLoading: false,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Submit'), findsOneWidget);
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+      });
+    });
+
+    group('Disabled State', () {
+      testWidgets('is disabled when onPressed is null', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppButton.filled(label: 'Disabled', onPressed: null),
+            ),
+          ),
+        );
+
+        final button = tester.widget<FilledButton>(find.byType(FilledButton));
+        expect(button.onPressed, isNull);
+      });
+
+      testWidgets('does not trigger callback when disabled', (tester) async {
+        var callbackTriggered = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.filled(label: 'Disabled', onPressed: null),
+            ),
+          ),
+        );
+
+        await tester.tap(find.byType(FilledButton));
+        await tester.pump();
+
+        expect(callbackTriggered, isFalse);
+      });
+    });
+
+    group('Enabled State', () {
+      testWidgets('triggers onPressed callback when tapped', (tester) async {
+        var callbackTriggered = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.filled(
+                label: 'Enabled',
+                onPressed: () => callbackTriggered = true,
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.byType(FilledButton));
+        await tester.pump();
+
+        expect(callbackTriggered, isTrue);
+      });
+
+      testWidgets('is enabled when onPressed is provided', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.filled(label: 'Enabled', onPressed: () {}),
+            ),
+          ),
+        );
+
+        final button = tester.widget<FilledButton>(find.byType(FilledButton));
+        expect(button.onPressed, isNotNull);
+      });
+    });
+
+    group('Icon Support', () {
+      testWidgets('displays icon when provided for filled variant', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.filled(
+                label: 'With Icon',
+                icon: Icons.add,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.add), findsOneWidget);
+        expect(find.text('With Icon'), findsOneWidget);
+      });
+
+      testWidgets('displays icon when provided for outlined variant', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.outlined(
+                label: 'With Icon',
+                icon: Icons.download,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.download), findsOneWidget);
+        expect(find.text('With Icon'), findsOneWidget);
+      });
+
+      testWidgets('does not display icon when not provided', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.filled(label: 'No Icon', onPressed: () {}),
+            ),
+          ),
+        );
+
+        expect(find.byType(Icon), findsNothing);
+        expect(find.text('No Icon'), findsOneWidget);
+      });
+    });
+
+    group('Icon + Loading Combination', () {
+      testWidgets(
+        'shows loading indicator instead of icon when loading (filled)',
+        (tester) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: AppButton.filled(
+                  label: 'Loading',
+                  icon: Icons.add,
+                  isLoading: true,
+                  onPressed: () {},
+                ),
+              ),
+            ),
+          );
+
+          expect(find.byType(CircularProgressIndicator), findsOneWidget);
+          expect(find.byIcon(Icons.add), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'shows loading indicator instead of icon when loading (outlined)',
+        (tester) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: AppButton.outlined(
+                  label: 'Loading',
+                  icon: Icons.download,
+                  isLoading: true,
+                  onPressed: () {},
+                ),
+              ),
+            ),
+          );
+
+          expect(find.byType(CircularProgressIndicator), findsOneWidget);
+          expect(find.byIcon(Icons.download), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'shows loading indicator instead of icon when loading (text)',
+        (tester) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: AppButton.text(
+                  label: 'Loading',
+                  icon: Icons.save,
+                  isLoading: true,
+                  onPressed: () {},
+                ),
+              ),
+            ),
+          );
+
+          expect(find.byType(CircularProgressIndicator), findsOneWidget);
+          expect(find.byIcon(Icons.save), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'shows loading indicator instead of icon when loading (elevated)',
+        (tester) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: AppButton.elevated(
+                  label: 'Loading',
+                  icon: Icons.upload,
+                  isLoading: true,
+                  onPressed: () {},
+                ),
+              ),
+            ),
+          );
+
+          expect(find.byType(CircularProgressIndicator), findsOneWidget);
+          expect(find.byIcon(Icons.upload), findsNothing);
+        },
+      );
+
+      testWidgets('shows icon when not loading', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.filled(
+                label: 'Not Loading',
+                icon: Icons.check,
+                isLoading: false,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.check), findsOneWidget);
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+      });
+    });
+
+    group('Full Width', () {
+      testWidgets('expands to fill parent width when fullWidth is true', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 300,
+                child: AppButton.filled(
+                  label: 'Full Width',
+                  fullWidth: true,
+                  onPressed: () {},
+                ),
+              ),
+            ),
+          ),
+        );
+
+        // Find the SizedBox that wraps the button (created by fullWidth=true)
+        final appButton = find.byType(AppButton);
+        final sizedBoxes = find.descendant(
+          of: appButton,
+          matching: find.byType(SizedBox),
+        );
+
+        // Should have at least one SizedBox with infinite width
+        final hasFullWidth = tester
+            .widgetList<SizedBox>(sizedBoxes)
+            .any((box) => box.width == double.infinity);
+        expect(hasFullWidth, isTrue);
+      });
+
+      testWidgets('does not expand when fullWidth is false', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.filled(
+                label: 'Normal Width',
+                fullWidth: false,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        // When fullWidth is false, SizedBox with infinity width should not exist
+        // Find all SizedBox widgets and check none have infinite width
+        final allSizedBoxes = tester.widgetList<SizedBox>(
+          find.byType(SizedBox),
+        );
+        final hasInfiniteWidth = allSizedBoxes.any(
+          (box) => box.width == double.infinity,
+        );
+
+        expect(hasInfiniteWidth, isFalse);
+      });
+    });
+
+    group('Label Display', () {
+      testWidgets('displays label text correctly', (tester) async {
+        const labelText = 'Test Label';
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.filled(label: labelText, onPressed: () {}),
+            ),
+          ),
+        );
+
+        expect(find.text(labelText), findsOneWidget);
+      });
+
+      testWidgets('handles long label text', (tester) async {
+        const longLabel =
+            'This is a very long button label that might wrap or overflow';
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 200,
+                child: AppButton.filled(label: longLabel, onPressed: () {}),
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text(longLabel), findsOneWidget);
+      });
+
+      testWidgets('handles empty label', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.filled(label: '', onPressed: () {}),
+            ),
+          ),
+        );
+
+        expect(find.text(''), findsOneWidget);
+      });
+    });
+
+    group('Accessibility', () {
+      testWidgets('has Semantics wrapper for enabled button', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.filled(
+                label: 'Accessible Button',
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        // Verify Semantics widget exists
+        expect(find.byType(Semantics), findsWidgets);
+
+        // Verify the button is accessible and the label is present
+        expect(find.text('Accessible Button'), findsOneWidget);
+      });
+
+      testWidgets('has Semantics wrapper for disabled button', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppButton.filled(label: 'Disabled Button', onPressed: null),
+            ),
+          ),
+        );
+
+        // Verify Semantics widget exists
+        expect(find.byType(Semantics), findsWidgets);
+
+        // Verify the button label is present
+        expect(find.text('Disabled Button'), findsOneWidget);
+      });
+
+      testWidgets('has loading state in semantic label', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.filled(
+                label: 'Processing',
+                isLoading: true,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        // Find the AppButton's Semantics widget (not Material button's semantics)
+        final appButtonSemantics = tester.widget<Semantics>(
+          find
+              .descendant(
+                of: find.byType(AppButton),
+                matching: find.byType(Semantics),
+              )
+              .first,
+        );
+
+        expect(appButtonSemantics.properties.label, contains('loading'));
+      });
+    });
+
+    group('Edge Cases', () {
+      testWidgets('handles null icon parameter', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.filled(
+                label: 'No Icon',
+                icon: null,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(Icon), findsNothing);
+        expect(find.byType(FilledButton), findsOneWidget);
+      });
+
+      testWidgets('handles all parameters together', (tester) async {
+        var callbackTriggered = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.filled(
+                label: 'Complete Button',
+                icon: Icons.check,
+                fullWidth: true,
+                isLoading: false,
+                onPressed: () => callbackTriggered = true,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Complete Button'), findsOneWidget);
+        expect(find.byIcon(Icons.check), findsOneWidget);
+
+        // Tap the AppButton widget directly
+        await tester.tap(find.byType(AppButton));
+        await tester.pump();
+
+        expect(callbackTriggered, isTrue);
+      });
+
+      testWidgets('maintains loading state correctly', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.filled(
+                label: 'Loading Button',
+                isLoading: true,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        // Verify loading state shows indicator
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+        // Rebuild with non-loading state
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton.filled(
+                label: 'Loading Button',
+                isLoading: false,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        // Should now show label instead of loading indicator
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+        expect(find.text('Loading Button'), findsOneWidget);
+      });
+    });
+
+    group('Variant Constructor', () {
+      testWidgets('creates correct variant using main constructor', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton(
+                label: 'Default Variant',
+                variant: AppButtonVariant.outlined,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(OutlinedButton), findsOneWidget);
+      });
+
+      testWidgets('defaults to filled variant', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton(label: 'Default', onPressed: () {}),
+            ),
+          ),
+        );
+
+        expect(find.byType(FilledButton), findsOneWidget);
+      });
+    });
+  });
+}

--- a/packages/core_kit/test/widgets/buttons/app_text_button_test.dart
+++ b/packages/core_kit/test/widgets/buttons/app_text_button_test.dart
@@ -1,0 +1,545 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:core_kit/core_kit.dart';
+
+void main() {
+  group('AppTextButton', () {
+    group('Widget Structure', () {
+      testWidgets('renders correctly with required parameters', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(label: 'Test Button', onPressed: () {}),
+            ),
+          ),
+        );
+
+        expect(find.text('Test Button'), findsOneWidget);
+        expect(find.byType(TextButton), findsOneWidget);
+      });
+
+      testWidgets('delegates to AppButton.text() internally', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(label: 'Delegated', onPressed: () {}),
+            ),
+          ),
+        );
+
+        // Verify that a TextButton is created (which AppButton.text() uses)
+        expect(find.byType(TextButton), findsOneWidget);
+        expect(find.text('Delegated'), findsOneWidget);
+      });
+
+      testWidgets('displays label text correctly', (tester) async {
+        const labelText = 'Custom Label';
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(label: labelText, onPressed: () {}),
+            ),
+          ),
+        );
+
+        expect(find.text(labelText), findsOneWidget);
+      });
+    });
+
+    group('States', () {
+      testWidgets('is enabled when onPressed is provided', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(label: 'Enabled', onPressed: () {}),
+            ),
+          ),
+        );
+
+        final button = tester.widget<TextButton>(find.byType(TextButton));
+        expect(button.onPressed, isNotNull);
+      });
+
+      testWidgets('is disabled when onPressed is null', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(label: 'Disabled', onPressed: null),
+            ),
+          ),
+        );
+
+        final button = tester.widget<TextButton>(find.byType(TextButton));
+        expect(button.onPressed, isNull);
+      });
+
+      testWidgets('triggers onPressed callback when tapped', (tester) async {
+        var callbackTriggered = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(
+                label: 'Tap Me',
+                onPressed: () => callbackTriggered = true,
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.byType(TextButton));
+        await tester.pump();
+
+        expect(callbackTriggered, isTrue);
+      });
+
+      testWidgets('does not trigger callback when disabled', (tester) async {
+        var callbackTriggered = false;
+
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(label: 'Disabled', onPressed: null),
+            ),
+          ),
+        );
+
+        await tester.tap(find.byType(TextButton));
+        await tester.pump();
+
+        expect(callbackTriggered, isFalse);
+      });
+    });
+
+    group('Loading State', () {
+      testWidgets('displays circular progress indicator when loading', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(
+                label: 'Loading',
+                isLoading: true,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.text('Loading'), findsNothing);
+      });
+
+      testWidgets('disables button when loading', (tester) async {
+        var callbackTriggered = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(
+                label: 'Loading',
+                isLoading: true,
+                onPressed: () => callbackTriggered = true,
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.byType(TextButton));
+        await tester.pump();
+
+        expect(callbackTriggered, isFalse);
+      });
+
+      testWidgets('shows label when not loading', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(
+                label: 'Submit',
+                isLoading: false,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Submit'), findsOneWidget);
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+      });
+    });
+
+    group('Icon Support', () {
+      testWidgets('displays icon when provided', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(
+                label: 'With Icon',
+                icon: Icons.add,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.add), findsOneWidget);
+        expect(find.text('With Icon'), findsOneWidget);
+      });
+
+      testWidgets('does not display icon when not provided', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(label: 'No Icon', onPressed: () {}),
+            ),
+          ),
+        );
+
+        expect(find.byType(Icon), findsNothing);
+        expect(find.text('No Icon'), findsOneWidget);
+      });
+
+      testWidgets('handles null icon parameter', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(
+                label: 'Null Icon',
+                icon: null,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(Icon), findsNothing);
+        expect(find.byType(TextButton), findsOneWidget);
+      });
+    });
+
+    group('Icon + Loading Combination', () {
+      testWidgets('shows loading indicator instead of icon when loading', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(
+                label: 'Loading',
+                icon: Icons.save,
+                isLoading: true,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byIcon(Icons.save), findsNothing);
+      });
+
+      testWidgets('shows icon when not loading', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(
+                label: 'Not Loading',
+                icon: Icons.check,
+                isLoading: false,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.check), findsOneWidget);
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+      });
+    });
+
+    group('Full Width', () {
+      testWidgets('expands to fill parent width when fullWidth is true', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 300,
+                child: AppTextButton(
+                  label: 'Full Width',
+                  fullWidth: true,
+                  onPressed: () {},
+                ),
+              ),
+            ),
+          ),
+        );
+
+        // Find the SizedBox that wraps the button (created by fullWidth=true)
+        final appTextButton = find.byType(AppTextButton);
+        final sizedBoxes = find.descendant(
+          of: appTextButton,
+          matching: find.byType(SizedBox),
+        );
+
+        // Should have at least one SizedBox with infinite width
+        final hasFullWidth = tester
+            .widgetList<SizedBox>(sizedBoxes)
+            .any((box) => box.width == double.infinity);
+        expect(hasFullWidth, isTrue);
+      });
+
+      testWidgets('does not expand when fullWidth is false', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(
+                label: 'Normal Width',
+                fullWidth: false,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        // When fullWidth is false, SizedBox with infinity width should not exist
+        final allSizedBoxes = tester.widgetList<SizedBox>(
+          find.byType(SizedBox),
+        );
+        final hasInfiniteWidth = allSizedBoxes.any(
+          (box) => box.width == double.infinity,
+        );
+
+        expect(hasInfiniteWidth, isFalse);
+      });
+    });
+
+    group('Label Display', () {
+      testWidgets('handles long label text', (tester) async {
+        const longLabel =
+            'This is a very long button label that might wrap or overflow';
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 200,
+                child: AppTextButton(label: longLabel, onPressed: () {}),
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text(longLabel), findsOneWidget);
+      });
+
+      testWidgets('handles empty label', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(label: '', onPressed: () {}),
+            ),
+          ),
+        );
+
+        expect(find.text(''), findsOneWidget);
+      });
+    });
+
+    group('Accessibility', () {
+      testWidgets('has Semantics wrapper for enabled button', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(label: 'Accessible Button', onPressed: () {}),
+            ),
+          ),
+        );
+
+        // Verify Semantics widget exists
+        expect(find.byType(Semantics), findsWidgets);
+
+        // Verify the button is accessible and the label is present
+        expect(find.text('Accessible Button'), findsOneWidget);
+      });
+
+      testWidgets('has Semantics wrapper for disabled button', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(label: 'Disabled Button', onPressed: null),
+            ),
+          ),
+        );
+
+        // Verify Semantics widget exists
+        expect(find.byType(Semantics), findsWidgets);
+
+        // Verify the button label is present
+        expect(find.text('Disabled Button'), findsOneWidget);
+      });
+
+      testWidgets('has loading state in semantic label', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(
+                label: 'Processing',
+                isLoading: true,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        // Find the AppButton's Semantics widget (which AppTextButton delegates to)
+        final appButtonSemantics = tester.widget<Semantics>(
+          find
+              .descendant(
+                of: find.byType(AppButton),
+                matching: find.byType(Semantics),
+              )
+              .first,
+        );
+
+        expect(appButtonSemantics.properties.label, contains('loading'));
+      });
+    });
+
+    group('Edge Cases', () {
+      testWidgets('handles all parameters together', (tester) async {
+        var callbackTriggered = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(
+                label: 'Complete Button',
+                icon: Icons.check,
+                fullWidth: true,
+                isLoading: false,
+                onPressed: () => callbackTriggered = true,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Complete Button'), findsOneWidget);
+        expect(find.byIcon(Icons.check), findsOneWidget);
+
+        // Tap the AppTextButton widget directly
+        await tester.tap(find.byType(AppTextButton));
+        await tester.pump();
+
+        expect(callbackTriggered, isTrue);
+      });
+
+      testWidgets('maintains loading state correctly', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(
+                label: 'Loading Button',
+                isLoading: true,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+
+        // Verify loading state shows indicator
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+        // Rebuild with non-loading state
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppTextButton(
+                label: 'Loading Button',
+                isLoading: false,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        // Should now show label instead of loading indicator
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+        expect(find.text('Loading Button'), findsOneWidget);
+      });
+    });
+
+    group('Delegation Verification', () {
+      testWidgets('produces same output as AppButton.text()', (tester) async {
+        // Build both versions side by side
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Column(
+                children: [
+                  AppTextButton(label: 'Test', onPressed: () {}),
+                  AppButton.text(label: 'Test', onPressed: () {}),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        // Both should produce TextButton widgets
+        expect(find.byType(TextButton), findsNWidgets(2));
+
+        // Both should have the same label
+        expect(find.text('Test'), findsNWidgets(2));
+      });
+
+      testWidgets('delegates all parameters correctly', (tester) async {
+        var textButtonCalled = false;
+        var appButtonCalled = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Column(
+                children: [
+                  AppTextButton(
+                    label: 'TextButtonTest',
+                    icon: Icons.star,
+                    isLoading: false,
+                    onPressed: () => textButtonCalled = true,
+                  ),
+                  AppButton.text(
+                    label: 'AppButtonTest',
+                    icon: Icons.star,
+                    isLoading: false,
+                    onPressed: () => appButtonCalled = true,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        // Tap the first button (AppTextButton) using its label
+        await tester.tap(find.text('TextButtonTest'));
+        await tester.pump();
+        expect(textButtonCalled, isTrue);
+
+        // Tap the second button (AppButton) using its label
+        await tester.tap(find.text('AppButtonTest'));
+        await tester.pump();
+        expect(appButtonCalled, isTrue);
+
+        // Both should have icons
+        expect(find.byIcon(Icons.star), findsNWidgets(2));
+      });
+    });
+  });
+}

--- a/packages/core_kit/test/widgets/inputs/app_checkbox_test.dart
+++ b/packages/core_kit/test/widgets/inputs/app_checkbox_test.dart
@@ -1,0 +1,553 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:core_kit/core_kit.dart';
+
+void main() {
+  group('AppCheckbox', () {
+    group('Basic Functionality', () {
+      testWidgets('renders correctly', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: AppCheckbox(value: false, onChanged: (_) {})),
+          ),
+        );
+
+        expect(find.byType(AppCheckbox), findsOneWidget);
+        expect(find.byType(Checkbox), findsOneWidget);
+      });
+
+      testWidgets('displays unchecked state', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: AppCheckbox(value: false, onChanged: (_) {})),
+          ),
+        );
+
+        final checkbox = tester.widget<Checkbox>(find.byType(Checkbox));
+        expect(checkbox.value, false);
+      });
+
+      testWidgets('displays checked state', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: AppCheckbox(value: true, onChanged: (_) {})),
+          ),
+        );
+
+        final checkbox = tester.widget<Checkbox>(find.byType(Checkbox));
+        expect(checkbox.value, true);
+      });
+
+      testWidgets('calls onChanged when tapped', (WidgetTester tester) async {
+        bool? changedValue;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppCheckbox(
+                value: false,
+                onChanged: (value) {
+                  changedValue = value;
+                },
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.byType(Checkbox));
+        await tester.pumpAndSettle();
+
+        expect(changedValue, true);
+      });
+
+      testWidgets('toggles from checked to unchecked', (
+        WidgetTester tester,
+      ) async {
+        bool? changedValue;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppCheckbox(
+                value: true,
+                onChanged: (value) {
+                  changedValue = value;
+                },
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.byType(Checkbox));
+        await tester.pumpAndSettle();
+
+        expect(changedValue, false);
+      });
+    });
+
+    group('Tristate Support', () {
+      testWidgets('supports tristate mode', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppCheckbox(value: null, tristate: true, onChanged: (_) {}),
+            ),
+          ),
+        );
+
+        final checkbox = tester.widget<Checkbox>(find.byType(Checkbox));
+        expect(checkbox.tristate, true);
+        expect(checkbox.value, null);
+      });
+
+      testWidgets('cycles through tristate values correctly', (
+        WidgetTester tester,
+      ) async {
+        bool? currentValue = false;
+        final values = <bool?>[];
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: StatefulBuilder(
+                builder: (context, setState) {
+                  return AppCheckbox(
+                    value: currentValue,
+                    tristate: true,
+                    onChanged: (value) {
+                      setState(() {
+                        currentValue = value;
+                        values.add(value);
+                      });
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        // Tap 1: false → true
+        await tester.tap(find.byType(Checkbox));
+        await tester.pumpAndSettle();
+        expect(values.last, true);
+
+        // Tap 2: true → null
+        await tester.tap(find.byType(Checkbox));
+        await tester.pumpAndSettle();
+        expect(values.last, null);
+
+        // Tap 3: null → false
+        await tester.tap(find.byType(Checkbox));
+        await tester.pumpAndSettle();
+        expect(values.last, false);
+      });
+    });
+
+    group('Label Integration', () {
+      testWidgets('displays label when provided', (WidgetTester tester) async {
+        const labelText = 'Accept terms';
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppCheckbox(
+                value: false,
+                label: labelText,
+                onChanged: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text(labelText), findsOneWidget);
+      });
+
+      testWidgets('does not display label when null', (
+        WidgetTester tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: AppCheckbox(value: false, onChanged: (_) {})),
+          ),
+        );
+
+        expect(find.byType(Text), findsNothing);
+      });
+
+      testWidgets('label wraps correctly with long text', (
+        WidgetTester tester,
+      ) async {
+        const longLabel =
+            'This is a very long label that should wrap to multiple lines when the available space is limited';
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 200,
+                child: AppCheckbox(
+                  value: false,
+                  label: longLabel,
+                  onChanged: (_) {},
+                ),
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text(longLabel), findsOneWidget);
+      });
+
+      testWidgets('label is tappable', (WidgetTester tester) async {
+        bool? changedValue;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppCheckbox(
+                value: false,
+                label: 'Tap me',
+                onChanged: (value) {
+                  changedValue = value;
+                },
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Tap me'));
+        await tester.pumpAndSettle();
+
+        expect(changedValue, true);
+      });
+    });
+
+    group('Error Handling', () {
+      testWidgets('displays error state styling', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppCheckbox(value: false, error: true, onChanged: (_) {}),
+            ),
+          ),
+        );
+
+        final checkbox = tester.widget<Checkbox>(find.byType(Checkbox));
+        final theme = Theme.of(tester.element(find.byType(AppCheckbox)));
+        expect(checkbox.activeColor, theme.colorScheme.error);
+      });
+
+      testWidgets('displays error text when provided', (
+        WidgetTester tester,
+      ) async {
+        const errorMessage = 'This field is required';
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppCheckbox(
+                value: false,
+                error: true,
+                errorText: errorMessage,
+                onChanged: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text(errorMessage), findsOneWidget);
+      });
+
+      testWidgets('does not display error text when error is false', (
+        WidgetTester tester,
+      ) async {
+        const errorMessage = 'This field is required';
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppCheckbox(
+                value: false,
+                error: false,
+                errorText: errorMessage,
+                onChanged: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text(errorMessage), findsNothing);
+      });
+
+      testWidgets('label uses error color when error is true', (
+        WidgetTester tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppCheckbox(
+                value: false,
+                label: 'Required field',
+                error: true,
+                onChanged: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        final text = tester.widget<Text>(find.text('Required field'));
+        final theme = Theme.of(tester.element(find.byType(AppCheckbox)));
+        expect(text.style?.color, theme.colorScheme.error);
+      });
+    });
+
+    group('Disabled State', () {
+      testWidgets('is disabled when onChanged is null', (
+        WidgetTester tester,
+      ) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(body: AppCheckbox(value: false, onChanged: null)),
+          ),
+        );
+
+        final checkbox = tester.widget<Checkbox>(find.byType(Checkbox));
+        expect(checkbox.onChanged, null);
+      });
+
+      testWidgets('is disabled when enabled is false', (
+        WidgetTester tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppCheckbox(
+                value: false,
+                enabled: false,
+                onChanged: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        final checkbox = tester.widget<Checkbox>(find.byType(Checkbox));
+        expect(checkbox.onChanged, null);
+      });
+
+      testWidgets('disabled checkbox does not trigger onChanged', (
+        WidgetTester tester,
+      ) async {
+        bool called = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppCheckbox(
+                value: false,
+                enabled: false,
+                onChanged: (_) {
+                  called = true;
+                },
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.byType(Checkbox));
+        await tester.pumpAndSettle();
+
+        expect(called, false);
+      });
+
+      testWidgets('disabled label has reduced opacity', (
+        WidgetTester tester,
+      ) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppCheckbox(
+                value: false,
+                label: 'Disabled checkbox',
+                onChanged: null,
+              ),
+            ),
+          ),
+        );
+
+        final text = tester.widget<Text>(find.text('Disabled checkbox'));
+        expect(text.style?.color?.a, closeTo(0.38, 0.01));
+      });
+    });
+
+    group('Accessibility', () {
+      testWidgets('has minimum touch target size', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: AppCheckbox(value: false, onChanged: (_) {})),
+          ),
+        );
+
+        final checkboxSize = tester.getSize(find.byType(Checkbox));
+        expect(checkboxSize.width, greaterThanOrEqualTo(40));
+        expect(checkboxSize.height, greaterThanOrEqualTo(40));
+      });
+
+      testWidgets('checkbox has proper semantics', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppCheckbox(
+                value: false,
+                label: 'Checkbox label',
+                onChanged: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        // Checkbox widget has built-in semantics
+        expect(find.byType(Checkbox), findsOneWidget);
+      });
+    });
+
+    group('Theme Integration', () {
+      testWidgets('uses theme primary color by default', (
+        WidgetTester tester,
+      ) async {
+        const customPrimary = Color(0xFF123456);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(
+              colorScheme: ColorScheme.fromSeed(seedColor: customPrimary),
+            ),
+            home: Scaffold(body: AppCheckbox(value: true, onChanged: (_) {})),
+          ),
+        );
+
+        final checkbox = tester.widget<Checkbox>(find.byType(Checkbox));
+        final theme = Theme.of(tester.element(find.byType(AppCheckbox)));
+        expect(checkbox.activeColor, theme.colorScheme.primary);
+      });
+
+      testWidgets('activeColor overrides theme color', (
+        WidgetTester tester,
+      ) async {
+        const customColor = Color(0xFFFF5722);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppCheckbox(
+                value: true,
+                activeColor: customColor,
+                onChanged: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        final checkbox = tester.widget<Checkbox>(find.byType(Checkbox));
+        expect(checkbox.activeColor, customColor);
+      });
+
+      testWidgets('checkColor overrides default', (WidgetTester tester) async {
+        const customCheckColor = Color(0xFF00FF00);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppCheckbox(
+                value: true,
+                checkColor: customCheckColor,
+                onChanged: (_) {},
+              ),
+            ),
+          ),
+        );
+
+        final checkbox = tester.widget<Checkbox>(find.byType(Checkbox));
+        expect(checkbox.checkColor, customCheckColor);
+      });
+    });
+
+    group('Edge Cases', () {
+      testWidgets('handles empty label', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppCheckbox(value: false, label: '', onChanged: (_) {}),
+            ),
+          ),
+        );
+
+        expect(find.text(''), findsOneWidget);
+      });
+
+      testWidgets('handles rapid tapping', (WidgetTester tester) async {
+        int callCount = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppCheckbox(
+                value: false,
+                onChanged: (_) {
+                  callCount++;
+                },
+              ),
+            ),
+          ),
+        );
+
+        // Tap rapidly 5 times
+        for (int i = 0; i < 5; i++) {
+          await tester.tap(find.byType(Checkbox));
+        }
+        await tester.pumpAndSettle();
+
+        expect(callCount, 5);
+      });
+
+      testWidgets('multiple checkboxes can coexist', (
+        WidgetTester tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Column(
+                children: [
+                  AppCheckbox(
+                    value: false,
+                    label: 'Checkbox 1',
+                    onChanged: (_) {},
+                  ),
+                  AppCheckbox(
+                    value: true,
+                    label: 'Checkbox 2',
+                    onChanged: (_) {},
+                  ),
+                  AppCheckbox(
+                    value: null,
+                    tristate: true,
+                    label: 'Checkbox 3',
+                    onChanged: (_) {},
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(AppCheckbox), findsNWidgets(3));
+        expect(find.text('Checkbox 1'), findsOneWidget);
+        expect(find.text('Checkbox 2'), findsOneWidget);
+        expect(find.text('Checkbox 3'), findsOneWidget);
+      });
+    });
+  });
+}

--- a/packages/core_kit/test/widgets/inputs/app_dropdown_test.dart
+++ b/packages/core_kit/test/widgets/inputs/app_dropdown_test.dart
@@ -1,0 +1,361 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:core_kit/core_kit.dart';
+
+void main() {
+  group('AppDropdown', () {
+    // =========================================================================
+    // Unit Tests - Logic and State
+    // =========================================================================
+
+    group('Unit Tests', () {
+      test('AppDropdownItem equality works correctly', () {
+        const item1 = AppDropdownItem(value: 'test', label: 'Test');
+        const item2 = AppDropdownItem(value: 'test', label: 'Test');
+        const item3 = AppDropdownItem(value: 'other', label: 'Other');
+
+        expect(item1, equals(item2));
+        expect(item1, isNot(equals(item3)));
+      });
+
+      test('AppDropdownItem hashCode is consistent', () {
+        const item1 = AppDropdownItem(value: 'test', label: 'Test');
+        const item2 = AppDropdownItem(value: 'test', label: 'Test');
+
+        expect(item1.hashCode, equals(item2.hashCode));
+      });
+
+      test('AppDropdownItem toString returns correct format', () {
+        const item = AppDropdownItem(value: 'test', label: 'Test Label');
+
+        expect(item.toString(), contains('test'));
+        expect(item.toString(), contains('Test Label'));
+      });
+    });
+
+    // =========================================================================
+    // Widget Tests - UI and Interaction
+    // =========================================================================
+
+    group('Widget Tests', () {
+      testWidgets('renders with basic configuration', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppDropdown<String>(
+                items: const ['Option 1', 'Option 2', 'Option 3'],
+                itemLabelBuilder: (item) => item,
+                label: 'Test Label',
+                hint: 'Test Hint',
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Test Label'), findsWidgets);
+        expect(find.text('Test Hint'), findsWidgets);
+      });
+
+      testWidgets('displays selected value', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppDropdown<String>(
+                items: const ['Option 1', 'Option 2', 'Option 3'],
+                value: 'Option 2',
+                itemLabelBuilder: (item) => item,
+                label: 'Select',
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Option 2'), findsWidgets);
+      });
+
+      testWidgets('onChanged callback is triggered on selection', (
+        tester,
+      ) async {
+        String? selectedValue;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppDropdown<String>(
+                items: const ['Option 1', 'Option 2', 'Option 3'],
+                itemLabelBuilder: (item) => item,
+                label: 'Select',
+                onChanged: (value) {
+                  selectedValue = value;
+                },
+              ),
+            ),
+          ),
+        );
+
+        // Tap on the dropdown to open menu
+        await tester.tap(find.byType(DropdownMenu<String>));
+        await tester.pumpAndSettle();
+
+        // Select an option
+        await tester.tap(find.text('Option 2').last);
+        await tester.pumpAndSettle();
+
+        expect(selectedValue, equals('Option 2'));
+      });
+
+      testWidgets('displays helper text when provided', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppDropdown<String>(
+                items: const ['Option 1', 'Option 2'],
+                itemLabelBuilder: (item) => item,
+                label: 'Select',
+                helperText: 'This is helper text',
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('This is helper text'), findsOneWidget);
+      });
+
+      testWidgets('displays error text when provided', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppDropdown<String>(
+                items: const ['Option 1', 'Option 2'],
+                itemLabelBuilder: (item) => item,
+                label: 'Select',
+                errorText: 'This field is required',
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('This field is required'), findsOneWidget);
+      });
+
+      testWidgets('does not display helper text when error text is present', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppDropdown<String>(
+                items: const ['Option 1', 'Option 2'],
+                itemLabelBuilder: (item) => item,
+                label: 'Select',
+                helperText: 'Helper text',
+                errorText: 'Error text',
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Error text'), findsOneWidget);
+        expect(find.text('Helper text'), findsNothing);
+      });
+
+      testWidgets('disabled state prevents interaction', (tester) async {
+        String? selectedValue;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppDropdown<String>(
+                items: const ['Option 1', 'Option 2', 'Option 3'],
+                itemLabelBuilder: (item) => item,
+                label: 'Select',
+                enabled: false,
+                onChanged: (value) {
+                  selectedValue = value;
+                },
+              ),
+            ),
+          ),
+        );
+
+        // Try to tap on the disabled dropdown
+        await tester.tap(find.byType(DropdownMenu<String>));
+        await tester.pumpAndSettle();
+
+        expect(selectedValue, isNull);
+      });
+
+      testWidgets('renders with leading icon', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppDropdown<String>(
+                items: const ['Option 1', 'Option 2'],
+                itemLabelBuilder: (item) => item,
+                label: 'Select',
+                leadingIcon: Icons.person,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.person), findsWidgets);
+      });
+
+      testWidgets(
+        'search functionality is enabled with withSearch constructor',
+        (tester) async {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: AppDropdown<String>.withSearch(
+                  items: const ['Apple', 'Banana', 'Cherry', 'Date'],
+                  itemLabelBuilder: (item) => item,
+                  label: 'Select Fruit',
+                ),
+              ),
+            ),
+          );
+
+          // Dropdown should render
+          expect(find.byType(DropdownMenu<String>), findsOneWidget);
+        },
+      );
+
+      testWidgets('works with custom objects', (tester) async {
+        final items = [
+          const AppDropdownItem(value: '1', label: 'Item 1', icon: Icons.home),
+          const AppDropdownItem(value: '2', label: 'Item 2', icon: Icons.work),
+          const AppDropdownItem(
+            value: '3',
+            label: 'Item 3',
+            icon: Icons.school,
+          ),
+        ];
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (context) => AppDropdown<AppDropdownItem<String>>(
+                  items: items,
+                  itemLabelBuilder: (item) => item.label,
+                  customItemBuilder: (item) => item.buildWidget(context),
+                  label: 'Select',
+                ),
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Item 1'), findsOneWidget);
+      });
+
+      testWidgets('null value shows hint text', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppDropdown<String>(
+                items: const ['Option 1', 'Option 2'],
+                value: null,
+                itemLabelBuilder: (item) => item,
+                label: 'Select',
+                hint: 'Choose an option',
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Choose an option'), findsOneWidget);
+      });
+
+      testWidgets('respects custom width', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppDropdown<String>(
+                items: const ['Option 1', 'Option 2'],
+                itemLabelBuilder: (item) => item,
+                label: 'Select',
+                width: 200,
+              ),
+            ),
+          ),
+        );
+
+        final dropdownMenu = tester.widget<DropdownMenu<String>>(
+          find.byType(DropdownMenu<String>),
+        );
+        expect(dropdownMenu.width, equals(200));
+      });
+    });
+
+    // =========================================================================
+    // AppDropdownItem Widget Builder Tests
+    // =========================================================================
+
+    group('AppDropdownItem Widget Builder', () {
+      testWidgets('builds widget with icon', (tester) async {
+        const item = AppDropdownItem(
+          value: 'test',
+          label: 'Test Item',
+          icon: Icons.star,
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Builder(builder: (context) => item.buildWidget(context)),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.star), findsOneWidget);
+        expect(find.text('Test Item'), findsOneWidget);
+      });
+
+      testWidgets('builds widget with subtitle', (tester) async {
+        const item = AppDropdownItem(
+          value: 'test',
+          label: 'Test Item',
+          subtitle: 'This is a subtitle',
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Builder(builder: (context) => item.buildWidget(context)),
+            ),
+          ),
+        );
+
+        expect(find.text('Test Item'), findsOneWidget);
+        expect(find.text('This is a subtitle'), findsOneWidget);
+      });
+
+      testWidgets('builds widget with icon and subtitle', (tester) async {
+        const item = AppDropdownItem(
+          value: 'test',
+          label: 'Test Item',
+          icon: Icons.star,
+          subtitle: 'This is a subtitle',
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Builder(builder: (context) => item.buildWidget(context)),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.star), findsOneWidget);
+        expect(find.text('Test Item'), findsOneWidget);
+        expect(find.text('This is a subtitle'), findsOneWidget);
+      });
+    });
+  });
+}

--- a/packages/core_kit/test/widgets/inputs/app_password_field_test.dart
+++ b/packages/core_kit/test/widgets/inputs/app_password_field_test.dart
@@ -1,0 +1,574 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:core_kit/core_kit.dart';
+
+void main() {
+  group('AppPasswordField', () {
+    testWidgets('renders with label', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppPasswordField(label: 'Password')),
+        ),
+      );
+
+      expect(find.text('Password'), findsOneWidget);
+    });
+
+    testWidgets('obscures text by default', (WidgetTester tester) async {
+      final controller = TextEditingController(text: 'test123');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppPasswordField(controller: controller, label: 'Password'),
+          ),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.obscureText, isTrue);
+    });
+
+    testWidgets('toggles visibility when icon is tapped', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppPasswordField(label: 'Password')),
+        ),
+      );
+
+      // Initially obscured
+      TextField textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.obscureText, isTrue);
+
+      // Find and tap visibility toggle
+      await tester.tap(find.byType(IconButton));
+      await tester.pump();
+
+      // Now visible
+      textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.obscureText, isFalse);
+
+      // Toggle again
+      await tester.tap(find.byType(IconButton));
+      await tester.pump();
+
+      // Obscured again
+      textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.obscureText, isTrue);
+    });
+
+    testWidgets('shows strength indicator when enabled', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppPasswordField(
+              controller: controller,
+              label: 'Password',
+              showStrengthIndicator: true,
+            ),
+          ),
+        ),
+      );
+
+      // Enter weak password
+      controller.text = '123';
+      await tester.pump();
+
+      // Strength indicator should be visible
+      expect(find.text('Weak'), findsOneWidget);
+
+      // Enter medium password
+      controller.text = 'Test1234';
+      await tester.pump();
+
+      expect(find.text('Medium'), findsOneWidget);
+
+      // Enter strong password
+      controller.text = 'Test@1234Strong';
+      await tester.pump();
+
+      expect(find.text('Strong'), findsOneWidget);
+    });
+
+    testWidgets('does not show strength indicator when disabled', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController(text: 'test123');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppPasswordField(
+              controller: controller,
+              label: 'Password',
+              showStrengthIndicator: false,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Weak'), findsNothing);
+      expect(find.text('Medium'), findsNothing);
+      expect(find.text('Strong'), findsNothing);
+    });
+
+    testWidgets('hides strength indicator when there is an error', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController(text: 'test123');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppPasswordField(
+              controller: controller,
+              label: 'Password',
+              showStrengthIndicator: true,
+              errorText: 'Password is too short',
+            ),
+          ),
+        ),
+      );
+
+      // Error text should be visible
+      expect(find.text('Password is too short'), findsOneWidget);
+      // Strength indicator should be hidden
+      expect(find.text('Weak'), findsNothing);
+    });
+
+    testWidgets('shows lock icon when enabled', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppPasswordField(label: 'Password', showLockIcon: true),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.lock_outline), findsOneWidget);
+    });
+
+    testWidgets('calls onChanged callback', (WidgetTester tester) async {
+      String? changedValue;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppPasswordField(
+              label: 'Password',
+              onChanged: (value) => changedValue = value,
+            ),
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), 'newpassword');
+      expect(changedValue, 'newpassword');
+    });
+
+    testWidgets('calls onSubmitted callback', (WidgetTester tester) async {
+      String? submittedValue;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppPasswordField(
+              label: 'Password',
+              onSubmitted: (value) => submittedValue = value,
+            ),
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), 'password123');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+
+      expect(submittedValue, 'password123');
+    });
+
+    testWidgets('disables field when enabled is false', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppPasswordField(label: 'Password', enabled: false),
+          ),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.enabled, isFalse);
+    });
+
+    testWidgets('prevents visibility toggle when disabled', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppPasswordField(label: 'Password', enabled: false),
+          ),
+        ),
+      );
+
+      // Try to tap visibility toggle
+      await tester.tap(find.byType(IconButton));
+      await tester.pump();
+
+      // Should still be obscured
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.obscureText, isTrue);
+    });
+
+    testWidgets('uses correct keyboard type', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppPasswordField(label: 'Password')),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.keyboardType, TextInputType.visiblePassword);
+    });
+
+    testWidgets('shows helper text when provided', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppPasswordField(
+              label: 'Password',
+              helperText: 'Use a strong password',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Use a strong password'), findsOneWidget);
+    });
+
+    testWidgets('shows error text when provided', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppPasswordField(
+              label: 'Password',
+              errorText: 'Password is required',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Password is required'), findsOneWidget);
+    });
+
+    testWidgets('has proper accessibility semantics', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppPasswordField(label: 'Password')),
+        ),
+      );
+
+      // Check for semantic labels
+      final semantics = tester.getSemantics(find.byType(TextField));
+      expect(semantics.label, contains('Password'));
+    });
+
+    group('Password Strength Calculation', () {
+      testWidgets('calculates weak strength for short passwords', (
+        WidgetTester tester,
+      ) async {
+        final controller = TextEditingController();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppPasswordField(
+                controller: controller,
+                label: 'Password',
+                showStrengthIndicator: true,
+              ),
+            ),
+          ),
+        );
+
+        controller.text = '123';
+        await tester.pump();
+
+        expect(find.text('Weak'), findsOneWidget);
+      });
+
+      testWidgets('calculates medium strength for basic passwords', (
+        WidgetTester tester,
+      ) async {
+        final controller = TextEditingController();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppPasswordField(
+                controller: controller,
+                label: 'Password',
+                showStrengthIndicator: true,
+              ),
+            ),
+          ),
+        );
+
+        controller.text = 'Password1';
+        await tester.pump();
+
+        expect(find.text('Medium'), findsOneWidget);
+      });
+
+      testWidgets('calculates strong strength for complex passwords', (
+        WidgetTester tester,
+      ) async {
+        final controller = TextEditingController();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppPasswordField(
+                controller: controller,
+                label: 'Password',
+                showStrengthIndicator: true,
+              ),
+            ),
+          ),
+        );
+
+        controller.text = 'P@ssw0rd!123';
+        await tester.pump();
+
+        expect(find.text('Strong'), findsOneWidget);
+      });
+    });
+
+    group('Password Confirmation Matching', () {
+      testWidgets('detects when passwords match', (WidgetTester tester) async {
+        final passwordController = TextEditingController();
+        final confirmController = TextEditingController();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Column(
+                children: [
+                  AppPasswordField(
+                    controller: passwordController,
+                    label: 'Password',
+                  ),
+                  AppPasswordField(
+                    controller: confirmController,
+                    label: 'Confirm Password',
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        // Enter matching passwords
+        passwordController.text = 'Test@1234';
+        confirmController.text = 'Test@1234';
+        await tester.pump();
+
+        // Both should have the same text
+        expect(passwordController.text, confirmController.text);
+      });
+
+      testWidgets('detects when passwords do not match', (
+        WidgetTester tester,
+      ) async {
+        final passwordController = TextEditingController();
+        final confirmController = TextEditingController();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Column(
+                children: [
+                  AppPasswordField(
+                    controller: passwordController,
+                    label: 'Password',
+                  ),
+                  AppPasswordField(
+                    controller: confirmController,
+                    label: 'Confirm Password',
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        // Enter non-matching passwords
+        passwordController.text = 'Test@1234';
+        confirmController.text = 'Different@5678';
+        await tester.pump();
+
+        // Should not match
+        expect(passwordController.text == confirmController.text, isFalse);
+      });
+
+      testWidgets('shows error when confirmation does not match', (
+        WidgetTester tester,
+      ) async {
+        final confirmController = TextEditingController();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppPasswordField(
+                controller: confirmController,
+                label: 'Confirm Password',
+                errorText: 'Passwords do not match',
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Passwords do not match'), findsOneWidget);
+      });
+    });
+
+    group('Dynamic Validation Errors', () {
+      testWidgets('shows length error for short passwords', (
+        WidgetTester tester,
+      ) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppPasswordField(
+                label: 'Password',
+                errorText: 'Password must be at least 8 characters',
+              ),
+            ),
+          ),
+        );
+
+        expect(
+          find.text('Password must be at least 8 characters'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('shows uppercase requirement error', (
+        WidgetTester tester,
+      ) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppPasswordField(
+                label: 'Password',
+                errorText:
+                    'Password must contain at least one uppercase letter',
+              ),
+            ),
+          ),
+        );
+
+        expect(
+          find.text('Password must contain at least one uppercase letter'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('shows number requirement error', (
+        WidgetTester tester,
+      ) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppPasswordField(
+                label: 'Password',
+                errorText: 'Password must contain at least one number',
+              ),
+            ),
+          ),
+        );
+
+        expect(
+          find.text('Password must contain at least one number'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('shows special character requirement error', (
+        WidgetTester tester,
+      ) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppPasswordField(
+                label: 'Password',
+                errorText:
+                    'Password must contain at least one special character',
+              ),
+            ),
+          ),
+        );
+
+        expect(
+          find.text('Password must contain at least one special character'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('clears error when validation passes', (
+        WidgetTester tester,
+      ) async {
+        final controller = TextEditingController();
+        String? errorText = 'Password is too short';
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: StatefulBuilder(
+                builder: (context, setState) {
+                  return AppPasswordField(
+                    controller: controller,
+                    label: 'Password',
+                    errorText: errorText,
+                    onChanged: (value) {
+                      setState(() {
+                        if (value.length >= 8) {
+                          errorText = null;
+                        } else {
+                          errorText = 'Password is too short';
+                        }
+                      });
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        // Initially has error
+        expect(find.text('Password is too short'), findsOneWidget);
+
+        // Enter valid password
+        await tester.enterText(find.byType(TextField), 'ValidPass123');
+        await tester.pumpAndSettle();
+
+        // Error should be cleared
+        expect(find.text('Password is too short'), findsNothing);
+      });
+    });
+  });
+}

--- a/packages/core_kit/test/widgets/inputs/app_search_field_test.dart
+++ b/packages/core_kit/test/widgets/inputs/app_search_field_test.dart
@@ -1,0 +1,414 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:core_kit/core_kit.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AppSearchField', () {
+    testWidgets('renders with search icon and hint text', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppSearchField(hint: 'Search products...')),
+        ),
+      );
+
+      // Verify search icon is displayed
+      expect(find.byIcon(Icons.search), findsOneWidget);
+
+      // Verify hint text is displayed
+      expect(find.text('Search products...'), findsOneWidget);
+    });
+
+    testWidgets('displays default hint text when not provided', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: AppSearchField())),
+      );
+
+      // Verify default hint text
+      expect(find.text('Search...'), findsOneWidget);
+    });
+
+    testWidgets('shows clear button when text is entered', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: AppSearchField(controller: controller)),
+        ),
+      );
+
+      // Initially no clear button
+      expect(find.byIcon(Icons.clear), findsNothing);
+
+      // Enter text
+      await tester.enterText(find.byType(TextField), 'test query');
+      await tester.pump();
+
+      // Clear button should appear
+      expect(find.byIcon(Icons.clear), findsOneWidget);
+    });
+
+    testWidgets('clears text when clear button is tapped', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController(text: 'initial text');
+      String? lastSearchQuery;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppSearchField(
+              controller: controller,
+              onSearchChanged: (query) {
+                lastSearchQuery = query;
+              },
+            ),
+          ),
+        ),
+      );
+
+      // Verify initial text
+      expect(controller.text, 'initial text');
+      expect(find.byIcon(Icons.clear), findsOneWidget);
+
+      // Tap clear button
+      await tester.tap(find.byIcon(Icons.clear));
+      await tester.pump();
+
+      // Verify text is cleared
+      expect(controller.text, '');
+      expect(find.byIcon(Icons.clear), findsNothing);
+      expect(lastSearchQuery, '');
+    });
+
+    testWidgets('triggers onSearchChanged after debounce delay', (
+      WidgetTester tester,
+    ) async {
+      final List<String> searchQueries = [];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppSearchField(
+              debounceDelay: 300,
+              onSearchChanged: (query) {
+                searchQueries.add(query);
+              },
+            ),
+          ),
+        ),
+      );
+
+      // Enter text
+      await tester.enterText(find.byType(TextField), 'test');
+
+      // Should not trigger immediately
+      expect(searchQueries, isEmpty);
+
+      // Wait for debounce delay
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Should trigger after debounce
+      expect(searchQueries, ['test']);
+    });
+
+    testWidgets('debouncing cancels previous timer on new input', (
+      WidgetTester tester,
+    ) async {
+      final List<String> searchQueries = [];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppSearchField(
+              debounceDelay: 300,
+              onSearchChanged: (query) {
+                searchQueries.add(query);
+              },
+            ),
+          ),
+        ),
+      );
+
+      // Enter text multiple times rapidly
+      await tester.enterText(find.byType(TextField), 't');
+      await tester.pump(const Duration(milliseconds: 100));
+
+      await tester.enterText(find.byType(TextField), 'te');
+      await tester.pump(const Duration(milliseconds: 100));
+
+      await tester.enterText(find.byType(TextField), 'test');
+
+      // Should not trigger for intermediate values
+      expect(searchQueries, isEmpty);
+
+      // Wait for debounce delay from last input
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Should only trigger for final value
+      expect(searchQueries, ['test']);
+    });
+
+    testWidgets('triggers onSearchSubmitted immediately without debounce', (
+      WidgetTester tester,
+    ) async {
+      String? submittedQuery;
+      final List<String> changedQueries = [];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppSearchField(
+              debounceDelay: 300,
+              onSearchChanged: (query) {
+                changedQueries.add(query);
+              },
+              onSearchSubmitted: (query) {
+                submittedQuery = query;
+              },
+            ),
+          ),
+        ),
+      );
+
+      // Enter text and submit
+      await tester.enterText(find.byType(TextField), 'immediate search');
+      await tester.testTextInput.receiveAction(TextInputAction.search);
+      await tester.pump();
+
+      // Should trigger submit immediately
+      expect(submittedQuery, 'immediate search');
+
+      // Should not have triggered debounced change yet
+      expect(changedQueries, isEmpty);
+
+      // Wait for debounce delay
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Now debounced change should not trigger (cancelled by submit)
+      expect(changedQueries, isEmpty);
+    });
+
+    testWidgets('clears field on submit when clearOnSubmit is true', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppSearchField(
+              controller: controller,
+              clearOnSubmit: true,
+              onSearchSubmitted: (query) {},
+            ),
+          ),
+        ),
+      );
+
+      // Enter text
+      await tester.enterText(find.byType(TextField), 'test query');
+      await tester.pump();
+
+      expect(controller.text, 'test query');
+
+      // Submit
+      await tester.testTextInput.receiveAction(TextInputAction.search);
+      await tester.pump();
+
+      // Should be cleared
+      expect(controller.text, '');
+    });
+
+    testWidgets('does not clear field on submit when clearOnSubmit is false', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppSearchField(
+              controller: controller,
+              clearOnSubmit: false,
+              onSearchSubmitted: (query) {},
+            ),
+          ),
+        ),
+      );
+
+      // Enter text
+      await tester.enterText(find.byType(TextField), 'test query');
+      await tester.pump();
+
+      expect(controller.text, 'test query');
+
+      // Submit
+      await tester.testTextInput.receiveAction(TextInputAction.search);
+      await tester.pump();
+
+      // Should not be cleared
+      expect(controller.text, 'test query');
+    });
+
+    testWidgets('shows loading indicator when isLoading is true', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppSearchField(isLoading: true)),
+        ),
+      );
+
+      // Verify loading indicator is displayed
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      // Clear button should not be visible
+      expect(find.byIcon(Icons.clear), findsNothing);
+    });
+
+    testWidgets('loading indicator takes priority over clear button', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController(text: 'search query');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppSearchField(controller: controller, isLoading: true),
+          ),
+        ),
+      );
+
+      // Loading indicator should be visible
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      // Clear button should not be visible even though text exists
+      expect(find.byIcon(Icons.clear), findsNothing);
+    });
+
+    testWidgets('autofocus works when enabled', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppSearchField(autofocus: true)),
+        ),
+      );
+
+      await tester.pump();
+
+      // TextField should be focused
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.autofocus, isTrue);
+    });
+
+    testWidgets('disabled state prevents interaction', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: AppSearchField(enabled: false))),
+      );
+
+      // Verify field is disabled
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.enabled, isFalse);
+    });
+
+    testWidgets('uses custom debounce delay', (WidgetTester tester) async {
+      final List<String> searchQueries = [];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppSearchField(
+              debounceDelay: 500,
+              onSearchChanged: (query) {
+                searchQueries.add(query);
+              },
+            ),
+          ),
+        ),
+      );
+
+      // Enter text
+      await tester.enterText(find.byType(TextField), 'test');
+
+      // Wait for 300ms (default delay)
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Should not trigger yet (using 500ms delay)
+      expect(searchQueries, isEmpty);
+
+      // Wait for remaining 200ms
+      await tester.pump(const Duration(milliseconds: 200));
+
+      // Should trigger now
+      expect(searchQueries, ['test']);
+    });
+
+    testWidgets('disposes controller when internally created', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: AppSearchField())),
+      );
+
+      // Dispose widget
+      await tester.pumpWidget(const MaterialApp(home: Scaffold()));
+
+      // Should not throw error (controller properly disposed)
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('does not dispose external controller', (
+      WidgetTester tester,
+    ) async {
+      final controller = TextEditingController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: AppSearchField(controller: controller)),
+        ),
+      );
+
+      // Dispose widget
+      await tester.pumpWidget(const MaterialApp(home: Scaffold()));
+
+      // External controller should still be usable
+      expect(() => controller.text, returnsNormally);
+      controller.dispose();
+    });
+
+    testWidgets('updates when controller changes', (WidgetTester tester) async {
+      final controller1 = TextEditingController(text: 'first');
+      final controller2 = TextEditingController(text: 'second');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: AppSearchField(controller: controller1)),
+        ),
+      );
+
+      expect(find.text('first'), findsOneWidget);
+
+      // Change controller
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: AppSearchField(controller: controller2)),
+        ),
+      );
+
+      expect(find.text('second'), findsOneWidget);
+
+      controller1.dispose();
+      controller2.dispose();
+    });
+  });
+}

--- a/packages/core_kit/test/widgets/inputs/app_slider_test.dart
+++ b/packages/core_kit/test/widgets/inputs/app_slider_test.dart
@@ -1,0 +1,615 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:core_kit/widgets/inputs/app_slider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AppSlider', () {
+    group('Basic Rendering', () {
+      testWidgets('renders with required properties', (tester) async {
+        double sliderValue = 50;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider(
+                value: sliderValue,
+                min: 0,
+                max: 100,
+                onChanged: (value) {
+                  sliderValue = value;
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(Slider), findsOneWidget);
+      });
+
+      testWidgets('displays label when provided', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider(
+                value: 50,
+                min: 0,
+                max: 100,
+                label: 'Volume',
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Volume'), findsOneWidget);
+      });
+
+      testWidgets('renders without label (slider only)', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider(
+                value: 50,
+                min: 0,
+                max: 100,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(Slider), findsOneWidget);
+        expect(find.byType(Text), findsNothing);
+      });
+
+      testWidgets('shows min/max indicators when enabled', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider(
+                value: 50,
+                min: 0,
+                max: 100,
+                showMinMaxIndicators: true,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('0.0'), findsOneWidget);
+        expect(find.text('100.0'), findsOneWidget);
+      });
+    });
+
+    group('Continuous Mode', () {
+      testWidgets('displays initial value correctly', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider(
+                value: 75,
+                min: 0,
+                max: 100,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final slider = tester.widget<Slider>(find.byType(Slider));
+        expect(slider.value, 75);
+      });
+
+      testWidgets('calls onChanged during drag', (tester) async {
+        double sliderValue = 50;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: StatefulBuilder(
+                builder: (context, setState) {
+                  return AppSlider(
+                    value: sliderValue,
+                    min: 0,
+                    max: 100,
+                    onChanged: (value) {
+                      setState(() {
+                        sliderValue = value;
+                      });
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        // Simulate drag (this is simplified, actual drag testing is complex)
+        final slider = find.byType(Slider);
+        expect(slider, findsOneWidget);
+
+        // Verify initial value
+        expect(sliderValue, 50);
+      });
+
+      testWidgets('calls onChangeEnd when drag completes', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider(
+                value: 50,
+                min: 0,
+                max: 100,
+                onChanged: (value) {},
+                onChangeEnd: (value) {
+                  // Callback exists and will be called
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(Slider), findsOneWidget);
+      });
+
+      testWidgets('respects min and max bounds', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider(
+                value: 25,
+                min: 10,
+                max: 90,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final slider = tester.widget<Slider>(find.byType(Slider));
+        expect(slider.min, 10);
+        expect(slider.max, 90);
+      });
+    });
+
+    group('Discrete Mode', () {
+      testWidgets('creates divisions when specified', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider(
+                value: 5,
+                min: 0,
+                max: 10,
+                divisions: 10,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final slider = tester.widget<Slider>(find.byType(Slider));
+        expect(slider.divisions, 10);
+      });
+
+      testWidgets('shows value label in discrete mode', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider(
+                value: 5,
+                min: 0,
+                max: 10,
+                divisions: 10,
+                showValueLabel: true,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final slider = tester.widget<Slider>(find.byType(Slider));
+        expect(slider.label, isNotNull);
+        expect(slider.label, '5');
+      });
+    });
+
+    group('Range Mode', () {
+      testWidgets('renders RangeSlider for range mode', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider.range(
+                values: const RangeValues(20, 80),
+                min: 0,
+                max: 100,
+                onRangeChanged: (values) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(RangeSlider), findsOneWidget);
+      });
+
+      testWidgets('displays initial range values', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider.range(
+                values: const RangeValues(25, 75),
+                min: 0,
+                max: 100,
+                onRangeChanged: (values) {},
+              ),
+            ),
+          ),
+        );
+
+        final rangeSlider = tester.widget<RangeSlider>(
+          find.byType(RangeSlider),
+        );
+        expect(rangeSlider.values.start, 25);
+        expect(rangeSlider.values.end, 75);
+      });
+
+      testWidgets('shows range labels when enabled', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider.range(
+                values: const RangeValues(20, 80),
+                min: 0,
+                max: 100,
+                showValueLabel: true,
+                onRangeChanged: (values) {},
+              ),
+            ),
+          ),
+        );
+
+        final rangeSlider = tester.widget<RangeSlider>(
+          find.byType(RangeSlider),
+        );
+        expect(rangeSlider.labels, isNotNull);
+        expect(rangeSlider.labels?.start, '20.0');
+        expect(rangeSlider.labels?.end, '80.0');
+      });
+
+      testWidgets('respects min and max bounds in range mode', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider.range(
+                values: const RangeValues(100, 500),
+                min: 0,
+                max: 1000,
+                onRangeChanged: (values) {},
+              ),
+            ),
+          ),
+        );
+
+        final rangeSlider = tester.widget<RangeSlider>(
+          find.byType(RangeSlider),
+        );
+        expect(rangeSlider.min, 0);
+        expect(rangeSlider.max, 1000);
+      });
+    });
+
+    group('Value Labels and Formatting', () {
+      testWidgets('uses default formatter when none provided', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider(
+                value: 42.7,
+                min: 0,
+                max: 100,
+                showValueLabel: true,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final slider = tester.widget<Slider>(find.byType(Slider));
+        expect(slider.label, '42.7');
+      });
+
+      testWidgets('uses custom label formatter', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider(
+                value: 50,
+                min: 0,
+                max: 100,
+                showValueLabel: true,
+                labelFormatter: (value) => '\$${value.toStringAsFixed(0)}',
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final slider = tester.widget<Slider>(find.byType(Slider));
+        expect(slider.label, '\$50');
+      });
+
+      testWidgets('custom formatter works with min/max indicators', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider(
+                value: 50,
+                min: 0,
+                max: 100,
+                showMinMaxIndicators: true,
+                labelFormatter: (value) => '${value.toInt()}%',
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('0%'), findsOneWidget);
+        expect(find.text('100%'), findsOneWidget);
+      });
+    });
+
+    group('Disabled State', () {
+      testWidgets('is disabled when onChanged is null', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider(value: 50, min: 0, max: 100, onChanged: null),
+            ),
+          ),
+        );
+
+        final slider = tester.widget<Slider>(find.byType(Slider));
+        expect(slider.onChanged, isNull);
+      });
+
+      testWidgets('is disabled when enabled is false', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider(
+                value: 50,
+                min: 0,
+                max: 100,
+                enabled: false,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final slider = tester.widget<Slider>(find.byType(Slider));
+        expect(slider.onChanged, isNull);
+      });
+
+      testWidgets('range slider is disabled when onRangeChanged is null', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider.range(
+                values: const RangeValues(20, 80),
+                min: 0,
+                max: 100,
+                onRangeChanged: null,
+              ),
+            ),
+          ),
+        );
+
+        final rangeSlider = tester.widget<RangeSlider>(
+          find.byType(RangeSlider),
+        );
+        expect(rangeSlider.onChanged, isNull);
+      });
+
+      testWidgets('label shows reduced opacity when disabled', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider(
+                value: 50,
+                min: 0,
+                max: 100,
+                label: 'Disabled slider',
+                onChanged: null,
+              ),
+            ),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Disabled slider'));
+        final textStyle = textWidget.style;
+
+        // Check if the text has reduced opacity (disabled state)
+        expect(textStyle?.color?.a, lessThan(1.0));
+      });
+    });
+
+    group('Color Customization', () {
+      testWidgets('uses custom active color', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider(
+                value: 50,
+                min: 0,
+                max: 100,
+                activeColor: Colors.green,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final slider = tester.widget<Slider>(find.byType(Slider));
+        expect(slider.activeColor, Colors.green);
+      });
+
+      testWidgets('uses custom inactive color', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider(
+                value: 50,
+                min: 0,
+                max: 100,
+                inactiveColor: Colors.grey,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final slider = tester.widget<Slider>(find.byType(Slider));
+        expect(slider.inactiveColor, Colors.grey);
+      });
+
+      testWidgets('uses custom thumb color', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider(
+                value: 50,
+                min: 0,
+                max: 100,
+                thumbColor: Colors.orange,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final slider = tester.widget<Slider>(find.byType(Slider));
+        expect(slider.thumbColor, Colors.orange);
+      });
+    });
+
+    group('Theme Integration', () {
+      testWidgets('uses theme colors when custom colors not provided', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(
+              colorScheme: ColorScheme.fromSeed(
+                seedColor: Colors.blue,
+                brightness: Brightness.light,
+              ),
+            ),
+            home: Scaffold(
+              body: AppSlider(
+                value: 50,
+                min: 0,
+                max: 100,
+                label: 'Themed slider',
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Themed slider'), findsOneWidget);
+        expect(find.byType(Slider), findsOneWidget);
+      });
+
+      testWidgets('respects dark theme', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(
+              colorScheme: ColorScheme.fromSeed(
+                seedColor: Colors.blue,
+                brightness: Brightness.dark,
+              ),
+            ),
+            home: Scaffold(
+              body: AppSlider(
+                value: 50,
+                min: 0,
+                max: 100,
+                label: 'Dark themed slider',
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Dark themed slider'), findsOneWidget);
+        expect(find.byType(Slider), findsOneWidget);
+      });
+    });
+
+    group('Edge Cases', () {
+      testWidgets('handles min equal to max', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider(
+                value: 50,
+                min: 50,
+                max: 50,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final slider = tester.widget<Slider>(find.byType(Slider));
+        expect(slider.min, slider.max);
+      });
+
+      testWidgets('handles value at minimum', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider(
+                value: 0,
+                min: 0,
+                max: 100,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final slider = tester.widget<Slider>(find.byType(Slider));
+        expect(slider.value, slider.min);
+      });
+
+      testWidgets('handles value at maximum', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSlider(
+                value: 100,
+                min: 0,
+                max: 100,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final slider = tester.widget<Slider>(find.byType(Slider));
+        expect(slider.value, slider.max);
+      });
+    });
+  });
+}

--- a/packages/core_kit/test/widgets/inputs/app_switch_test.dart
+++ b/packages/core_kit/test/widgets/inputs/app_switch_test.dart
@@ -1,0 +1,498 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:core_kit/widgets/inputs/app_switch.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AppSwitch', () {
+    group('Basic Rendering', () {
+      testWidgets('renders with required properties', (tester) async {
+        bool switchValue = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: switchValue,
+                onChanged: (value) {
+                  switchValue = value;
+                },
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(Switch), findsOneWidget);
+      });
+
+      testWidgets('displays label when provided', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                label: 'Enable notifications',
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Enable notifications'), findsOneWidget);
+      });
+
+      testWidgets('displays subtitle when provided', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                label: 'Dark mode',
+                subtitle: 'Use dark theme across the app',
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Dark mode'), findsOneWidget);
+        expect(find.text('Use dark theme across the app'), findsOneWidget);
+      });
+
+      testWidgets('displays icon when provided', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                label: 'Bluetooth',
+                icon: Icons.bluetooth,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.bluetooth), findsOneWidget);
+      });
+
+      testWidgets('renders without label (switch only)', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(value: false, onChanged: (value) {}),
+            ),
+          ),
+        );
+
+        expect(find.byType(Switch), findsOneWidget);
+        expect(find.byType(Text), findsNothing);
+      });
+    });
+
+    group('State Management', () {
+      testWidgets('shows on state when value is true', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: AppSwitch(value: true, onChanged: (value) {})),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        expect(switchWidget.value, true);
+      });
+
+      testWidgets('shows off state when value is false', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(value: false, onChanged: (value) {}),
+            ),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        expect(switchWidget.value, false);
+      });
+
+      testWidgets('calls onChanged when toggled', (tester) async {
+        bool switchValue = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: switchValue,
+                onChanged: (value) {
+                  switchValue = value;
+                },
+              ),
+            ),
+          ),
+        );
+
+        // Tap the switch
+        await tester.tap(find.byType(Switch));
+        await tester.pumpAndSettle();
+
+        // Verify the value changed
+        expect(switchValue, true);
+      });
+
+      testWidgets('calls onChanged when label is tapped', (tester) async {
+        bool switchValue = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: StatefulBuilder(
+                builder: (context, setState) {
+                  return AppSwitch(
+                    value: switchValue,
+                    label: 'Toggle me',
+                    onChanged: (value) {
+                      setState(() {
+                        switchValue = value;
+                      });
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        // Tap the label
+        await tester.tap(find.text('Toggle me'));
+        await tester.pumpAndSettle();
+
+        // Verify the value changed
+        expect(switchValue, true);
+      });
+    });
+
+    group('Disabled State', () {
+      testWidgets('is disabled when onChanged is null', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: AppSwitch(value: false, onChanged: null)),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        expect(switchWidget.onChanged, isNull);
+      });
+
+      testWidgets('is disabled when enabled is false', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                enabled: false,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        expect(switchWidget.onChanged, isNull);
+      });
+
+      testWidgets('shows disabled on state', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: AppSwitch(value: true, onChanged: null)),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        expect(switchWidget.value, true);
+        expect(switchWidget.onChanged, isNull);
+      });
+
+      testWidgets('shows disabled off state', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: AppSwitch(value: false, onChanged: null)),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        expect(switchWidget.value, false);
+        expect(switchWidget.onChanged, isNull);
+      });
+
+      testWidgets('does not call onChanged when disabled', (tester) async {
+        bool callbackCalled = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                enabled: false,
+                onChanged: (value) {
+                  callbackCalled = true;
+                },
+              ),
+            ),
+          ),
+        );
+
+        // Try to tap the switch
+        await tester.tap(find.byType(Switch));
+        await tester.pumpAndSettle();
+
+        // Verify callback was not called
+        expect(callbackCalled, false);
+      });
+    });
+
+    group('Color Customization', () {
+      testWidgets('uses custom activeColor', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: true,
+                activeColor: Colors.green,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        final thumbColor = switchWidget.thumbColor;
+        expect(thumbColor, isNotNull);
+        // Verify thumbColor is a WidgetStateProperty
+        expect(thumbColor, isA<WidgetStateProperty<Color?>>());
+      });
+
+      testWidgets('uses custom inactiveColor', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                inactiveColor: Colors.grey,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        final thumbColor = switchWidget.thumbColor;
+        expect(thumbColor, isNotNull);
+        expect(thumbColor, isA<WidgetStateProperty<Color?>>());
+      });
+
+      testWidgets('uses custom activeTrackColor', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: true,
+                activeTrackColor: Colors.lightGreen,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        final trackColor = switchWidget.trackColor;
+        expect(trackColor, isNotNull);
+        expect(trackColor, isA<WidgetStateProperty<Color?>>());
+      });
+
+      testWidgets('uses custom inactiveTrackColor', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                inactiveTrackColor: Colors.blueGrey,
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        final trackColor = switchWidget.trackColor;
+        expect(trackColor, isNotNull);
+        expect(trackColor, isA<WidgetStateProperty<Color?>>());
+      });
+    });
+
+    group('Layout Variants', () {
+      testWidgets('switch only layout has no padding or text', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(value: false, onChanged: (value) {}),
+            ),
+          ),
+        );
+
+        expect(find.byType(Text), findsNothing);
+        expect(find.byType(Switch), findsOneWidget);
+      });
+
+      testWidgets('switch with label has proper layout', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                label: 'Test label',
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Test label'), findsOneWidget);
+        expect(find.byType(Switch), findsOneWidget);
+        expect(find.byType(Row), findsOneWidget);
+      });
+
+      testWidgets('switch with icon, label, and subtitle has full layout', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                icon: Icons.wifi,
+                label: 'WiFi',
+                subtitle: 'Connect to wireless networks',
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.wifi), findsOneWidget);
+        expect(find.text('WiFi'), findsOneWidget);
+        expect(find.text('Connect to wireless networks'), findsOneWidget);
+        expect(find.byType(Switch), findsOneWidget);
+      });
+    });
+
+    group('Accessibility', () {
+      testWidgets('has minimum touch target size', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(value: false, onChanged: (value) {}),
+            ),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        expect(
+          switchWidget.materialTapTargetSize,
+          MaterialTapTargetSize.padded,
+        );
+      });
+
+      testWidgets('label provides semantic context', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                label: 'Enable dark mode',
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Enable dark mode'), findsOneWidget);
+      });
+
+      testWidgets('disabled state is properly indicated', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                label: 'Disabled switch',
+                onChanged: null,
+              ),
+            ),
+          ),
+        );
+
+        final switchWidget = tester.widget<Switch>(find.byType(Switch));
+        expect(switchWidget.onChanged, isNull);
+
+        // Find the label text widget
+        final textWidget = tester.widget<Text>(find.text('Disabled switch'));
+        final textStyle = textWidget.style;
+
+        // Check if the text has reduced opacity (disabled state)
+        expect(textStyle?.color?.a, lessThan(1.0));
+      });
+    });
+
+    group('Theme Integration', () {
+      testWidgets('uses theme colors when custom colors not provided', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(
+              colorScheme: ColorScheme.fromSeed(
+                seedColor: Colors.blue,
+                brightness: Brightness.light,
+              ),
+            ),
+            home: Scaffold(
+              body: AppSwitch(
+                value: true,
+                label: 'Themed switch',
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Themed switch'), findsOneWidget);
+        expect(find.byType(Switch), findsOneWidget);
+      });
+
+      testWidgets('respects dark theme', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(
+              colorScheme: ColorScheme.fromSeed(
+                seedColor: Colors.blue,
+                brightness: Brightness.dark,
+              ),
+            ),
+            home: Scaffold(
+              body: AppSwitch(
+                value: false,
+                label: 'Dark themed switch',
+                onChanged: (value) {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Dark themed switch'), findsOneWidget);
+        expect(find.byType(Switch), findsOneWidget);
+      });
+    });
+  });
+}

--- a/packages/core_kit/test/widgets/inputs/app_text_field_test.dart
+++ b/packages/core_kit/test/widgets/inputs/app_text_field_test.dart
@@ -1,0 +1,413 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:core_kit/core_kit.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AppTextField', () {
+    testWidgets('renders with label and hint', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppTextField(label: 'Test Label', hint: 'Test Hint'),
+          ),
+        ),
+      );
+
+      expect(find.text('Test Label'), findsOneWidget);
+      expect(find.text('Test Hint'), findsOneWidget);
+    });
+
+    testWidgets('displays helper text', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppTextField(
+              label: 'Field',
+              helperText: 'This is helper text',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('This is helper text'), findsOneWidget);
+    });
+
+    testWidgets('displays error text in error state', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppTextField(label: 'Field', errorText: 'This is an error'),
+          ),
+        ),
+      );
+
+      expect(find.text('This is an error'), findsOneWidget);
+    });
+
+    testWidgets('calls onChanged when text changes', (tester) async {
+      String? changedValue;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppTextField(
+              label: 'Field',
+              onChanged: (value) => changedValue = value,
+            ),
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), 'Test Value');
+      expect(changedValue, 'Test Value');
+    });
+
+    testWidgets('calls onSubmitted when submitted', (tester) async {
+      String? submittedValue;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppTextField(
+              label: 'Field',
+              onSubmitted: (value) => submittedValue = value,
+            ),
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), 'Submit Test');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+
+      expect(submittedValue, 'Submit Test');
+    });
+
+    testWidgets('displays prefix icon', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppTextField(label: 'Field', prefixIcon: Icons.search),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.search), findsOneWidget);
+    });
+
+    testWidgets('displays suffix icon and handles tap', (tester) async {
+      bool suffixTapped = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppTextField(
+              label: 'Field',
+              suffixIcon: Icons.clear,
+              onSuffixIconTap: () => suffixTapped = true,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.clear), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.clear));
+      await tester.pump();
+
+      expect(suffixTapped, true);
+    });
+
+    testWidgets('obscures text when obscureText is true', (tester) async {
+      final controller = TextEditingController(text: 'password123');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppTextField(
+              controller: controller,
+              label: 'Password',
+              obscureText: true,
+            ),
+          ),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.obscureText, true);
+    });
+
+    testWidgets('is disabled when enabled is false', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppTextField(label: 'Disabled Field', enabled: false),
+          ),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.enabled, false);
+    });
+
+    testWidgets('is read-only when readOnly is true', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppTextField(label: 'Read-only Field', readOnly: true),
+          ),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.readOnly, true);
+    });
+
+    testWidgets('enforces maxLength', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppTextField(label: 'Field', maxLength: 5)),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.maxLength, 5);
+    });
+
+    testWidgets('uses controller with initial text', (tester) async {
+      final controller = TextEditingController(text: 'Initial Text');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppTextField(label: 'Field', controller: controller),
+          ),
+        ),
+      );
+
+      expect(controller.text, 'Initial Text');
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.controller?.text, 'Initial Text');
+    });
+
+    testWidgets('autofocuses when autofocus is true', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppTextField(label: 'Field', autofocus: true)),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.autofocus, true);
+    });
+
+    testWidgets('calls onFocusChange when focus changes', (tester) async {
+      bool? hasFocus;
+      final focusNode1 = FocusNode();
+      final focusNode2 = FocusNode();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                AppTextField(
+                  label: 'Field 1',
+                  focusNode: focusNode1,
+                  onFocusChange: (focused) => hasFocus = focused,
+                ),
+                AppTextField(label: 'Field 2', focusNode: focusNode2),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Request focus on first field
+      focusNode1.requestFocus();
+      await tester.pump();
+      expect(hasFocus, true);
+
+      // Request focus on second field
+      focusNode2.requestFocus();
+      await tester.pump();
+      expect(hasFocus, false);
+    });
+  });
+
+  group('AppTextField.multiline', () {
+    testWidgets('creates multiline text field', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppTextField.multiline(label: 'Description')),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.maxLines, 5);
+      expect(textField.minLines, 3);
+      expect(textField.keyboardType, TextInputType.multiline);
+    });
+  });
+
+  group('AppTextField.numeric', () {
+    testWidgets('creates numeric text field', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppTextField.numeric(label: 'Age')),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.keyboardType, TextInputType.number);
+      expect(textField.maxLines, 1);
+    });
+
+    testWidgets('applies numeric input formatters', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppTextField.numeric(
+              label: 'Age',
+              inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            ),
+          ),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.inputFormatters, isNotEmpty);
+    });
+  });
+
+  group('AppTextField.email', () {
+    testWidgets('creates email text field', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppTextField.email(label: 'Email')),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.keyboardType, TextInputType.emailAddress);
+      expect(textField.autofillHints, contains(AutofillHints.email));
+    });
+  });
+
+  group('AppTextField.phone', () {
+    testWidgets('creates phone text field', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppTextField.phone(label: 'Phone')),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.keyboardType, TextInputType.phone);
+      expect(textField.autofillHints, contains(AutofillHints.telephoneNumber));
+    });
+  });
+
+  group('AppTextField.url', () {
+    testWidgets('creates URL text field', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppTextField.url(label: 'Website')),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      expect(textField.keyboardType, TextInputType.url);
+      expect(textField.autofillHints, contains(AutofillHints.url));
+    });
+  });
+
+  group('AppTextField Material Design 3 styling', () {
+    testWidgets('applies correct border radius', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppTextField(label: 'Field')),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      final decoration = textField.decoration as InputDecoration;
+      final border = decoration.border as OutlineInputBorder;
+
+      expect(border.borderRadius, BorderRadius.circular(4.0));
+    });
+
+    testWidgets('applies correct content padding', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppTextField(label: 'Field')),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      final decoration = textField.decoration as InputDecoration;
+
+      expect(
+        decoration.contentPadding,
+        const EdgeInsets.symmetric(horizontal: 16.0, vertical: 16.0),
+      );
+    });
+
+    testWidgets('hides character counter when showCharacterCounter is false', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppTextField(
+              label: 'Field',
+              maxLength: 10,
+              showCharacterCounter: false,
+            ),
+          ),
+        ),
+      );
+
+      final textField = tester.widget<TextField>(find.byType(TextField));
+      final decoration = textField.decoration as InputDecoration;
+
+      expect(decoration.counterText, '');
+    });
+  });
+
+  group('AppTextField controller integration', () {
+    testWidgets('uses provided controller', (tester) async {
+      final controller = TextEditingController(text: 'Initial');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppTextField(controller: controller, label: 'Field'),
+          ),
+        ),
+      );
+
+      expect(find.text('Initial'), findsOneWidget);
+      expect(controller.text, 'Initial');
+    });
+
+    testWidgets('updates controller when text changes', (tester) async {
+      final controller = TextEditingController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppTextField(controller: controller, label: 'Field'),
+          ),
+        ),
+      );
+
+      await tester.enterText(find.byType(TextField), 'New Text');
+      expect(controller.text, 'New Text');
+    });
+  });
+}

--- a/packages/core_kit/test/widgets/surfaces/app_card_test.dart
+++ b/packages/core_kit/test/widgets/surfaces/app_card_test.dart
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:core_kit/widgets/surfaces/app_card.dart';
+
+void main() {
+  group('AppCard Tests', () {
+    testWidgets('AppCard default variant renders correctly', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: AppCard(child: const Text('Default Card'))),
+        ),
+      );
+
+      final cardFinder = find.byType(Card);
+      expect(cardFinder, findsOneWidget);
+
+      final Card card = tester.widget(cardFinder);
+      expect(card.elevation, 1.0);
+      expect(card.clipBehavior, Clip.hardEdge);
+      expect(find.text('Default Card'), findsOneWidget);
+    });
+
+    testWidgets('AppCard.flat variant has 0 elevation', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(body: AppCard.flat(child: const Text('Flat Card'))),
+        ),
+      );
+
+      final Card card = tester.widget(find.byType(Card));
+      expect(card.elevation, 0.0);
+    });
+
+    testWidgets('AppCard.elevated variant has 3 elevation', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppCard.elevated(child: const Text('Elevated Card')),
+          ),
+        ),
+      );
+
+      final Card card = tester.widget(find.byType(Card));
+      expect(card.elevation, 3.0);
+    });
+
+    testWidgets('AppCard.outlined variant has border and 0 elevation', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppCard.outlined(child: const Text('Outlined Card')),
+          ),
+        ),
+      );
+
+      final Card card = tester.widget(find.byType(Card));
+      expect(card.elevation, 0.0);
+
+      final shape = card.shape as RoundedRectangleBorder;
+      expect(shape.side.style, BorderStyle.solid);
+    });
+
+    testWidgets('AppCard handles onTap interaction', (tester) async {
+      bool tapped = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppCard(
+              onTap: () {
+                tapped = true;
+              },
+              child: const Text('Tappable Card'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(AppCard));
+      await tester.pumpAndSettle();
+
+      expect(tapped, isTrue);
+      // Ensure InkWell is present
+      expect(find.byType(InkWell), findsOneWidget);
+    });
+
+    testWidgets('AppCard applies custom properties correctly', (tester) async {
+      const customPadding = EdgeInsets.all(20);
+      const customColor = Colors.red;
+      const customRadius = BorderRadius.all(Radius.circular(20));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppCard(
+              padding: customPadding,
+              color: customColor,
+              borderRadius: customRadius,
+              child: const Text('Custom Card'),
+            ),
+          ),
+        ),
+      );
+
+      final Card card = tester.widget(find.byType(Card));
+      expect(card.color, customColor);
+
+      // Find the Padding that directly wraps the text "Custom Card"
+      // Note: There might be other paddings (e.g. Card margin), so we target the specific one.
+      final paddingFinder = find
+          .ancestor(
+            of: find.text('Custom Card'),
+            matching: find.byType(Padding),
+          )
+          .first;
+
+      final paddingWidget = tester.widget<Padding>(paddingFinder);
+      expect(paddingWidget.padding, customPadding);
+
+      final shape = card.shape as RoundedRectangleBorder;
+      expect(shape.borderRadius, customRadius);
+    });
+
+    testWidgets('AppCard structure renders InkWell inside Card', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppCard(onTap: () {}, child: const Text('Structure Test')),
+          ),
+        ),
+      );
+
+      // Verify InkWell is a descendant of Card
+      expect(
+        find.descendant(of: find.byType(Card), matching: find.byType(InkWell)),
+        findsOneWidget,
+      );
+    });
+  });
+}

--- a/packages/core_kit/test/widgets/surfaces/app_list_tile_test.dart
+++ b/packages/core_kit/test/widgets/surfaces/app_list_tile_test.dart
@@ -1,0 +1,449 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:core_kit/core_kit.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AppListTile', () {
+    testWidgets('renders with title only', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppListTile(title: 'Test Title')),
+        ),
+      );
+
+      expect(find.text('Test Title'), findsOneWidget);
+    });
+
+    testWidgets('renders with title and subtitle', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppListTile(title: 'Test Title', subtitle: 'Test Subtitle'),
+          ),
+        ),
+      );
+
+      expect(find.text('Test Title'), findsOneWidget);
+      expect(find.text('Test Subtitle'), findsOneWidget);
+    });
+
+    testWidgets('renders with leading widget', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppListTile(leading: Icon(Icons.star), title: 'Test Title'),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.star), findsOneWidget);
+      expect(find.text('Test Title'), findsOneWidget);
+    });
+
+    testWidgets('renders with trailing widget', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              title: 'Test Title',
+              trailing: Icon(Icons.chevron_right),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Test Title'), findsOneWidget);
+      expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+    });
+
+    testWidgets('renders with all widgets', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              leading: Icon(Icons.star),
+              title: 'Test Title',
+              subtitle: 'Test Subtitle',
+              trailing: Icon(Icons.chevron_right),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.star), findsOneWidget);
+      expect(find.text('Test Title'), findsOneWidget);
+      expect(find.text('Test Subtitle'), findsOneWidget);
+      expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+    });
+
+    testWidgets('calls onTap when tapped', (WidgetTester tester) async {
+      var tapped = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppListTile(title: 'Test Title', onTap: () => tapped = true),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(AppListTile));
+      await tester.pump();
+
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('calls onLongPress when long pressed', (
+      WidgetTester tester,
+    ) async {
+      var longPressed = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              title: 'Test Title',
+              onLongPress: () => longPressed = true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.longPress(find.byType(AppListTile));
+      await tester.pump();
+
+      expect(longPressed, isTrue);
+    });
+
+    testWidgets('does not call onTap when disabled', (
+      WidgetTester tester,
+    ) async {
+      var tapped = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              title: 'Test Title',
+              enabled: false,
+              onTap: () => tapped = true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(AppListTile));
+      await tester.pump();
+
+      expect(tapped, isFalse);
+    });
+
+    testWidgets('does not call onLongPress when disabled', (
+      WidgetTester tester,
+    ) async {
+      var longPressed = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              title: 'Test Title',
+              enabled: false,
+              onLongPress: () => longPressed = true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.longPress(find.byType(AppListTile));
+      await tester.pump();
+
+      expect(longPressed, isFalse);
+    });
+
+    testWidgets('displays selected state', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppListTile(title: 'Test Title', selected: true),
+          ),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.selected, isTrue);
+    });
+
+    testWidgets('applies dense mode', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppListTile(title: 'Test Title', dense: true)),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.dense, isTrue);
+    });
+
+    testWidgets('enables three-line mode', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              title: 'Test Title',
+              subtitle: 'Test Title',
+              isThreeLine: true,
+            ),
+          ),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.isThreeLine, isTrue);
+    });
+
+    testWidgets('applies custom content padding', (WidgetTester tester) async {
+      const customPadding = EdgeInsets.all(24.0);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              title: 'Test Title',
+              contentPadding: customPadding,
+            ),
+          ),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.contentPadding, customPadding);
+    });
+
+    testWidgets('applies custom tile color', (WidgetTester tester) async {
+      const customColor = Colors.blue;
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppListTile(title: 'Test Title', tileColor: customColor),
+          ),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.tileColor, customColor);
+    });
+
+    testWidgets('applies custom selected tile color', (
+      WidgetTester tester,
+    ) async {
+      const customColor = Colors.green;
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              title: 'Test Title',
+              selected: true,
+              selectedTileColor: customColor,
+            ),
+          ),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.selectedTileColor, customColor);
+    });
+
+    testWidgets('uses default selected tile color from theme', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            useMaterial3: true,
+            colorScheme: ColorScheme.light(secondaryContainer: Colors.purple),
+          ),
+          home: const Scaffold(
+            body: AppListTile(title: 'Test Title', selected: true),
+          ),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.selectedTileColor, Colors.purple);
+    });
+
+    testWidgets('applies custom shape', (WidgetTester tester) async {
+      final customShape = RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16.0),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppListTile(title: 'Test Title', shape: customShape),
+          ),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.shape, customShape);
+    });
+
+    testWidgets('applies custom visual density', (WidgetTester tester) async {
+      const customDensity = VisualDensity.compact;
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              title: 'Test Title',
+              visualDensity: customDensity,
+            ),
+          ),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.visualDensity, customDensity);
+    });
+
+    testWidgets('applies default horizontal padding', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppListTile(title: 'Test Title')),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(
+        listTile.contentPadding,
+        const EdgeInsets.symmetric(horizontal: 16.0),
+      );
+    });
+
+    testWidgets('ensures minimum touch target in dense mode', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppListTile(title: 'Test Title', dense: true)),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.minVerticalPadding, 4.0);
+    });
+
+    testWidgets('ensures minimum touch target in normal mode', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppListTile(title: 'Test Title')),
+        ),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.minVerticalPadding, 8.0);
+    });
+
+    testWidgets('works with complex leading widget', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              leading: Stack(
+                children: const [
+                  CircleAvatar(child: Icon(Icons.person)),
+                  Positioned(
+                    right: 0,
+                    bottom: 0,
+                    child: CircleAvatar(
+                      radius: 6,
+                      backgroundColor: Colors.green,
+                    ),
+                  ),
+                ],
+              ),
+              title: 'Test Title',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(CircleAvatar), findsNWidgets(2));
+      expect(find.text('Test Title'), findsOneWidget);
+    });
+
+    testWidgets('works with complex trailing widget', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppListTile(
+              title: 'Test Title',
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: const [
+                  Icon(Icons.favorite),
+                  SizedBox(width: 8),
+                  Icon(Icons.more_vert),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.favorite), findsOneWidget);
+      expect(find.byIcon(Icons.more_vert), findsOneWidget);
+      expect(find.text('Test Title'), findsOneWidget);
+    });
+
+    testWidgets('works in ListView', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ListView(
+              children: const [
+                AppListTile(title: 'Item 1'),
+                AppListTile(title: 'Item 2'),
+                AppListTile(title: 'Item 3'),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Item 1'), findsOneWidget);
+      expect(find.text('Item 2'), findsOneWidget);
+      expect(find.text('Item 3'), findsOneWidget);
+    });
+
+    testWidgets('maintains accessibility in dense mode', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppListTile(title: 'Test Title', dense: true)),
+        ),
+      );
+
+      // Verify that even in dense mode, the touch target is adequate
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.dense, isTrue);
+      expect(listTile.minVerticalPadding, 4.0);
+    });
+  });
+}

--- a/packages/core_kit/test/widgets/surfaces/app_section_header_test.dart
+++ b/packages/core_kit/test/widgets/surfaces/app_section_header_test.dart
@@ -1,0 +1,567 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:core_kit/widgets/surfaces/app_section_header.dart';
+
+void main() {
+  group('AppSectionHeader Tests', () {
+    // ==================== Basic Rendering Tests ====================
+
+    testWidgets('renders with title only', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppSectionHeader(title: 'Section Title')),
+        ),
+      );
+
+      expect(find.text('Section Title'), findsOneWidget);
+    });
+
+    testWidgets('renders with title and subtitle', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              subtitle: 'Section description text',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Section Title'), findsOneWidget);
+      expect(find.text('Section description text'), findsOneWidget);
+    });
+
+    testWidgets('renders uppercase title when isUpperCase is true', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(title: 'Section Title', isUpperCase: true),
+          ),
+        ),
+      );
+
+      expect(find.text('SECTION TITLE'), findsOneWidget);
+      expect(find.text('Section Title'), findsNothing);
+    });
+
+    // ==================== Leading & Trailing Tests ====================
+
+    testWidgets('renders with leading widget', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              leading: Icon(Icons.settings),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.settings), findsOneWidget);
+      expect(find.text('Section Title'), findsOneWidget);
+    });
+
+    testWidgets('renders with trailing widget', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              trailing: TextButton(
+                onPressed: () {},
+                child: const Text('Action'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Action'), findsOneWidget);
+      expect(find.byType(TextButton), findsOneWidget);
+    });
+
+    testWidgets('renders with both leading and trailing', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              leading: const Icon(Icons.notifications),
+              trailing: IconButton(
+                onPressed: () {},
+                icon: const Icon(Icons.arrow_forward),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.notifications), findsOneWidget);
+      expect(find.byIcon(Icons.arrow_forward), findsOneWidget);
+    });
+
+    // ==================== Divider Tests ====================
+
+    testWidgets('does not show divider by default', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppSectionHeader(title: 'Section Title')),
+        ),
+      );
+
+      expect(find.byType(Divider), findsNothing);
+    });
+
+    testWidgets('shows divider below when showDivider is true', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              showDivider: true,
+              dividerPosition: DividerPosition.below,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(Divider), findsOneWidget);
+    });
+
+    testWidgets('shows divider above when dividerPosition is above', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              showDivider: true,
+              dividerPosition: DividerPosition.above,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(Divider), findsOneWidget);
+    });
+
+    testWidgets('shows dividers both sides when dividerPosition is both', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              showDivider: true,
+              dividerPosition: DividerPosition.both,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(Divider), findsNWidgets(2));
+    });
+
+    testWidgets('does not show divider when dividerPosition is none', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              showDivider: true,
+              dividerPosition: DividerPosition.none,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(Divider), findsNothing);
+    });
+
+    // ==================== Custom Styling Tests ====================
+
+    testWidgets('applies custom padding', (tester) async {
+      const customPadding = EdgeInsets.all(24);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              padding: customPadding,
+            ),
+          ),
+        ),
+      );
+
+      final paddingFinder = find.ancestor(
+        of: find.text('Section Title'),
+        matching: find.byType(Padding),
+      );
+
+      expect(paddingFinder, findsWidgets);
+
+      // Find the Padding that has our custom padding
+      bool foundCustomPadding = false;
+      for (final element in paddingFinder.evaluate()) {
+        final widget = element.widget as Padding;
+        if (widget.padding == customPadding) {
+          foundCustomPadding = true;
+          break;
+        }
+      }
+      expect(foundCustomPadding, isTrue);
+    });
+
+    testWidgets('applies background color', (tester) async {
+      const bgColor = Colors.red;
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              backgroundColor: bgColor,
+            ),
+          ),
+        ),
+      );
+
+      // Find ColoredBox widgets and check if any has our background color
+      final coloredBoxFinder = find.byType(ColoredBox);
+      expect(coloredBoxFinder, findsWidgets);
+
+      bool foundBgColor = false;
+      for (final element in coloredBoxFinder.evaluate()) {
+        final coloredBox = element.widget as ColoredBox;
+        if (coloredBox.color == bgColor) {
+          foundBgColor = true;
+          break;
+        }
+      }
+      expect(foundBgColor, isTrue);
+    });
+
+    testWidgets('applies custom text style', (tester) async {
+      const customStyle = TextStyle(
+        fontSize: 20,
+        fontWeight: FontWeight.bold,
+        color: Colors.blue,
+      );
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              textStyle: customStyle,
+            ),
+          ),
+        ),
+      );
+
+      final textFinder = find.text('Section Title');
+      final textWidget = tester.widget<Text>(textFinder);
+
+      expect(textWidget.style?.fontSize, 20);
+      expect(textWidget.style?.fontWeight, FontWeight.bold);
+      expect(textWidget.style?.color, Colors.blue);
+    });
+
+    testWidgets('applies custom subtitle style', (tester) async {
+      const customSubtitleStyle = TextStyle(
+        fontSize: 14,
+        fontStyle: FontStyle.italic,
+        color: Colors.green,
+      );
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              subtitle: 'Subtitle text',
+              subtitleStyle: customSubtitleStyle,
+            ),
+          ),
+        ),
+      );
+
+      final subtitleFinder = find.text('Subtitle text');
+      final subtitleWidget = tester.widget<Text>(subtitleFinder);
+
+      expect(subtitleWidget.style?.fontSize, 14);
+      expect(subtitleWidget.style?.fontStyle, FontStyle.italic);
+      expect(subtitleWidget.style?.color, Colors.green);
+    });
+
+    // ==================== Accessibility Tests ====================
+
+    testWidgets('has correct semantics for accessibility', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppSectionHeader(title: 'Section Title')),
+        ),
+      );
+
+      final semanticsFinder = find.byType(Semantics);
+      expect(semanticsFinder, findsWidgets);
+
+      // Find the Semantics widget that wraps our content
+      final semanticsWidget = tester.widget<Semantics>(
+        find
+            .ancestor(
+              of: find.text('Section Title'),
+              matching: find.byType(Semantics),
+            )
+            .first,
+      );
+
+      expect(semanticsWidget.properties.header, isTrue);
+    });
+
+    testWidgets('includes subtitle in semantic label', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              subtitle: 'Description',
+            ),
+          ),
+        ),
+      );
+
+      final semanticsWidget = tester.widget<Semantics>(
+        find
+            .ancestor(
+              of: find.text('Section Title'),
+              matching: find.byType(Semantics),
+            )
+            .first,
+      );
+
+      expect(semanticsWidget.properties.label, 'Section Title, Description');
+    });
+
+    // ==================== Layout Tests ====================
+
+    testWidgets('content is laid out in a Row', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              leading: Icon(Icons.star),
+            ),
+          ),
+        ),
+      );
+
+      // Icon and text should be in a row
+      final rowFinder = find.ancestor(
+        of: find.byIcon(Icons.star),
+        matching: find.byType(Row),
+      );
+      expect(rowFinder, findsOneWidget);
+    });
+
+    testWidgets('trailing action is tappable', (tester) async {
+      bool actionTapped = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              trailing: TextButton(
+                onPressed: () {
+                  actionTapped = true;
+                },
+                child: const Text('Tap Me'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Tap Me'));
+      await tester.pumpAndSettle();
+
+      expect(actionTapped, isTrue);
+    });
+
+    // ==================== Min Height Tests ====================
+
+    testWidgets('has minimum height of 48dp by default', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppSectionHeader(title: 'Section Title')),
+        ),
+      );
+
+      final constrainedBoxFinder = find.byType(ConstrainedBox);
+      expect(constrainedBoxFinder, findsWidgets);
+
+      bool foundMinHeight = false;
+      for (final element in constrainedBoxFinder.evaluate()) {
+        final widget = element.widget as ConstrainedBox;
+        if (widget.constraints.minHeight == 48.0) {
+          foundMinHeight = true;
+          break;
+        }
+      }
+      expect(foundMinHeight, isTrue);
+    });
+
+    testWidgets('respects custom minHeight', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(title: 'Section Title', minHeight: 64.0),
+          ),
+        ),
+      );
+
+      final constrainedBoxFinder = find.byType(ConstrainedBox);
+      expect(constrainedBoxFinder, findsWidgets);
+
+      bool foundCustomHeight = false;
+      for (final element in constrainedBoxFinder.evaluate()) {
+        final widget = element.widget as ConstrainedBox;
+        if (widget.constraints.minHeight == 64.0) {
+          foundCustomHeight = true;
+          break;
+        }
+      }
+      expect(foundCustomHeight, isTrue);
+    });
+
+    // ==================== Divider Indent Tests ====================
+
+    testWidgets('applies divider indent', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              showDivider: true,
+              dividerIndent: 16.0,
+            ),
+          ),
+        ),
+      );
+
+      final dividerFinder = find.byType(Divider);
+      expect(dividerFinder, findsOneWidget);
+
+      final divider = tester.widget<Divider>(dividerFinder);
+      expect(divider.indent, 16.0);
+    });
+
+    testWidgets('applies divider end indent', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppSectionHeader(
+              title: 'Section Title',
+              showDivider: true,
+              dividerEndIndent: 16.0,
+            ),
+          ),
+        ),
+      );
+
+      final dividerFinder = find.byType(Divider);
+      expect(dividerFinder, findsOneWidget);
+
+      final divider = tester.widget<Divider>(dividerFinder);
+      expect(divider.endIndent, 16.0);
+    });
+  });
+
+  // ==================== SectionHeaderDelegate Tests ====================
+
+  group('SectionHeaderDelegate Tests', () {
+    testWidgets('renders in SliverPersistentHeader', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CustomScrollView(
+              slivers: [
+                SliverPersistentHeader(
+                  pinned: true,
+                  delegate: const SectionHeaderDelegate(
+                    child: AppSectionHeader(
+                      title: 'Sticky Section',
+                      backgroundColor: Colors.white,
+                    ),
+                  ),
+                ),
+                SliverList(
+                  delegate: SliverChildListDelegate([
+                    const ListTile(title: Text('Item 1')),
+                    const ListTile(title: Text('Item 2')),
+                  ]),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Sticky Section'), findsOneWidget);
+    });
+
+    testWidgets('has correct min and max extent', (tester) async {
+      const delegate = SectionHeaderDelegate(
+        child: AppSectionHeader(title: 'Test'),
+        height: 56.0,
+      );
+
+      expect(delegate.minExtent, 56.0);
+      expect(delegate.maxExtent, 56.0);
+    });
+
+    testWidgets('shouldRebuild returns true when child changes', (
+      tester,
+    ) async {
+      const delegate1 = SectionHeaderDelegate(
+        child: AppSectionHeader(title: 'Test 1'),
+      );
+
+      const delegate2 = SectionHeaderDelegate(
+        child: AppSectionHeader(title: 'Test 2'),
+      );
+
+      expect(delegate1.shouldRebuild(delegate2), isTrue);
+    });
+
+    testWidgets('shouldRebuild returns true when height changes', (
+      tester,
+    ) async {
+      const delegate1 = SectionHeaderDelegate(
+        child: AppSectionHeader(title: 'Test'),
+        height: 48.0,
+      );
+
+      const delegate2 = SectionHeaderDelegate(
+        child: AppSectionHeader(title: 'Test'),
+        height: 56.0,
+      );
+
+      expect(delegate1.shouldRebuild(delegate2), isTrue);
+    });
+  });
+}

--- a/widgetbook_kit/README.md
+++ b/widgetbook_kit/README.md
@@ -1,16 +1,337 @@
-# widgetbook_kit
+<!--
+SPDX-FileCopyrightText: 2025 hexaTune LLC
+SPDX-License-Identifier: MIT
+-->
 
-A new Flutter project.
+# Widgetbook Kit
 
-## Getting Started
+**Interactive component catalog for hexaMobileShare with 218+ component stories**
 
-This project is a starting point for a Flutter application.
+The Widgetbook Kit is a comprehensive visual catalog showcasing all widgets, utilities, and services from the 11 modular packages in hexaMobileShare. It provides an interactive development environment for exploring, testing, and documenting components.
 
-A few resources to get you started if this is your first Flutter project:
+---
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+## 🔗 Live Preview
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+**Explore the live Widgetbook catalog:**
+
+**[https://story.mobile.dev.hexatune.com](https://story.mobile.dev.hexatune.com)**
+
+The live preview is automatically updated when changes are merged to the `develop` branch.
+
+---
+
+## 📖 What is Widgetbook?
+
+Widgetbook is a Flutter package that creates an interactive catalog for widgets, similar to Storybook for React. It allows developers and designers to:
+
+- 🎨 Browse all available components visually
+- 🔍 Test components with interactive controls (knobs)
+- 📱 Preview components in different screen sizes and orientations
+- 🌙 Toggle between light and dark themes
+- ♿ Test accessibility features
+- 📚 View component documentation and usage examples
+
+---
+
+## 🗂️ Structure
+
+The Widgetbook Kit contains **218+ story files** organized by package:
+
+```
+widgetbook_kit/
+├── lib/
+│   ├── app/                              # Widgetbook app configuration
+│   │   ├── widgetbook_app.dart          # Main app entry point
+│   │   └── widgetbook_app.directories.g.dart  # Auto-generated navigation
+│   └── stories/                          # Component stories (1-to-1 with packages)
+│       ├── analytics_kit/               # Analytics, logging, feature flags
+│       ├── auth_kit/                    # Authentication & authorization
+│       ├── core_kit/                    # Core UI widgets & theming
+│       ├── data_kit/                    # HTTP client, API handling
+│       ├── forms_kit/                   # Form management & validation
+│       ├── localization_kit/            # Internationalization
+│       ├── media_kit/                   # Media handling
+│       ├── monetization_kit/            # In-app purchases
+│       ├── navigation_kit/              # Routing & deep linking
+│       ├── notifications_kit/           # Push & local notifications
+│       └── storage_kit/                 # Local storage & caching
+└── main.dart                            # App entry point
+```
+
+Each story file corresponds to a specific widget, service, or utility in the packages.
+
+---
+
+## 🚀 Running Locally
+
+### Prerequisites
+
+- Flutter SDK 3.x+
+- Dart SDK 3.x+
+- Node.js 18+ and pnpm (for monorepo scripts)
+
+### Option 1: Using pnpm Scripts (Recommended)
+
+From the **root** of the monorepo:
+
+```bash
+# Install dependencies and bootstrap packages
+pnpm install
+
+# Run Widgetbook in Chrome
+pnpm storybook
+
+# Or use the specific script
+pnpm widgetbook:web
+```
+
+This will start Widgetbook at: **http://localhost:8080**
+
+### Option 2: Using Flutter CLI
+
+From the **widgetbook_kit** directory:
+
+```bash
+# Get dependencies
+flutter pub get
+
+# Run on Chrome (web)
+flutter run -d chrome
+
+# Run on macOS
+flutter run -d macos
+
+# Run on specific device
+flutter devices
+flutter run -d <device-id>
+```
+
+### Option 3: Using Melos
+
+From the **root** of the monorepo:
+
+```bash
+# Bootstrap all packages
+melos bootstrap
+
+# Run Widgetbook
+cd widgetbook_kit
+flutter run -d chrome
+```
+
+---
+
+## 🏗️ Building for Production
+
+### Build Web Version
+
+```bash
+# From root (using pnpm)
+pnpm build-storybook
+
+# Or from widgetbook_kit directory
+cd widgetbook_kit
+flutter build web --release
+```
+
+The build output will be in: `widgetbook_kit/build/web`
+
+### Build for Other Platforms
+
+```bash
+cd widgetbook_kit
+
+# macOS
+flutter build macos --release
+
+# Linux
+flutter build linux --release
+
+# Windows
+flutter build windows --release
+```
+
+---
+
+## 🚀 Deployment
+
+The Widgetbook is automatically deployed to GitHub Pages when changes are merged to `develop`.
+
+### Automatic Deployment
+
+**Trigger:** Merged PRs to `develop` that modify:
+- `widgetbook_kit/**`
+- `packages/**`
+- `.github/workflows/widgetbook-deploy.yml`
+
+**Live URL:** https://story.mobile.dev.hexatune.com
+
+### Manual Deployment
+
+Trigger deployment manually via GitHub Actions:
+
+1. Go to: `Actions > Deploy Widgetbook to GitHub Pages`
+2. Click **Run workflow**
+3. Select branch: `develop`
+4. Click **Run workflow**
+
+For detailed deployment instructions, see: **[docs/WIDGETBOOK_DEPLOYMENT.md](../docs/WIDGETBOOK_DEPLOYMENT.md)**
+
+---
+
+## 📝 Adding New Stories
+
+When creating a new widget or component in any package, add a corresponding story:
+
+### 1. Create a Story File
+
+```dart
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:core_kit/core_kit.dart';
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+@widgetbook.UseCase(
+  name: 'Default',
+  type: MyNewWidget,
+)
+Widget myNewWidgetUseCase(BuildContext context) {
+  return MyNewWidget(
+    title: context.knobs.string(
+      label: 'Title',
+      initialValue: 'Hello World',
+    ),
+    onTap: () {
+      print('Widget tapped!');
+    },
+  );
+}
+```
+
+### 2. Organize by Package
+
+Place the story in the appropriate package directory:
+
+```
+lib/stories/<package_name>/<feature>/<widget>_stories.dart
+```
+
+### 3. Run Code Generation
+
+```bash
+# From root
+pnpm bootstrap
+
+# Or from widgetbook_kit
+flutter pub run build_runner build --delete-conflicting-outputs
+```
+
+### 4. Verify Story Appears
+
+Run Widgetbook and verify the new story appears in the navigation:
+
+```bash
+pnpm storybook
+```
+
+---
+
+## 🎨 Using Knobs
+
+Knobs allow interactive control of widget properties in Widgetbook:
+
+```dart
+@widgetbook.UseCase(name: 'Interactive', type: MyButton)
+Widget myButtonUseCase(BuildContext context) {
+  return MyButton(
+    label: context.knobs.string(
+      label: 'Button Label',
+      initialValue: 'Click Me',
+    ),
+    color: context.knobs.color(
+      label: 'Background Color',
+      initialValue: Colors.blue,
+    ),
+    enabled: context.knobs.boolean(
+      label: 'Enabled',
+      initialValue: true,
+    ),
+    size: context.knobs.list(
+      label: 'Size',
+      options: ['small', 'medium', 'large'],
+      initialOption: 'medium',
+    ),
+  );
+}
+```
+
+**Available Knobs:**
+- `string()` – Text input
+- `boolean()` – Toggle switch
+- `number()` – Number input
+- `color()` – Color picker
+- `list()` – Dropdown selection
+- `sliderKnob()` – Slider
+
+---
+
+## 🧪 Testing
+
+Run tests for Widgetbook:
+
+```bash
+cd widgetbook_kit
+flutter test
+```
+
+---
+
+## 📚 Documentation
+
+For more information, see:
+
+- **[Widgetbook Deployment Guide](../docs/WIDGETBOOK_DEPLOYMENT.md)** – Deployment setup and troubleshooting
+- **[Development Guide](../docs/DEVELOPMENT_GUIDE.md)** – Development workflow
+- **[Project Structure](../docs/PROJECT_STRUCTURE.md)** – Repository organization
+- **[Widgetbook Official Docs](https://docs.widgetbook.io)** – Widgetbook package documentation
+
+---
+
+## 🤝 Contributing
+
+When contributing to hexaMobileShare:
+
+1. **Add stories for new components** – Every new widget should have a corresponding Widgetbook story
+2. **Update stories when APIs change** – Keep stories in sync with component updates
+3. **Test stories locally** – Run `pnpm storybook` to verify stories render correctly
+4. **Follow naming conventions** – Use `<widget_name>_stories.dart` format
+5. **Include SPDX headers** – All story files must include licensing headers
+
+See **[CONTRIBUTING.md](../docs/CONTRIBUTING.md)** for full contribution guidelines.
+
+---
+
+## 📜 License
+
+This project is licensed under the **MIT License** – see the [LICENSE](../LICENSE) file for details.
+
+```dart
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+```
+
+---
+
+## 🔗 Links
+
+- **Live Preview:** https://story.mobile.dev.hexatune.com
+- **GitHub Repository:** [hTuneSys/hexaMobileShare](https://github.com/hTuneSys/hexaMobileShare)
+- **Deployment Docs:** [docs/WIDGETBOOK_DEPLOYMENT.md](../docs/WIDGETBOOK_DEPLOYMENT.md)
+- **Main Project README:** [README.md](../README.md)
+
+---
+
+Built with ❤️ by **hexaTune LLC**

--- a/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
+++ b/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
@@ -15,8 +15,6 @@ import 'package:widgetbook_kit/stories/core_kit/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_buttons_app_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories;
-import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_fab_stories.dart'
-    as _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_icon_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_outlined_button_stories.dart'
@@ -25,6 +23,8 @@ import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_text_button_
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_checkbox_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_card_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories;
 
 final directories = <_widgetbook.WidgetbookNode>[
   _widgetbook.WidgetbookFolder(
@@ -233,59 +233,6 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories
                         .appButtonWithIcons,
-              ),
-            ],
-          ),
-          _widgetbook.WidgetbookComponent(
-            name: 'AppFab',
-            useCases: [
-              _widgetbook.WidgetbookUseCase(
-                name: 'Collapsed vs Expanded',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
-                        .appFabCollapsedExpanded,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Default',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
-                        .appFabDefault,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Extended Variants',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
-                        .appFabExtendedVariants,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Hide on Scroll',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
-                        .appFabHideOnScroll,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Playground (Static)',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
-                        .appFabPlayground,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Sizes',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
-                        .appFabSizes,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'States',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
-                        .appFabStates,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Theme Variations',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
-                        .appFabThemeVariations,
               ),
             ],
           ),
@@ -515,6 +462,58 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories
                         .appCheckboxThemeVariations,
+              ),
+            ],
+          ),
+        ],
+      ),
+      _widgetbook.WidgetbookFolder(
+        name: 'surfaces',
+        children: [
+          _widgetbook.WidgetbookComponent(
+            name: 'AppCard',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'All Variants',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
+                        .appCardVariants,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Content Types',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
+                        .appCardContentTypes,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Custom Styling',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
+                        .appCardCustom,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
+                        .appCardDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Elevation Levels',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
+                        .appCardElevations,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Interactive',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
+                        .appCardInteractive,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Interactive Playground',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
+                        .appCardPlayground,
               ),
             ],
           ),

--- a/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
+++ b/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
@@ -29,6 +29,8 @@ import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_search_field_
     as _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_card_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_section_header_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_surfaces_app_section_header_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_list_tile_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories;
 

--- a/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
+++ b/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
@@ -15,6 +15,8 @@ import 'package:widgetbook_kit/stories/core_kit/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_buttons_app_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_text_button_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories;
 
 final directories = <_widgetbook.WidgetbookNode>[
   _widgetbook.WidgetbookFolder(
@@ -223,6 +225,53 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories
                         .appButtonWithIcons,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'AppTextButton',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Button Hierarchy',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories
+                        .appTextButtonHierarchy,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Common Use Cases',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories
+                        .appTextButtonUseCases,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories
+                        .appTextButtonDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Inline Usage',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories
+                        .appTextButtonInlineUsage,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'States',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories
+                        .appTextButtonStates,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Theme Variations',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories
+                        .appTextButtonThemeVariations,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Icon',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories
+                        .appTextButtonWithIcon,
               ),
             ],
           ),

--- a/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
+++ b/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
@@ -25,6 +25,10 @@ import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_text_button_
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_checkbox_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_switch_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_card_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_search_field_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_card_stories.dart'

--- a/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
+++ b/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
@@ -15,6 +15,8 @@ import 'package:widgetbook_kit/stories/core_kit/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_buttons_app_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_fab_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_icon_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_outlined_button_stories.dart'
@@ -23,8 +25,12 @@ import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_text_button_
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_checkbox_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_search_field_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_card_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_list_tile_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories;
 
 final directories = <_widgetbook.WidgetbookNode>[
   _widgetbook.WidgetbookFolder(
@@ -233,6 +239,59 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories
                         .appButtonWithIcons,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'AppFab',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Collapsed vs Expanded',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabCollapsedExpanded,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Extended Variants',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabExtendedVariants,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Hide on Scroll',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabHideOnScroll,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Playground (Static)',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabPlayground,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Sizes',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabSizes,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'States',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabStates,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Theme Variations',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabThemeVariations,
               ),
             ],
           ),
@@ -465,6 +524,59 @@ final directories = <_widgetbook.WidgetbookNode>[
               ),
             ],
           ),
+          _widgetbook.WidgetbookComponent(
+            name: 'AppSearchField',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Auto Focus',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
+                        .autoFocusSearchField,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Basic',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
+                        .basicSearchField,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Custom Hint',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
+                        .customHintSearchField,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Disabled',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
+                        .disabledSearchField,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Loading State',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
+                        .loadingSearchField,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Submit Action',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
+                        .submitActionSearchField,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Clear Button',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
+                        .searchFieldWithClearButton,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Results',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
+                        .searchFieldWithResults,
+              ),
+            ],
+          ),
         ],
       ),
       _widgetbook.WidgetbookFolder(
@@ -514,6 +626,77 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories
                         .appCardPlayground,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'AppListTile',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Common Patterns',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTilePatterns,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTileDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Dense Mode',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTileDense,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Interactive Playground',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTilePlayground,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Leading Widgets',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTileLeading,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'One Line',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTileOneLine,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'States',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTileStates,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Theme Variations',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTileThemes,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Three Line',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTileThreeLine,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Trailing Widgets',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTileTrailing,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Two Line',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
+                        .appListTileTwoLine,
               ),
             ],
           ),

--- a/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
+++ b/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
@@ -13,6 +13,8 @@
 import 'package:widgetbook/widgetbook.dart' as _widgetbook;
 import 'package:widgetbook_kit/stories/core_kit/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_buttons_app_button_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_button_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories;
 
 final directories = <_widgetbook.WidgetbookNode>[
   _widgetbook.WidgetbookFolder(
@@ -24,6 +26,12 @@ final directories = <_widgetbook.WidgetbookNode>[
           _widgetbook.WidgetbookComponent(
             name: 'AppButton',
             useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'All Variants',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories
+                        .appButtonAllVariants,
+              ),
               _widgetbook.WidgetbookUseCase(
                 name: 'Default',
                 builder:
@@ -37,6 +45,12 @@ final directories = <_widgetbook.WidgetbookNode>[
                         .dialogActions,
               ),
               _widgetbook.WidgetbookUseCase(
+                name: 'Dialog Actions Example',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories
+                        .dialogActionsExample,
+              ),
+              _widgetbook.WidgetbookUseCase(
                 name: 'Disabled',
                 builder:
                     _widgetbook_kit_stories_core_kit_buttons_app_button_stories
@@ -47,6 +61,18 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _widgetbook_kit_stories_core_kit_buttons_app_button_stories
                         .ecommerceAddToCart,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'E-commerce Example',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories
+                        .ecommerceExample,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Edge Cases',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories
+                        .appButtonEdgeCases,
               ),
               _widgetbook.WidgetbookUseCase(
                 name: 'Elevated Default',
@@ -85,6 +111,12 @@ final directories = <_widgetbook.WidgetbookNode>[
                         .filledButtonFullWidth,
               ),
               _widgetbook.WidgetbookUseCase(
+                name: 'Interactive Playground',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories
+                        .appButtonPlayground,
+              ),
+              _widgetbook.WidgetbookUseCase(
                 name: 'Loading Processing Payment',
                 builder:
                     _widgetbook_kit_stories_core_kit_buttons_app_button_stories
@@ -95,6 +127,12 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _widgetbook_kit_stories_core_kit_buttons_app_button_stories
                         .filledButtonLoading,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Login Form Example',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories
+                        .loginFormExample,
               ),
               _widgetbook.WidgetbookUseCase(
                 name: 'Login Form Submit',
@@ -133,6 +171,18 @@ final directories = <_widgetbook.WidgetbookNode>[
                         .outlinedButtonWithIcon,
               ),
               _widgetbook.WidgetbookUseCase(
+                name: 'Sizes',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories
+                        .appButtonSizes,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'States',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories
+                        .appButtonStates,
+              ),
+              _widgetbook.WidgetbookUseCase(
                 name: 'Text Default',
                 builder:
                     _widgetbook_kit_stories_core_kit_buttons_app_button_stories
@@ -157,10 +207,22 @@ final directories = <_widgetbook.WidgetbookNode>[
                         .textButtonWithIcon,
               ),
               _widgetbook.WidgetbookUseCase(
+                name: 'Theme Variations',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories
+                        .appButtonThemeVariations,
+              ),
+              _widgetbook.WidgetbookUseCase(
                 name: 'With Icon',
                 builder:
                     _widgetbook_kit_stories_core_kit_buttons_app_button_stories
                         .filledButtonWithIcon,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Icons',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories
+                        .appButtonWithIcons,
               ),
             ],
           ),

--- a/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
+++ b/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
@@ -15,10 +15,16 @@ import 'package:widgetbook_kit/stories/core_kit/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_buttons_app_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories;
-import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_checkbox_stories.dart'
-    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_fab_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_icon_button_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_outlined_button_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_text_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_checkbox_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories;
 
 final directories = <_widgetbook.WidgetbookNode>[
   _widgetbook.WidgetbookFolder(
@@ -227,6 +233,153 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories
                         .appButtonWithIcons,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'AppFab',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Collapsed vs Expanded',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabCollapsedExpanded,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Extended Variants',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabExtendedVariants,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Hide on Scroll',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabHideOnScroll,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Playground (Static)',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabPlayground,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Sizes',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabSizes,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'States',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabStates,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Theme Variations',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_fab_stories
+                        .appFabThemeVariations,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'AppIconButton',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'All Variants',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonAllVariants,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Common Icons',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonCommonIcons,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Interactive Playground',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonPlayground,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Sizes',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonSizes,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'States',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonStates,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Theme Variations',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonTheme,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Toggle Button',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_icon_button_stories
+                        .appIconButtonToggle,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'AppOutlinedButton',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Comparison',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonComparison,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Sizes',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonSizes,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'States',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonStates,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Theme Variations',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonTheme,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Icon',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_buttons_app_outlined_button_stories
+                        .appOutlinedButtonWithIcon,
               ),
             ],
           ),

--- a/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
+++ b/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
@@ -1,6 +1,3 @@
-// SPDX-FileCopyrightText: 2025 hexaTune LLC
-// SPDX-License-Identifier: MIT
-
 // dart format width=80
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -28,8 +25,18 @@ import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_text_button_
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_checkbox_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_dropdown_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_password_field_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_inputs_app_password_field_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_radio_group_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_radio_group_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_search_field_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_switch_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_text_field_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_text_field_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_card_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_list_tile_stories.dart'
@@ -530,6 +537,65 @@ final directories = <_widgetbook.WidgetbookNode>[
             ],
           ),
           _widgetbook.WidgetbookComponent(
+            name: 'AppDropdown',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Basic String Dropdown',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
+                        .basicStringDropdown,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Custom Objects Dropdown',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
+                        .customObjectsDropdown,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Disabled Dropdown',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
+                        .disabledDropdown,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Dropdown with Error',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
+                        .dropdownWithError,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Dropdown with Icons',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
+                        .dropdownWithIcons,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Dropdown with Placeholder',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
+                        .dropdownWithPlaceholder,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Dropdown with Search',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
+                        .dropdownWithSearch,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Large List Dropdown',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
+                        .largeListDropdown,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Rich Items Dropdown',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
+                        .richItemsDropdown,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
             name: 'AppPasswordField',
             useCases: [
               _widgetbook.WidgetbookUseCase(
@@ -579,6 +645,218 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _widgetbook_kit_stories_core_kit_widgets_inputs_app_password_field_stories
                         .passwordFieldWithError,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'AppRadioGroup',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'All States',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_radio_group_stories
+                        .appRadioGroupAllStates,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_radio_group_stories
+                        .appRadioGroupDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Disabled',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_radio_group_stories
+                        .appRadioGroupDisabled,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Error State',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_radio_group_stories
+                        .appRadioGroupError,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Horizontal Layout',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_radio_group_stories
+                        .appRadioGroupHorizontal,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Pre-selected',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_radio_group_stories
+                        .appRadioGroupPreselected,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Descriptions',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_radio_group_stories
+                        .appRadioGroupWithDescriptions,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Icons',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_radio_group_stories
+                        .appRadioGroupWithIcons,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'AppSearchField',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Auto Focus',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
+                        .autoFocusSearchField,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Basic',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
+                        .basicSearchField,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Custom Hint',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
+                        .customHintSearchField,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Disabled',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
+                        .disabledSearchField,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Loading State',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
+                        .loadingSearchField,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Submit Action',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
+                        .submitActionSearchField,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Clear Button',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
+                        .searchFieldWithClearButton,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Results',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
+                        .searchFieldWithResults,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'AppSwitch',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'All States',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
+                        .appSwitchStates,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
+                        .appSwitchDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Real-World Examples',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
+                        .appSwitchExamples,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Settings List',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
+                        .appSwitchSettingsList,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Theme Variations',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
+                        .appSwitchThemeVariations,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Icons',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
+                        .appSwitchIcons,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Labels',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
+                        .appSwitchLabels,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'AppTextField',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Basic',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_text_field_stories
+                        .buildAppTextFieldBasicUseCase,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Character Counter & Max Length',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_text_field_stories
+                        .buildAppTextFieldCharacterCounterUseCase,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Email & URL Input',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_text_field_stories
+                        .buildAppTextFieldEmailUrlUseCase,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Multiline (Text Area)',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_text_field_stories
+                        .buildAppTextFieldMultilineUseCase,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Numeric Input with Formatter',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_text_field_stories
+                        .buildAppTextFieldNumericUseCase,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Search Field Variant',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_text_field_stories
+                        .buildAppTextFieldSearchUseCase,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'States (Disabled & Read-only)',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_text_field_stories
+                        .buildAppTextFieldStatesUseCase,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Icons',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_text_field_stories
+                        .buildAppTextFieldWithIconsUseCase,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Validation Error',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_text_field_stories
+                        .buildAppTextFieldErrorUseCase,
               ),
             ],
           ),

--- a/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
+++ b/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
@@ -15,6 +15,8 @@ import 'package:widgetbook_kit/stories/core_kit/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_buttons_app_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_checkbox_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_text_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories;
 
@@ -272,6 +274,94 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories
                         .appTextButtonWithIcon,
+              ),
+            ],
+          ),
+        ],
+      ),
+      _widgetbook.WidgetbookFolder(
+        name: 'inputs',
+        children: [
+          _widgetbook.WidgetbookComponent(
+            name: 'AppCheckbox',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'All States',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories
+                        .appCheckboxAllStates,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Checked',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories
+                        .appCheckboxChecked,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories
+                        .appCheckboxDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Disabled Checked',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories
+                        .appCheckboxDisabledChecked,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Disabled Unchecked',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories
+                        .appCheckboxDisabledUnchecked,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Error State',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories
+                        .appCheckboxError,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Form Example',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories
+                        .appCheckboxFormExample,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Indeterminate',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories
+                        .appCheckboxIndeterminate,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'List Integration',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories
+                        .appCheckboxListIntegration,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Long Label',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories
+                        .appCheckboxLongLabel,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'No Label',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories
+                        .appCheckboxNoLabel,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Short Label',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories
+                        .appCheckboxShortLabel,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Theme Variations',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories
+                        .appCheckboxThemeVariations,
               ),
             ],
           ),

--- a/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
+++ b/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
@@ -25,18 +25,18 @@ import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_text_button_
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_checkbox_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_dropdown_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_search_field_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_switch_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_card_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories;
-import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_search_field_stories.dart'
-    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories;
-import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_card_stories.dart'
-    as _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories;
-import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_section_header_stories.dart'
-    as _widgetbook_kit_stories_core_kit_widgets_surfaces_app_section_header_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_list_tile_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_section_header_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_surfaces_app_section_header_stories;
 
 final directories = <_widgetbook.WidgetbookNode>[
   _widgetbook.WidgetbookFolder(
@@ -531,6 +531,65 @@ final directories = <_widgetbook.WidgetbookNode>[
             ],
           ),
           _widgetbook.WidgetbookComponent(
+            name: 'AppDropdown',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Basic String Dropdown',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
+                        .basicStringDropdown,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Custom Objects Dropdown',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
+                        .customObjectsDropdown,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Disabled Dropdown',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
+                        .disabledDropdown,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Dropdown with Error',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
+                        .dropdownWithError,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Dropdown with Icons',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
+                        .dropdownWithIcons,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Dropdown with Placeholder',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
+                        .dropdownWithPlaceholder,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Dropdown with Search',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
+                        .dropdownWithSearch,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Large List Dropdown',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
+                        .largeListDropdown,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Rich Items Dropdown',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
+                        .richItemsDropdown,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
             name: 'AppSearchField',
             useCases: [
               _widgetbook.WidgetbookUseCase(
@@ -580,6 +639,53 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
                         .searchFieldWithResults,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'AppSwitch',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'All States',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
+                        .appSwitchStates,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
+                        .appSwitchDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Real-World Examples',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
+                        .appSwitchExamples,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Settings List',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
+                        .appSwitchSettingsList,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Theme Variations',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
+                        .appSwitchThemeVariations,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Icons',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
+                        .appSwitchIcons,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Labels',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
+                        .appSwitchLabels,
               ),
             ],
           ),
@@ -703,6 +809,59 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _widgetbook_kit_stories_core_kit_widgets_surfaces_app_list_tile_stories
                         .appListTileTwoLine,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'AppSectionHeader',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_section_header_stories
+                        .appSectionHeaderDefault,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Interactive Playground',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_section_header_stories
+                        .appSectionHeaderPlayground,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Settings List Example',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_section_header_stories
+                        .appSectionHeaderSettingsList,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Theme Variations',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_section_header_stories
+                        .appSectionHeaderThemeVariations,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Divider',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_section_header_stories
+                        .appSectionHeaderWithDivider,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Leading',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_section_header_stories
+                        .appSectionHeaderWithLeading,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Subtitle',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_section_header_stories
+                        .appSectionHeaderWithSubtitle,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Trailing',
+                builder:
+                    _widgetbook_kit_stories_core_kit_widgets_surfaces_app_section_header_stories
+                        .appSectionHeaderWithTrailing,
               ),
             ],
           ),

--- a/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
+++ b/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
 // dart format width=80
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -25,12 +28,8 @@ import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_text_button_
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_text_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_checkbox_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_inputs_app_checkbox_stories;
-import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_dropdown_stories.dart'
-    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories;
-import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_search_field_stories.dart'
-    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories;
-import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_switch_stories.dart'
-    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories;
+import 'package:widgetbook_kit/stories/core_kit/widgets/inputs/app_password_field_stories.dart'
+    as _widgetbook_kit_stories_core_kit_widgets_inputs_app_password_field_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_card_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_surfaces_app_card_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/surfaces/app_list_tile_stories.dart'
@@ -531,161 +530,55 @@ final directories = <_widgetbook.WidgetbookNode>[
             ],
           ),
           _widgetbook.WidgetbookComponent(
-            name: 'AppDropdown',
+            name: 'AppPasswordField',
             useCases: [
-              _widgetbook.WidgetbookUseCase(
-                name: 'Basic String Dropdown',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
-                        .basicStringDropdown,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Custom Objects Dropdown',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
-                        .customObjectsDropdown,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Disabled Dropdown',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
-                        .disabledDropdown,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Dropdown with Error',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
-                        .dropdownWithError,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Dropdown with Icons',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
-                        .dropdownWithIcons,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Dropdown with Placeholder',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
-                        .dropdownWithPlaceholder,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Dropdown with Search',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
-                        .dropdownWithSearch,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Large List Dropdown',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
-                        .largeListDropdown,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Rich Items Dropdown',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_dropdown_stories
-                        .richItemsDropdown,
-              ),
-            ],
-          ),
-          _widgetbook.WidgetbookComponent(
-            name: 'AppSearchField',
-            useCases: [
-              _widgetbook.WidgetbookUseCase(
-                name: 'Auto Focus',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
-                        .autoFocusSearchField,
-              ),
               _widgetbook.WidgetbookUseCase(
                 name: 'Basic',
                 builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
-                        .basicSearchField,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Custom Hint',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
-                        .customHintSearchField,
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_password_field_stories
+                        .basicPasswordField,
               ),
               _widgetbook.WidgetbookUseCase(
                 name: 'Disabled',
                 builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
-                        .disabledSearchField,
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_password_field_stories
+                        .disabledPasswordField,
               ),
               _widgetbook.WidgetbookUseCase(
-                name: 'Loading State',
+                name: 'Login Form Variant',
                 builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
-                        .loadingSearchField,
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_password_field_stories
+                        .loginFormPasswordField,
               ),
               _widgetbook.WidgetbookUseCase(
-                name: 'Submit Action',
+                name: 'Password Confirmation',
                 builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
-                        .submitActionSearchField,
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_password_field_stories
+                        .passwordConfirmationFields,
               ),
               _widgetbook.WidgetbookUseCase(
-                name: 'With Clear Button',
+                name: 'Registration Form Variant',
                 builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
-                        .searchFieldWithClearButton,
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_password_field_stories
+                        .registrationFormPasswordField,
               ),
               _widgetbook.WidgetbookUseCase(
-                name: 'With Results',
+                name: 'With Copy Prevention',
                 builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_search_field_stories
-                        .searchFieldWithResults,
-              ),
-            ],
-          ),
-          _widgetbook.WidgetbookComponent(
-            name: 'AppSwitch',
-            useCases: [
-              _widgetbook.WidgetbookUseCase(
-                name: 'All States',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
-                        .appSwitchStates,
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_password_field_stories
+                        .passwordFieldWithCopyPrevention,
               ),
               _widgetbook.WidgetbookUseCase(
-                name: 'Default',
+                name: 'With Strength Indicator',
                 builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
-                        .appSwitchDefault,
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_password_field_stories
+                        .passwordFieldWithStrength,
               ),
               _widgetbook.WidgetbookUseCase(
-                name: 'Real-World Examples',
+                name: 'With Validation Error',
                 builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
-                        .appSwitchExamples,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Settings List',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
-                        .appSwitchSettingsList,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'Theme Variations',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
-                        .appSwitchThemeVariations,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'With Icons',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
-                        .appSwitchIcons,
-              ),
-              _widgetbook.WidgetbookUseCase(
-                name: 'With Labels',
-                builder:
-                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_switch_stories
-                        .appSwitchLabels,
+                    _widgetbook_kit_stories_core_kit_widgets_inputs_app_password_field_stories
+                        .passwordFieldWithError,
               ),
             ],
           ),

--- a/widgetbook_kit/lib/stories/analytics_kit/analytics/screen_tracking_mixin_stories.dart
+++ b/widgetbook_kit/lib/stories/analytics_kit/analytics/screen_tracking_mixin_stories.dart
@@ -1,2 +1,410 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:analytics_kit/analytics/screen_tracking_mixin.dart';
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+/// Widgetbook stories for [ScreenTrackingMixin].
+///
+/// Demonstrates various usage patterns of the ScreenTrackingMixin
+/// for automatic screen view tracking.
+
+// ============================================================================
+// Basic Usage Example
+// ============================================================================
+
+/// A simple screen demonstrating basic [ScreenTrackingMixin] usage.
+///
+/// Screen name is automatically detected from the widget type.
+class BasicTrackingScreen extends StatefulWidget {
+  const BasicTrackingScreen({super.key});
+
+  @override
+  State<BasicTrackingScreen> createState() => _BasicTrackingScreenState();
+}
+
+class _BasicTrackingScreenState extends State<BasicTrackingScreen>
+    with ScreenTrackingMixin {
+  @override
+  bool get enableDebugLogging => true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Basic Screen Tracking'),
+        backgroundColor: Theme.of(context).colorScheme.primary,
+        foregroundColor: Theme.of(context).colorScheme.onPrimary,
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.analytics_outlined, size: 80, color: Colors.blue),
+            const SizedBox(height: 24),
+            const Text(
+              'Basic Screen Tracking',
+              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 32),
+              child: Text(
+                'This screen uses ScreenTrackingMixin for automatic tracking. '
+                'Check the console for tracking logs.',
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'Screen name: ${runtimeType.toString()}',
+              style: TextStyle(
+                color: Colors.grey[600],
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ============================================================================
+// Custom Screen Name Example
+// ============================================================================
+
+/// A screen demonstrating custom screen name override.
+class CustomNameScreen extends StatefulWidget {
+  const CustomNameScreen({super.key});
+
+  @override
+  State<CustomNameScreen> createState() => _CustomNameScreenState();
+}
+
+class _CustomNameScreenState extends State<CustomNameScreen>
+    with ScreenTrackingMixin {
+  @override
+  String get screenName => 'custom_home_screen';
+
+  @override
+  bool get enableDebugLogging => true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Custom Screen Name'),
+        backgroundColor: Theme.of(context).colorScheme.secondary,
+        foregroundColor: Theme.of(context).colorScheme.onSecondary,
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.edit_note, size: 80, color: Colors.orange),
+            const SizedBox(height: 24),
+            const Text(
+              'Custom Screen Name',
+              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 32),
+              child: Text(
+                'This screen overrides the screenName getter to provide '
+                'a custom name for analytics tracking.',
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(height: 24),
+            Container(
+              padding: const EdgeInsets.all(16),
+              margin: const EdgeInsets.symmetric(horizontal: 32),
+              decoration: BoxDecoration(
+                color: Colors.orange.shade50,
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: Colors.orange.shade200),
+              ),
+              child: Text(
+                'Screen name: $screenName',
+                style: const TextStyle(
+                  fontWeight: FontWeight.w600,
+                  color: Colors.orange,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ============================================================================
+// Screen Parameters Example
+// ============================================================================
+
+/// A screen demonstrating screen parameters tracking.
+class ParametersTrackingScreen extends StatefulWidget {
+  const ParametersTrackingScreen({
+    super.key,
+    required this.userId,
+    this.category = 'general',
+  });
+
+  final String userId;
+  final String category;
+
+  @override
+  State<ParametersTrackingScreen> createState() =>
+      _ParametersTrackingScreenState();
+}
+
+class _ParametersTrackingScreenState extends State<ParametersTrackingScreen>
+    with ScreenTrackingMixin {
+  String _selectedFilter = 'all';
+
+  @override
+  String get screenName => 'product_list';
+
+  @override
+  Map<String, dynamic> get screenParameters => {
+    'user_id': widget.userId,
+    'category': widget.category,
+    'filter': _selectedFilter,
+    'timestamp': DateTime.now().toIso8601String(),
+  };
+
+  @override
+  bool get enableDebugLogging => true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Parameters Tracking'),
+        backgroundColor: Theme.of(context).colorScheme.tertiary,
+        foregroundColor: Theme.of(context).colorScheme.onTertiary,
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.tune, size: 80, color: Colors.purple),
+            const SizedBox(height: 24),
+            const Text(
+              'Screen Parameters Tracking',
+              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 32),
+              child: Text(
+                'This screen tracks additional parameters like user ID, '
+                'category, and filter settings.',
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(height: 24),
+            Container(
+              padding: const EdgeInsets.all(16),
+              margin: const EdgeInsets.symmetric(horizontal: 32),
+              decoration: BoxDecoration(
+                color: Colors.purple.shade50,
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: Colors.purple.shade200),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Current Parameters:',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      color: Colors.purple.shade900,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text('• User ID: ${widget.userId}'),
+                  Text('• Category: ${widget.category}'),
+                  Text('• Filter: $_selectedFilter'),
+                ],
+              ),
+            ),
+            const SizedBox(height: 24),
+            SegmentedButton<String>(
+              segments: const [
+                ButtonSegment(value: 'all', label: Text('All')),
+                ButtonSegment(value: 'new', label: Text('New')),
+                ButtonSegment(value: 'popular', label: Text('Popular')),
+              ],
+              selected: {_selectedFilter},
+              onSelectionChanged: (Set<String> newSelection) {
+                setState(() {
+                  _selectedFilter = newSelection.first;
+                });
+                // Re-track with updated parameters
+                trackScreenView();
+              },
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Change filter to update tracked parameters',
+              style: TextStyle(
+                fontSize: 12,
+                color: Colors.grey[600],
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ============================================================================
+// Multiple Screens Navigation Example
+// ============================================================================
+
+/// A navigation demo showing multiple screens with tracking.
+class NavigationDemoScreen extends StatefulWidget {
+  const NavigationDemoScreen({super.key});
+
+  @override
+  State<NavigationDemoScreen> createState() => _NavigationDemoScreenState();
+}
+
+class _NavigationDemoScreenState extends State<NavigationDemoScreen>
+    with ScreenTrackingMixin {
+  int _visitCount = 0;
+
+  @override
+  String get screenName => 'navigation_demo';
+
+  @override
+  Map<String, dynamic> get screenParameters => {'visit_count': _visitCount};
+
+  @override
+  bool get enableDebugLogging => true;
+
+  @override
+  void initState() {
+    super.initState();
+    _visitCount++;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Navigation Demo'),
+        backgroundColor: Theme.of(context).colorScheme.primary,
+        foregroundColor: Theme.of(context).colorScheme.onPrimary,
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.navigation, size: 80, color: Colors.blue),
+            const SizedBox(height: 24),
+            const Text(
+              'Navigation Demo',
+              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 32),
+              child: Text(
+                'Navigate between screens to see automatic tracking in action. '
+                'Check the console for screen view and exit events.',
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(height: 32),
+            Wrap(
+              alignment: WrapAlignment.center,
+              spacing: 16,
+              runSpacing: 16,
+              children: [
+                ElevatedButton.icon(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute<void>(
+                        builder: (context) => const BasicTrackingScreen(),
+                      ),
+                    );
+                  },
+                  icon: const Icon(Icons.analytics),
+                  label: const Text('Basic Tracking'),
+                ),
+                ElevatedButton.icon(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute<void>(
+                        builder: (context) => const CustomNameScreen(),
+                      ),
+                    );
+                  },
+                  icon: const Icon(Icons.edit_note),
+                  label: const Text('Custom Name'),
+                ),
+                ElevatedButton.icon(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute<void>(
+                        builder: (context) => const ParametersTrackingScreen(
+                          userId: 'user_123',
+                          category: 'electronics',
+                        ),
+                      ),
+                    );
+                  },
+                  icon: const Icon(Icons.tune),
+                  label: const Text('With Parameters'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'Visit count: $_visitCount',
+              style: TextStyle(color: Colors.grey[600]),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ============================================================================
+// Widgetbook Use Cases
+// ============================================================================
+
+@widgetbook.UseCase(name: 'Basic Usage', type: BasicTrackingScreen)
+Widget basicUsageUseCase(BuildContext context) {
+  return const BasicTrackingScreen();
+}
+
+@widgetbook.UseCase(name: 'Custom Screen Name', type: CustomNameScreen)
+Widget customNameUseCase(BuildContext context) {
+  return const CustomNameScreen();
+}
+
+@widgetbook.UseCase(name: 'With Parameters', type: ParametersTrackingScreen)
+Widget parametersUseCase(BuildContext context) {
+  return const ParametersTrackingScreen(
+    userId: 'demo_user_456',
+    category: 'technology',
+  );
+}
+
+@widgetbook.UseCase(name: 'Navigation Demo', type: NavigationDemoScreen)
+Widget navigationDemoUseCase(BuildContext context) {
+  return const NavigationDemoScreen();
+}

--- a/widgetbook_kit/lib/stories/core_kit/widgets/buttons/app_button_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/buttons/app_button_stories.dart
@@ -1,2 +1,415 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/core_kit.dart';
+
+// 1. Interactive Playground - All Variants with Different States
+@widgetbook.UseCase(name: 'Interactive Playground', type: AppButton)
+Widget appButtonPlayground(BuildContext context) {
+  return SingleChildScrollView(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            'Filled Variants',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          AppButton.filled(label: 'Default', onPressed: () {}),
+          const SizedBox(height: 8),
+          AppButton.filled(
+            label: 'With Icon',
+            icon: Icons.add,
+            onPressed: () {},
+          ),
+          const SizedBox(height: 8),
+          const AppButton.filled(label: 'Disabled', onPressed: null),
+          const SizedBox(height: 8),
+          AppButton.filled(label: 'Loading', isLoading: true, onPressed: () {}),
+          const SizedBox(height: 8),
+          AppButton.filled(
+            label: 'Full Width',
+            fullWidth: true,
+            onPressed: () {},
+          ),
+          const Divider(height: 32),
+          const Text(
+            'Outlined Variants',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          AppButton.outlined(label: 'Default', onPressed: () {}),
+          const SizedBox(height: 8),
+          AppButton.outlined(
+            label: 'With Icon',
+            icon: Icons.download,
+            onPressed: () {},
+          ),
+          const SizedBox(height: 8),
+          const AppButton.outlined(label: 'Disabled', onPressed: null),
+          const SizedBox(height: 8),
+          AppButton.outlined(
+            label: 'Loading',
+            isLoading: true,
+            onPressed: () {},
+          ),
+          const Divider(height: 32),
+          const Text(
+            'Text Variants',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          AppButton.text(label: 'Default', onPressed: () {}),
+          const SizedBox(height: 8),
+          AppButton.text(
+            label: 'With Icon',
+            icon: Icons.arrow_forward,
+            onPressed: () {},
+          ),
+          const SizedBox(height: 8),
+          const AppButton.text(label: 'Disabled', onPressed: null),
+          const SizedBox(height: 8),
+          AppButton.text(label: 'Loading', isLoading: true, onPressed: () {}),
+          const Divider(height: 32),
+          const Text(
+            'Elevated Variants',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          AppButton.elevated(label: 'Default', onPressed: () {}),
+          const SizedBox(height: 8),
+          AppButton.elevated(
+            label: 'With Icon',
+            icon: Icons.upload,
+            onPressed: () {},
+          ),
+          const SizedBox(height: 8),
+          const AppButton.elevated(label: 'Disabled', onPressed: null),
+          const SizedBox(height: 8),
+          AppButton.elevated(
+            label: 'Loading',
+            isLoading: true,
+            onPressed: () {},
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+// 2. All Variants Side-by-Side
+@widgetbook.UseCase(name: 'All Variants', type: AppButton)
+Widget appButtonAllVariants(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('Filled', style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        AppButton.filled(label: 'Filled Button', onPressed: () {}),
+        const SizedBox(height: 16),
+        const Text('Outlined', style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        AppButton.outlined(label: 'Outlined Button', onPressed: () {}),
+        const SizedBox(height: 16),
+        const Text('Text', style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        AppButton.text(label: 'Text Button', onPressed: () {}),
+        const SizedBox(height: 16),
+        const Text('Elevated', style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        AppButton.elevated(label: 'Elevated Button', onPressed: () {}),
+      ],
+    ),
+  );
+}
+
+// 3. With Icons - Demonstrate icon combinations
+@widgetbook.UseCase(name: 'With Icons', type: AppButton)
+Widget appButtonWithIcons(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'All button variants support icons',
+          style: TextStyle(fontStyle: FontStyle.italic),
+        ),
+        const SizedBox(height: 16),
+        AppButton.filled(label: 'Add Item', icon: Icons.add, onPressed: () {}),
+        const SizedBox(height: 8),
+        AppButton.outlined(
+          label: 'Download',
+          icon: Icons.download,
+          onPressed: () {},
+        ),
+        const SizedBox(height: 8),
+        AppButton.text(
+          label: 'Learn More',
+          icon: Icons.arrow_forward,
+          onPressed: () {},
+        ),
+        const SizedBox(height: 8),
+        AppButton.elevated(
+          label: 'Upload',
+          icon: Icons.upload,
+          onPressed: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+// 4. States - Interactive state demonstration
+@widgetbook.UseCase(name: 'States', type: AppButton)
+Widget appButtonStates(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('Enabled', style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        AppButton.filled(label: 'Enabled', onPressed: () {}),
+        const SizedBox(height: 16),
+        const Text('Disabled', style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        const AppButton.filled(label: 'Disabled', onPressed: null),
+        const SizedBox(height: 16),
+        const Text('Loading', style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        AppButton.filled(
+          label: 'Processing',
+          isLoading: true,
+          onPressed: () {},
+        ),
+        const SizedBox(height: 16),
+        const Text(
+          'Icon + Loading (Bug Fix Demo)',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 4),
+        const Text(
+          'When both icon and loading are true, loading indicator should show instead of icon',
+          style: TextStyle(fontSize: 12, fontStyle: FontStyle.italic),
+        ),
+        const SizedBox(height: 8),
+        AppButton.filled(
+          label: 'Uploading',
+          icon: Icons.cloud_upload,
+          isLoading: true,
+          onPressed: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+// 5. Sizes - Layout variations
+@widgetbook.UseCase(name: 'Sizes', type: AppButton)
+Widget appButtonSizes(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Text(
+          'Normal Width',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        AppButton.filled(label: 'Normal', fullWidth: false, onPressed: () {}),
+        const SizedBox(height: 16),
+        const Text('Full Width', style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        AppButton.filled(
+          label: 'Full Width',
+          fullWidth: true,
+          onPressed: () {},
+        ),
+        const SizedBox(height: 16),
+        const Text(
+          'Full Width with Icon',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        AppButton.filled(
+          label: 'Sign In',
+          icon: Icons.login,
+          fullWidth: true,
+          onPressed: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+// 6. Theme Variations - Light & dark mode
+@widgetbook.UseCase(name: 'Theme Variations', type: AppButton)
+Widget appButtonThemeVariations(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Toggle theme in Widgetbook settings (top toolbar) to see light/dark mode variations',
+          style: TextStyle(fontStyle: FontStyle.italic),
+        ),
+        const SizedBox(height: 16),
+        AppButton.filled(label: 'Filled', onPressed: () {}),
+        const SizedBox(height: 8),
+        AppButton.outlined(label: 'Outlined', onPressed: () {}),
+        const SizedBox(height: 8),
+        AppButton.text(label: 'Text', onPressed: () {}),
+        const SizedBox(height: 8),
+        AppButton.elevated(label: 'Elevated', onPressed: () {}),
+      ],
+    ),
+  );
+}
+
+// 7. Edge Cases
+@widgetbook.UseCase(name: 'Edge Cases', type: AppButton)
+Widget appButtonEdgeCases(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Very Long Label',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        SizedBox(
+          width: 200,
+          child: AppButton.filled(
+            label: 'This is a very long button label that might wrap',
+            onPressed: () {},
+          ),
+        ),
+        const SizedBox(height: 16),
+        const Text(
+          'Empty Label',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        AppButton.filled(label: '', onPressed: () {}),
+        const SizedBox(height: 16),
+        const Text(
+          'All Properties Combined',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        AppButton.filled(
+          label: 'Complete',
+          icon: Icons.check_circle,
+          fullWidth: true,
+          isLoading: false,
+          onPressed: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+// Real-world Examples
+
+@widgetbook.UseCase(name: 'Login Form Example', type: AppButton)
+Widget loginFormExample(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Text(
+          'Typical login form layout',
+          style: TextStyle(fontStyle: FontStyle.italic),
+        ),
+        const SizedBox(height: 16),
+        AppButton.filled(
+          label: 'Sign In',
+          icon: Icons.login,
+          fullWidth: true,
+          onPressed: () {},
+        ),
+        const SizedBox(height: 8),
+        AppButton.text(
+          label: 'Forgot Password?',
+          fullWidth: true,
+          onPressed: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Dialog Actions Example', type: AppButton)
+Widget dialogActionsExample(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Typical dialog action buttons',
+          style: TextStyle(fontStyle: FontStyle.italic),
+        ),
+        const SizedBox(height: 16),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            AppButton.text(label: 'Cancel', onPressed: () {}),
+            const SizedBox(width: 8),
+            AppButton.filled(label: 'Confirm', onPressed: () {}),
+          ],
+        ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'E-commerce Example', type: AppButton)
+Widget ecommerceExample(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Text(
+          'E-commerce product actions',
+          style: TextStyle(fontStyle: FontStyle.italic),
+        ),
+        const SizedBox(height: 16),
+        AppButton.filled(
+          label: 'Add to Cart',
+          icon: Icons.shopping_cart,
+          fullWidth: true,
+          onPressed: () {},
+        ),
+        const SizedBox(height: 8),
+        AppButton.outlined(
+          label: 'Add to Wishlist',
+          icon: Icons.favorite_border,
+          fullWidth: true,
+          onPressed: () {},
+        ),
+      ],
+    ),
+  );
+}

--- a/widgetbook_kit/lib/stories/core_kit/widgets/buttons/app_fab_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/buttons/app_fab_stories.dart
@@ -1,2 +1,249 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+// import 'package:widgetbook/widgetbook.dart' as widgetbook;
+import 'package:core_kit/widgets/buttons/app_fab.dart';
+
+// 1. Default FAB - Standard size
+@widgetbook.UseCase(name: 'Default', type: AppFab)
+Widget appFabDefault(BuildContext context) {
+  return Center(
+    child: AppFab(icon: Icons.add, onPressed: () {}),
+  );
+}
+
+// 2. All Sizes - Show size variants
+@widgetbook.UseCase(name: 'Sizes', type: AppFab)
+Widget appFabSizes(BuildContext context) {
+  return Center(
+    child: Wrap(
+      spacing: 16,
+      runSpacing: 16,
+      alignment: WrapAlignment.center,
+      children: [
+        AppFab.small(icon: Icons.filter_list, onPressed: () {}),
+        AppFab(icon: Icons.add, onPressed: () {}),
+        AppFab.large(icon: Icons.camera_alt, onPressed: () {}),
+        AppFab.extended(icon: Icons.edit, label: 'Compose', onPressed: () {}),
+      ],
+    ),
+  );
+}
+
+// 3. Extended FAB Variants
+@widgetbook.UseCase(name: 'Extended Variants', type: AppFab)
+Widget appFabExtendedVariants(BuildContext context) {
+  return Center(
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AppFab.extended(icon: Icons.edit, label: 'Edit', onPressed: () {}),
+        const SizedBox(height: 12),
+        AppFab.extended(
+          icon: Icons.download,
+          label: 'Download',
+          trailingIcon: Icons.arrow_forward,
+          onPressed: () {},
+        ),
+        const SizedBox(height: 12),
+        AppFab.extended(
+          icon: Icons.share,
+          label: 'Share a long descriptive label',
+          onPressed: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+// 4. States
+@widgetbook.UseCase(name: 'States', type: AppFab)
+Widget appFabStates(BuildContext context) {
+  return Center(
+    child: Wrap(
+      spacing: 16,
+      alignment: WrapAlignment.center,
+      children: [
+        AppFab(icon: Icons.add, onPressed: () {}),
+        const AppFab(icon: Icons.add, onPressed: null), // Disabled
+        const _LoadingFab(),
+      ],
+    ),
+  );
+}
+
+// 5. Theme Variations
+@widgetbook.UseCase(name: 'Theme Variations', type: AppFab)
+Widget appFabThemeVariations(BuildContext context) {
+  return Center(
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Theme(
+          data: ThemeData.light(useMaterial3: true),
+          child: Wrap(
+            spacing: 16,
+            alignment: WrapAlignment.center,
+            children: [
+              AppFab(icon: Icons.add, onPressed: () {}),
+              AppFab(
+                icon: Icons.add,
+                foregroundColor: Colors.white,
+                backgroundColor: Colors.blue,
+                onPressed: () {},
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 12),
+        Theme(
+          data: ThemeData.dark(useMaterial3: true),
+          child: Wrap(
+            spacing: 16,
+            alignment: WrapAlignment.center,
+            children: [
+              AppFab(icon: Icons.add, onPressed: () {}),
+              AppFab(
+                icon: Icons.add,
+                foregroundColor: Colors.black,
+                backgroundColor: Colors.yellow,
+                onPressed: () {},
+              ),
+            ],
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+// 6. Interactive Playground
+@widgetbook.UseCase(name: 'Playground (Static)', type: AppFab)
+Widget appFabPlayground(BuildContext context) {
+  return Center(
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AppFab(icon: Icons.add, onPressed: () {}),
+        const SizedBox(height: 12),
+        AppFab.small(icon: Icons.filter_list, onPressed: () {}),
+        const SizedBox(height: 12),
+        AppFab.large(icon: Icons.camera_alt, onPressed: () {}),
+        const SizedBox(height: 12),
+        AppFab.extended(icon: Icons.edit, label: 'Compose', onPressed: () {}),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Collapsed vs Expanded', type: AppFab)
+Widget appFabCollapsedExpanded(BuildContext context) {
+  return Center(child: _SwitchableDemo());
+}
+
+class _SwitchableDemo extends StatefulWidget {
+  @override
+  State<_SwitchableDemo> createState() => _SwitchableDemoState();
+}
+
+class _SwitchableDemoState extends State<_SwitchableDemo> {
+  bool _extended = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AppFabSwitchable(
+          isExtended: _extended,
+          icon: Icons.edit,
+          label: 'Compose',
+          trailingIcon: Icons.arrow_forward,
+          onPressed: () {},
+        ),
+        const SizedBox(height: 12),
+        Center(
+          child: ElevatedButton(
+            onPressed: () => setState(() => _extended = !_extended),
+            child: Text(_extended ? 'Collapse' : 'Expand'),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+@widgetbook.UseCase(name: 'Hide on Scroll', type: AppFab)
+Widget appFabHideOnScroll(BuildContext context) {
+  final controller = ScrollController();
+  return Center(
+    child: SizedBox(
+      height: 240,
+      child: Stack(
+        children: [
+          ListView.builder(
+            controller: controller,
+            itemCount: 30,
+            itemBuilder: (_, i) => ListTile(title: Text('Item $i')),
+          ),
+          Positioned(
+            right: 16,
+            bottom: 16,
+            child: AppFabHideOnScroll(
+              scrollController: controller,
+              fab: AppFab(icon: Icons.add, onPressed: () {}),
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+// Helper: loading state demo
+class _LoadingFab extends StatefulWidget {
+  const _LoadingFab();
+
+  @override
+  State<_LoadingFab> createState() => _LoadingFabState();
+}
+
+class _LoadingFabState extends State<_LoadingFab>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _rotation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 1),
+    )..repeat();
+    _rotation = Tween<double>(begin: 0, end: 1).animate(_controller);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppFab(
+      icon: Icons.sync,
+      onPressed: () {},
+      tooltip: 'Loading',
+      foregroundColor: Theme.of(context).colorScheme.onPrimaryContainer,
+      backgroundColor: Theme.of(context).colorScheme.primaryContainer,
+      heroTag: 'loading-fab',
+      iconWrapper: (icon) => RotationTransition(turns: _rotation, child: icon),
+    );
+  }
+}
+
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT

--- a/widgetbook_kit/lib/stories/core_kit/widgets/buttons/app_icon_button_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/buttons/app_icon_button_stories.dart
@@ -1,2 +1,301 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/widgets/buttons/app_icon_button.dart';
+
+@widgetbook.UseCase(name: 'Default', type: AppIconButton)
+Widget appIconButtonDefault(BuildContext context) {
+  return Center(
+    child: AppIconButton(
+      icon: context.knobs.object.dropdown(
+        label: 'Icon',
+        options: const [Icons.search, Icons.menu, Icons.favorite, Icons.share],
+        labelBuilder: (icon) => icon.toString(),
+      ),
+      onPressed: () {},
+      tooltip: context.knobs.string(label: 'Tooltip', initialValue: 'Action'),
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'All Variants', type: AppIconButton)
+Widget appIconButtonAllVariants(BuildContext context) {
+  const icon = Icons.search;
+  return Row(
+    mainAxisAlignment: MainAxisAlignment.center,
+    children: [
+      AppIconButton(icon: icon, tooltip: 'Standard', onPressed: () {}),
+      const SizedBox(width: 16),
+      AppIconButton.filled(icon: icon, tooltip: 'Filled', onPressed: () {}),
+      const SizedBox(width: 16),
+      AppIconButton.filledTonal(
+        icon: icon,
+        tooltip: 'Filled Tonal',
+        onPressed: () {},
+      ),
+      const SizedBox(width: 16),
+      AppIconButton.outlined(icon: icon, tooltip: 'Outlined', onPressed: () {}),
+    ],
+  );
+}
+
+@widgetbook.UseCase(name: 'Common Icons', type: AppIconButton)
+Widget appIconButtonCommonIcons(BuildContext context) {
+  Widget group(String title, List<IconData> icons) => Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Text(title),
+      const SizedBox(height: 8),
+      Wrap(
+        spacing: 12,
+        runSpacing: 12,
+        children: icons
+            .map(
+              (i) => AppIconButton(icon: i, tooltip: title, onPressed: () {}),
+            )
+            .toList(),
+      ),
+    ],
+  );
+
+  return SingleChildScrollView(
+    padding: const EdgeInsets.all(16),
+    child: Column(
+      children: [
+        group('Navigation', const [
+          Icons.arrow_back,
+          Icons.close,
+          Icons.menu,
+          Icons.more_vert,
+        ]),
+        const SizedBox(height: 16),
+        group('Actions', const [
+          Icons.search,
+          Icons.filter_list,
+          Icons.settings,
+          Icons.refresh,
+        ]),
+        const SizedBox(height: 16),
+        group('Content', const [
+          Icons.favorite_border,
+          Icons.share,
+          Icons.bookmark_border,
+          Icons.edit,
+        ]),
+        const SizedBox(height: 16),
+        group('Media', const [
+          Icons.play_arrow,
+          Icons.pause,
+          Icons.skip_next,
+          Icons.volume_up,
+        ]),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'States', type: AppIconButton)
+Widget appIconButtonStates(BuildContext context) {
+  return Row(
+    mainAxisAlignment: MainAxisAlignment.center,
+    children: [
+      AppIconButton(
+        icon: Icons.favorite_border,
+        tooltip: 'Enabled',
+        onPressed: () {},
+      ),
+      const SizedBox(width: 16),
+      const AppIconButton(
+        icon: Icons.delete,
+        tooltip: 'Disabled',
+        onPressed: null,
+      ),
+      const SizedBox(width: 16),
+      AppIconButton(
+        icon: Icons.favorite,
+        tooltip: 'Selected',
+        onPressed: () {},
+        isSelected: true,
+      ),
+    ],
+  );
+}
+
+@widgetbook.UseCase(name: 'Sizes', type: AppIconButton)
+Widget appIconButtonSizes(BuildContext context) {
+  return Row(
+    mainAxisAlignment: MainAxisAlignment.center,
+    children: [
+      AppIconButton(
+        icon: Icons.search,
+        tooltip: 'Small',
+        onPressed: () {},
+        iconSize: 20,
+      ),
+      const SizedBox(width: 16),
+      AppIconButton(
+        icon: Icons.search,
+        tooltip: 'Default',
+        onPressed: () {},
+        iconSize: 24,
+      ),
+      const SizedBox(width: 16),
+      AppIconButton(
+        icon: Icons.search,
+        tooltip: 'Large',
+        onPressed: () {},
+        iconSize: 32,
+      ),
+    ],
+  );
+}
+
+@widgetbook.UseCase(name: 'Toggle Button', type: AppIconButton)
+Widget appIconButtonToggle(BuildContext context) {
+  final selected = context.knobs.boolean(
+    label: 'Selected',
+    initialValue: false,
+  );
+  return Row(
+    mainAxisAlignment: MainAxisAlignment.center,
+    children: [
+      AppIconButton(
+        icon: selected ? Icons.favorite : Icons.favorite_border,
+        tooltip: 'Favorite',
+        isSelected: selected,
+        onPressed: () {},
+      ),
+      const SizedBox(width: 16),
+      AppIconButton(
+        icon: selected ? Icons.bookmark : Icons.bookmark_border,
+        tooltip: 'Bookmark',
+        isSelected: selected,
+        onPressed: () {},
+      ),
+      const SizedBox(width: 16),
+      AppIconButton(
+        icon: selected ? Icons.visibility : Icons.visibility_off,
+        tooltip: 'Visibility',
+        isSelected: selected,
+        onPressed: () {},
+      ),
+    ],
+  );
+}
+
+@widgetbook.UseCase(name: 'Theme Variations', type: AppIconButton)
+Widget appIconButtonTheme(BuildContext context) {
+  final dark = context.knobs.boolean(label: 'Dark mode', initialValue: false);
+  final colorOverride = context.knobs.color(label: 'Custom icon color');
+  final ThemeData theme = dark
+      ? ThemeData.dark(useMaterial3: true)
+      : ThemeData.light(useMaterial3: true);
+
+  return Theme(
+    data: theme,
+    child: Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        AppIconButton(
+          icon: Icons.settings,
+          tooltip: 'Standard',
+          onPressed: () {},
+          color: colorOverride,
+        ),
+        const SizedBox(width: 16),
+        AppIconButton.filled(
+          icon: Icons.toggle_on,
+          tooltip: 'Filled',
+          onPressed: () {},
+          color: colorOverride,
+        ),
+        const SizedBox(width: 16),
+        AppIconButton.filledTonal(
+          icon: Icons.toggle_on,
+          tooltip: 'Tonal',
+          onPressed: () {},
+          color: colorOverride,
+        ),
+        const SizedBox(width: 16),
+        AppIconButton.outlined(
+          icon: Icons.tune,
+          tooltip: 'Outlined',
+          onPressed: () {},
+          color: colorOverride,
+        ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Interactive Playground', type: AppIconButton)
+Widget appIconButtonPlayground(BuildContext context) {
+  final variant = context.knobs.object.dropdown(
+    label: 'Variant',
+    options: const ['standard', 'filled', 'filledTonal', 'outlined'],
+    labelBuilder: (v) => v,
+  );
+  final enabled = context.knobs.boolean(label: 'Enabled', initialValue: true);
+  final selected = context.knobs.boolean(
+    label: 'Selected',
+    initialValue: false,
+  );
+  final size = context.knobs.double.slider(
+    label: 'Icon size',
+    initialValue: 24,
+    min: 16,
+    max: 40,
+  );
+  final color = context.knobs.color(label: 'Icon color');
+  final icon = context.knobs.object.dropdown(
+    label: 'Icon',
+    options: const [
+      Icons.search,
+      Icons.menu,
+      Icons.favorite,
+      Icons.share,
+      Icons.edit,
+      Icons.delete,
+    ],
+    labelBuilder: (icon) => icon.toString(),
+  );
+
+  AppIconButton build() => switch (variant) {
+    'filled' => AppIconButton.filled(
+      icon: icon,
+      tooltip: 'Playground',
+      onPressed: enabled ? () {} : null,
+      isSelected: selected,
+      iconSize: size,
+      color: color,
+    ),
+    'filledTonal' => AppIconButton.filledTonal(
+      icon: icon,
+      tooltip: 'Playground',
+      onPressed: enabled ? () {} : null,
+      isSelected: selected,
+      iconSize: size,
+      color: color,
+    ),
+    'outlined' => AppIconButton.outlined(
+      icon: icon,
+      tooltip: 'Playground',
+      onPressed: enabled ? () {} : null,
+      isSelected: selected,
+      iconSize: size,
+      color: color,
+    ),
+    _ => AppIconButton(
+      icon: icon,
+      tooltip: 'Playground',
+      onPressed: enabled ? () {} : null,
+      isSelected: selected,
+      iconSize: size,
+      color: color,
+    ),
+  };
+
+  return Center(child: build());
+}

--- a/widgetbook_kit/lib/stories/core_kit/widgets/buttons/app_outlined_button_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/buttons/app_outlined_button_stories.dart
@@ -1,2 +1,116 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/widgets/buttons/app_outlined_button.dart';
+import 'package:core_kit/widgets/buttons/app_button.dart';
+
+// ...existing code...
+@widgetbook.UseCase(name: 'Default', type: AppOutlinedButton)
+Widget appOutlinedButtonDefault(BuildContext context) {
+  return Center(
+    child: AppOutlinedButton(
+      label: context.knobs.string(label: 'Label', initialValue: 'Button'),
+      onPressed: () {},
+    ),
+  );
+}
+
+// ...existing code...
+@widgetbook.UseCase(name: 'With Icon', type: AppOutlinedButton)
+Widget appOutlinedButtonWithIcon(BuildContext context) {
+  return Center(
+    child: AppOutlinedButton(
+      icon: Icons.download,
+      label: context.knobs.string(label: 'Label', initialValue: 'Download'),
+      onPressed: () {},
+    ),
+  );
+}
+
+// ...existing code...
+@widgetbook.UseCase(name: 'States', type: AppOutlinedButton)
+Widget appOutlinedButtonStates(BuildContext context) {
+  final label = context.knobs.string(label: 'Label', initialValue: 'Submit');
+  return Column(
+    mainAxisAlignment: MainAxisAlignment.center,
+    children: [
+      AppOutlinedButton(label: '$label (enabled)', onPressed: () {}),
+      const SizedBox(height: 12),
+      const AppOutlinedButton(label: 'Disabled'),
+      const SizedBox(height: 12),
+      const AppOutlinedButton(label: 'Loading', isLoading: true),
+      const SizedBox(height: 12),
+      AppOutlinedButton(label: 'Hover/Pressed demo', onPressed: () {}),
+    ],
+  );
+}
+
+// ...existing code...
+@widgetbook.UseCase(name: 'Sizes', type: AppOutlinedButton)
+Widget appOutlinedButtonSizes(BuildContext context) {
+  final longText = context.knobs.boolean(
+    label: 'Use long text',
+    initialValue: true,
+  );
+  return Padding(
+    padding: const EdgeInsets.all(16),
+    child: Column(
+      children: [
+        AppOutlinedButton(
+          label: longText
+              ? 'This is a very long button label to test wrapping and overflow'
+              : 'Normal',
+          onPressed: () {},
+        ),
+        const SizedBox(height: 12),
+        const AppOutlinedButton(label: 'Full width', fullWidth: true),
+      ],
+    ),
+  );
+}
+
+// ...existing code...
+@widgetbook.UseCase(name: 'Theme Variations', type: AppOutlinedButton)
+Widget appOutlinedButtonTheme(BuildContext context) {
+  final dark = context.knobs.boolean(label: 'Dark mode', initialValue: false);
+  final toggledTheme = dark
+      ? ThemeData.from(colorScheme: const ColorScheme.dark())
+      : ThemeData.from(colorScheme: const ColorScheme.light());
+
+  return Theme(
+    data: toggledTheme,
+    child: Center(
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: const [
+          AppOutlinedButton(label: 'Outlined'),
+          SizedBox(width: 12),
+          AppButton.filled(label: 'Filled'),
+        ],
+      ),
+    ),
+  );
+}
+
+// ...existing code...
+@widgetbook.UseCase(name: 'Comparison', type: AppOutlinedButton)
+Widget appOutlinedButtonComparison(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16),
+    child: Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: const [
+        AppButton.text(label: 'Text'),
+        SizedBox(width: 12),
+        AppOutlinedButton(label: 'Outlined'),
+        SizedBox(width: 12),
+        AppButton.filled(label: 'Filled'),
+      ],
+    ),
+  );
+}
+
+// ...existing code...

--- a/widgetbook_kit/lib/stories/core_kit/widgets/buttons/app_text_button_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/buttons/app_text_button_stories.dart
@@ -1,2 +1,417 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/core_kit.dart';
+
+// 1. Default Text Button - Interactive playground
+@widgetbook.UseCase(name: 'Default', type: AppTextButton)
+Widget appTextButtonDefault(BuildContext context) {
+  return Center(
+    child: AppTextButton(label: 'Text Button', onPressed: () {}),
+  );
+}
+
+// 2. With Icon - Icon + text combinations
+@widgetbook.UseCase(name: 'With Icon', type: AppTextButton)
+Widget appTextButtonWithIcon(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Text buttons with various icons',
+          style: TextStyle(fontStyle: FontStyle.italic),
+        ),
+        const SizedBox(height: 16),
+        AppTextButton(label: 'Add Item', icon: Icons.add, onPressed: () {}),
+        const SizedBox(height: 8),
+        AppTextButton(
+          label: 'Learn More',
+          icon: Icons.arrow_forward,
+          onPressed: () {},
+        ),
+        const SizedBox(height: 8),
+        AppTextButton(
+          label: 'Show Details',
+          icon: Icons.info_outline,
+          onPressed: () {},
+        ),
+        const SizedBox(height: 8),
+        AppTextButton(
+          label: 'See All',
+          icon: Icons.arrow_forward_ios,
+          onPressed: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+// 3. States - All button states
+@widgetbook.UseCase(name: 'States', type: AppTextButton)
+Widget appTextButtonStates(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('Enabled', style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        AppTextButton(label: 'Enabled', onPressed: () {}),
+        const SizedBox(height: 16),
+        const Text('Disabled', style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        const AppTextButton(label: 'Disabled', onPressed: null),
+        const SizedBox(height: 16),
+        const Text('Loading', style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        AppTextButton(label: 'Processing', isLoading: true, onPressed: () {}),
+        const SizedBox(height: 16),
+        const Text(
+          'Hover (Desktop)',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 4),
+        const Text(
+          'Hover over the button to see the subtle highlight effect',
+          style: TextStyle(fontSize: 12, fontStyle: FontStyle.italic),
+        ),
+        const SizedBox(height: 8),
+        AppTextButton(label: 'Hover Me', onPressed: () {}),
+      ],
+    ),
+  );
+}
+
+// 4. Inline Usage - Within text paragraphs
+@widgetbook.UseCase(name: 'Inline Usage', type: AppTextButton)
+Widget appTextButtonInlineUsage(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Text buttons work well inline within paragraphs',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 16),
+        Text.rich(
+          TextSpan(
+            style: const TextStyle(fontSize: 16),
+            children: [
+              const TextSpan(
+                text: 'By continuing, you agree to our terms and conditions. ',
+              ),
+              WidgetSpan(
+                alignment: PlaceholderAlignment.middle,
+                child: AppTextButton(label: 'Learn more', onPressed: () {}),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 24),
+        Text.rich(
+          TextSpan(
+            style: const TextStyle(fontSize: 16),
+            children: [
+              const TextSpan(text: 'Your order has been confirmed. '),
+              WidgetSpan(
+                alignment: PlaceholderAlignment.middle,
+                child: AppTextButton(label: 'View details', onPressed: () {}),
+              ),
+              const TextSpan(text: ' or '),
+              WidgetSpan(
+                alignment: PlaceholderAlignment.middle,
+                child: AppTextButton(label: 'track shipment', onPressed: () {}),
+              ),
+              const TextSpan(text: '.'),
+            ],
+          ),
+        ),
+        const SizedBox(height: 24),
+        const Text(
+          'Minimal Visual Impact',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        const Text(
+          'Notice how text buttons maintain minimal visual weight, '
+          'blending seamlessly with surrounding text while remaining '
+          'clearly interactive.',
+          style: TextStyle(fontStyle: FontStyle.italic),
+        ),
+      ],
+    ),
+  );
+}
+
+// 5. Button Hierarchy - Visual comparison
+@widgetbook.UseCase(name: 'Button Hierarchy', type: AppTextButton)
+Widget appTextButtonHierarchy(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Visual Weight Comparison',
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        const Text(
+          'Notice the decreasing visual emphasis from filled to text',
+          style: TextStyle(fontStyle: FontStyle.italic),
+        ),
+        const SizedBox(height: 24),
+        const Text(
+          'High Emphasis (Primary Actions)',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        AppButton.filled(label: 'Filled Button', onPressed: () {}),
+        const SizedBox(height: 24),
+        const Text(
+          'Medium Emphasis (Secondary Actions)',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        AppButton.outlined(label: 'Outlined Button', onPressed: () {}),
+        const SizedBox(height: 24),
+        const Text(
+          'Low Emphasis (Tertiary Actions)',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        AppTextButton(label: 'Text Button', onPressed: () {}),
+        const Divider(height: 48),
+        const Text(
+          'Common Pattern: Dialog Actions',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            AppTextButton(label: 'Cancel', onPressed: () {}),
+            const SizedBox(width: 8),
+            AppButton.filled(label: 'Confirm', onPressed: () {}),
+          ],
+        ),
+      ],
+    ),
+  );
+}
+
+// 6. Theme Variations - Light and dark modes
+@widgetbook.UseCase(name: 'Theme Variations', type: AppTextButton)
+Widget appTextButtonThemeVariations(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Toggle theme in Widgetbook settings (top toolbar) to see variations',
+          style: TextStyle(fontStyle: FontStyle.italic),
+        ),
+        const SizedBox(height: 24),
+        const Text('Enabled', style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        AppTextButton(label: 'Text Button', onPressed: () {}),
+        const SizedBox(height: 16),
+        const Text('Disabled', style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        const AppTextButton(label: 'Disabled', onPressed: null),
+        const SizedBox(height: 16),
+        const Text('With Icon', style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        AppTextButton(
+          label: 'Learn More',
+          icon: Icons.arrow_forward,
+          onPressed: () {},
+        ),
+        const SizedBox(height: 16),
+        const Text('Loading', style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        AppTextButton(label: 'Processing', isLoading: true, onPressed: () {}),
+        const Divider(height: 32),
+        const Text(
+          'Color Contrast',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        const Text(
+          'Text buttons use the primary color in light mode and adjust '
+          'automatically for dark mode. Disabled buttons use onSurface '
+          'color at 38% opacity.',
+          style: TextStyle(fontSize: 12),
+        ),
+      ],
+    ),
+  );
+}
+
+// 7. Common Use Cases - Real-world examples
+@widgetbook.UseCase(name: 'Common Use Cases', type: AppTextButton)
+Widget appTextButtonUseCases(BuildContext context) {
+  return SingleChildScrollView(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '1. Dialog Actions',
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              border: Border.all(color: Colors.grey.shade300),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('Delete this item?'),
+                const SizedBox(height: 16),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    AppTextButton(label: 'Cancel', onPressed: () {}),
+                    const SizedBox(width: 8),
+                    AppTextButton(label: 'Not now', onPressed: () {}),
+                    const SizedBox(width: 8),
+                    AppButton.filled(label: 'Delete', onPressed: () {}),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 24),
+          const Text(
+            '2. Navigation Links',
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              border: Border.all(color: Colors.grey.shade300),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('Popular Items'),
+                const SizedBox(height: 8),
+                const Text('Item 1'),
+                const Text('Item 2'),
+                const Text('Item 3'),
+                const SizedBox(height: 8),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: AppTextButton(
+                    label: 'See all',
+                    icon: Icons.arrow_forward,
+                    onPressed: () {},
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 24),
+          const Text(
+            '3. Inline Actions',
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              border: Border.all(color: Colors.grey.shade300),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    const Text('Shipping Address'),
+                    AppTextButton(label: 'Change', onPressed: () {}),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                const Text('123 Main St, City, State 12345'),
+              ],
+            ),
+          ),
+          const SizedBox(height: 24),
+          const Text(
+            '4. Toolbar/Menu Actions',
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            decoration: BoxDecoration(
+              border: Border.all(color: Colors.grey.shade300),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text('Document.pdf'),
+                Row(
+                  children: [
+                    AppTextButton(label: 'Share', onPressed: () {}),
+                    AppTextButton(label: 'Download', onPressed: () {}),
+                    AppTextButton(label: 'Delete', onPressed: () {}),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 24),
+          const Text(
+            '5. Skip Actions',
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              border: Border.all(color: Colors.grey.shade300),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const Text('Enable Notifications?'),
+                const SizedBox(height: 8),
+                const Text(
+                  'Get notified about important updates',
+                  style: TextStyle(fontSize: 12),
+                ),
+                const SizedBox(height: 16),
+                AppButton.filled(label: 'Enable', onPressed: () {}),
+                const SizedBox(height: 8),
+                Center(
+                  child: AppTextButton(label: 'Skip for now', onPressed: () {}),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}

--- a/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_checkbox_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_checkbox_stories.dart
@@ -1,2 +1,329 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/core_kit.dart';
+
+// 1. Default Checkbox - Basic unchecked state
+@widgetbook.UseCase(name: 'Default', type: AppCheckbox)
+Widget appCheckboxDefault(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: AppCheckbox(
+      value: false,
+      label: 'Checkbox label',
+      onChanged: (value) {},
+    ),
+  );
+}
+
+// 2. Checked State
+@widgetbook.UseCase(name: 'Checked', type: AppCheckbox)
+Widget appCheckboxChecked(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: AppCheckbox(
+      value: true,
+      label: 'Checked checkbox',
+      onChanged: (value) {},
+    ),
+  );
+}
+
+// 3. Indeterminate State
+@widgetbook.UseCase(name: 'Indeterminate', type: AppCheckbox)
+Widget appCheckboxIndeterminate(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: AppCheckbox(
+      value: null,
+      tristate: true,
+      label: 'Indeterminate checkbox (tristate)',
+      onChanged: (value) {},
+    ),
+  );
+}
+
+// 4. Disabled Unchecked
+@widgetbook.UseCase(name: 'Disabled Unchecked', type: AppCheckbox)
+Widget appCheckboxDisabledUnchecked(BuildContext context) {
+  return const Padding(
+    padding: EdgeInsets.all(16.0),
+    child: AppCheckbox(
+      value: false,
+      label: 'Disabled unchecked',
+      onChanged: null,
+    ),
+  );
+}
+
+// 5. Disabled Checked
+@widgetbook.UseCase(name: 'Disabled Checked', type: AppCheckbox)
+Widget appCheckboxDisabledChecked(BuildContext context) {
+  return const Padding(
+    padding: EdgeInsets.all(16.0),
+    child: AppCheckbox(value: true, label: 'Disabled checked', onChanged: null),
+  );
+}
+
+// 6. Error State
+@widgetbook.UseCase(name: 'Error State', type: AppCheckbox)
+Widget appCheckboxError(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: AppCheckbox(
+      value: false,
+      label: 'Required checkbox',
+      error: true,
+      errorText: 'This field is required',
+      onChanged: (value) {},
+    ),
+  );
+}
+
+// 7. No Label
+@widgetbook.UseCase(name: 'No Label', type: AppCheckbox)
+Widget appCheckboxNoLabel(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: AppCheckbox(value: false, onChanged: (value) {}),
+  );
+}
+
+// 8. Short Label
+@widgetbook.UseCase(name: 'Short Label', type: AppCheckbox)
+Widget appCheckboxShortLabel(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: AppCheckbox(value: true, label: 'I agree', onChanged: (value) {}),
+  );
+}
+
+// 9. Long Label
+@widgetbook.UseCase(name: 'Long Label', type: AppCheckbox)
+Widget appCheckboxLongLabel(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: SizedBox(
+      width: 300,
+      child: AppCheckbox(
+        value: false,
+        label:
+            'I have read and agree to the Terms of Service and Privacy Policy, and I understand that my data will be processed according to these terms.',
+        onChanged: (value) {},
+      ),
+    ),
+  );
+}
+
+// 10. List Integration
+@widgetbook.UseCase(name: 'List Integration', type: AppCheckbox)
+Widget appCheckboxListIntegration(BuildContext context) {
+  return SingleChildScrollView(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Select All (Indeterminate)',
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          AppCheckbox(
+            value: null,
+            tristate: true,
+            label: 'Select all items',
+            onChanged: (value) {},
+          ),
+          const Divider(height: 24),
+          AppCheckbox(
+            value: true,
+            label: 'Item 1 - Selected',
+            onChanged: (value) {},
+          ),
+          AppCheckbox(
+            value: true,
+            label: 'Item 2 - Selected',
+            onChanged: (value) {},
+          ),
+          AppCheckbox(
+            value: false,
+            label: 'Item 3 - Not selected',
+            onChanged: (value) {},
+          ),
+          AppCheckbox(
+            value: false,
+            label: 'Item 4 - Not selected',
+            onChanged: (value) {},
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+// 11. Form Example
+@widgetbook.UseCase(name: 'Form Example', type: AppCheckbox)
+Widget appCheckboxFormExample(BuildContext context) {
+  return SingleChildScrollView(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            'Registration Form',
+            style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 16),
+          const TextField(
+            decoration: InputDecoration(
+              labelText: 'Email',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 16),
+          const TextField(
+            decoration: InputDecoration(
+              labelText: 'Password',
+              border: OutlineInputBorder(),
+            ),
+            obscureText: true,
+          ),
+          const SizedBox(height: 16),
+          AppCheckbox(
+            value: false,
+            label: 'I accept the Terms and Conditions',
+            error: true,
+            errorText: 'You must accept the terms to continue',
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 8),
+          AppCheckbox(
+            value: true,
+            label: 'Subscribe to newsletter (optional)',
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 16),
+          ElevatedButton(onPressed: null, child: const Text('Register')),
+        ],
+      ),
+    ),
+  );
+}
+
+// 12. Theme Variations - Light & dark mode
+@widgetbook.UseCase(name: 'Theme Variations', type: AppCheckbox)
+Widget appCheckboxThemeVariations(BuildContext context) {
+  return SingleChildScrollView(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Toggle theme in Widgetbook to see variations',
+            style: TextStyle(fontStyle: FontStyle.italic, fontSize: 12),
+          ),
+          const SizedBox(height: 16),
+          const Text(
+            'Default Colors',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          AppCheckbox(
+            value: true,
+            label: 'Checked (uses primary color)',
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 8),
+          AppCheckbox(
+            value: false,
+            label: 'Unchecked (uses outline color)',
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 16),
+          const Text(
+            'Error State',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          AppCheckbox(
+            value: true,
+            label: 'Error checkbox',
+            error: true,
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 16),
+          const Text(
+            'Custom Colors',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          AppCheckbox(
+            value: true,
+            label: 'Custom green checkbox',
+            activeColor: Colors.green,
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 8),
+          AppCheckbox(
+            value: true,
+            label: 'Custom orange checkbox',
+            activeColor: Colors.deepOrange,
+            checkColor: Colors.white,
+            onChanged: (value) {},
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+// 13. All States
+@widgetbook.UseCase(name: 'All States', type: AppCheckbox)
+Widget appCheckboxAllStates(BuildContext context) {
+  return SingleChildScrollView(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Unchecked',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          AppCheckbox(value: false, label: 'Unchecked', onChanged: (value) {}),
+          const SizedBox(height: 8),
+          const Text('Checked', style: TextStyle(fontWeight: FontWeight.bold)),
+          AppCheckbox(value: true, label: 'Checked', onChanged: (value) {}),
+          const SizedBox(height: 8),
+          const Text(
+            'Indeterminate',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          AppCheckbox(
+            value: null,
+            tristate: true,
+            label: 'Indeterminate',
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 8),
+          const Text('Disabled', style: TextStyle(fontWeight: FontWeight.bold)),
+          const AppCheckbox(value: false, label: 'Disabled', onChanged: null),
+          const SizedBox(height: 8),
+          const Text('Error', style: TextStyle(fontWeight: FontWeight.bold)),
+          AppCheckbox(
+            value: false,
+            label: 'Error',
+            error: true,
+            errorText: 'Required field',
+            onChanged: (value) {},
+          ),
+        ],
+      ),
+    ),
+  );
+}

--- a/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_dropdown_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_dropdown_stories.dart
@@ -1,2 +1,339 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/core_kit.dart';
+
+// Model class for custom objects example
+class Country {
+  final String code;
+  final String name;
+  final String flag;
+
+  const Country(this.code, this.name, this.flag);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Country &&
+          runtimeType == other.runtimeType &&
+          code == other.code;
+
+  @override
+  int get hashCode => code.hashCode;
+}
+
+// ============================================================================
+// Story 1: Basic String Dropdown
+// ============================================================================
+
+@widgetbook.UseCase(name: 'Basic String Dropdown', type: AppDropdown)
+Widget basicStringDropdown(BuildContext context) {
+  return Center(
+    child: SizedBox(
+      width: 300,
+      child: AppDropdown<String>(
+        items: const [
+          'Option 1',
+          'Option 2',
+          'Option 3',
+          'Option 4',
+          'Option 5',
+        ],
+        itemLabelBuilder: (item) => item,
+        label: 'Select an option',
+        hint: 'Choose one...',
+        helperText: 'Pick your preferred option',
+        onChanged: (value) {
+          debugPrint('Selected: $value');
+        },
+      ),
+    ),
+  );
+}
+
+// ============================================================================
+// Story 2: Dropdown with Custom Objects
+// ============================================================================
+
+@widgetbook.UseCase(name: 'Custom Objects Dropdown', type: AppDropdown)
+Widget customObjectsDropdown(BuildContext context) {
+  const countries = [
+    Country('us', 'United States', '🇺🇸'),
+    Country('uk', 'United Kingdom', '🇬🇧'),
+    Country('ca', 'Canada', '🇨🇦'),
+    Country('de', 'Germany', '🇩🇪'),
+    Country('fr', 'France', '🇫🇷'),
+    Country('jp', 'Japan', '🇯🇵'),
+    Country('tr', 'Turkey', '🇹🇷'),
+  ];
+
+  return Center(
+    child: SizedBox(
+      width: 300,
+      child: AppDropdown<Country>(
+        items: countries,
+        itemLabelBuilder: (country) => '${country.flag} ${country.name}',
+        label: 'Select Country',
+        hint: 'Choose your country',
+        onChanged: (value) {
+          debugPrint('Selected: ${value?.name}');
+        },
+      ),
+    ),
+  );
+}
+
+// ============================================================================
+// Story 3: Dropdown with Search
+// ============================================================================
+
+@widgetbook.UseCase(name: 'Dropdown with Search', type: AppDropdown)
+Widget dropdownWithSearch(BuildContext context) {
+  final cities = [
+    'New York',
+    'Los Angeles',
+    'Chicago',
+    'Houston',
+    'Phoenix',
+    'Philadelphia',
+    'San Antonio',
+    'San Diego',
+    'Dallas',
+    'San Jose',
+    'Austin',
+    'Jacksonville',
+    'Fort Worth',
+    'Columbus',
+    'Charlotte',
+    'San Francisco',
+    'Indianapolis',
+    'Seattle',
+    'Denver',
+    'Washington',
+    'Boston',
+    'Nashville',
+    'Baltimore',
+    'Detroit',
+    'Portland',
+  ];
+
+  return Center(
+    child: SizedBox(
+      width: 350,
+      child: AppDropdown<String>.withSearch(
+        items: cities,
+        itemLabelBuilder: (city) => city,
+        label: 'Select City',
+        hint: 'Type to search cities...',
+        helperText: 'Search functionality enabled',
+        onChanged: (value) {
+          debugPrint('Selected: $value');
+        },
+      ),
+    ),
+  );
+}
+
+// ============================================================================
+// Story 4: Dropdown with Icons (using AppDropdownItem)
+// ============================================================================
+
+@widgetbook.UseCase(name: 'Dropdown with Icons', type: AppDropdown)
+Widget dropdownWithIcons(BuildContext context) {
+  final items = [
+    const AppDropdownItem<String>(
+      value: 'home',
+      label: 'Home',
+      icon: Icons.home,
+    ),
+    const AppDropdownItem<String>(
+      value: 'work',
+      label: 'Work',
+      icon: Icons.work,
+    ),
+    const AppDropdownItem<String>(
+      value: 'school',
+      label: 'School',
+      icon: Icons.school,
+    ),
+    const AppDropdownItem<String>(
+      value: 'favorite',
+      label: 'Favorite',
+      icon: Icons.favorite,
+    ),
+    const AppDropdownItem<String>(
+      value: 'settings',
+      label: 'Settings',
+      icon: Icons.settings,
+    ),
+  ];
+
+  return Center(
+    child: SizedBox(
+      width: 300,
+      child: Builder(
+        builder: (context) => AppDropdown<AppDropdownItem<String>>(
+          items: items,
+          itemLabelBuilder: (item) => item.label,
+          customItemBuilder: (item) => item.buildWidget(context),
+          label: 'Select Location',
+          hint: 'Choose a location type',
+          onChanged: (value) {
+            debugPrint('Selected: ${value?.label}');
+          },
+        ),
+      ),
+    ),
+  );
+}
+
+// ============================================================================
+// Story 5: Dropdown with Validation Error
+// ============================================================================
+
+@widgetbook.UseCase(name: 'Dropdown with Error', type: AppDropdown)
+Widget dropdownWithError(BuildContext context) {
+  return Center(
+    child: SizedBox(
+      width: 300,
+      child: AppDropdown<String>(
+        items: const ['Small', 'Medium', 'Large', 'Extra Large'],
+        itemLabelBuilder: (item) => item,
+        label: 'Select Size',
+        hint: 'Choose a size',
+        errorText: 'Size selection is required',
+        onChanged: (value) {
+          debugPrint('Selected: $value');
+        },
+      ),
+    ),
+  );
+}
+
+// ============================================================================
+// Story 6: Disabled Dropdown
+// ============================================================================
+
+@widgetbook.UseCase(name: 'Disabled Dropdown', type: AppDropdown)
+Widget disabledDropdown(BuildContext context) {
+  return Center(
+    child: SizedBox(
+      width: 300,
+      child: AppDropdown<String>(
+        items: const ['Option 1', 'Option 2', 'Option 3'],
+        value: 'Option 2',
+        itemLabelBuilder: (item) => item,
+        label: 'Select an option',
+        hint: 'This dropdown is disabled',
+        enabled: false,
+        onChanged: (value) {
+          debugPrint('Selected: $value');
+        },
+      ),
+    ),
+  );
+}
+
+// ============================================================================
+// Story 7: Dropdown with Placeholder (No Selection)
+// ============================================================================
+
+@widgetbook.UseCase(name: 'Dropdown with Placeholder', type: AppDropdown)
+Widget dropdownWithPlaceholder(BuildContext context) {
+  return Center(
+    child: SizedBox(
+      width: 300,
+      child: AppDropdown<String>(
+        items: const ['Apple', 'Banana', 'Cherry', 'Date', 'Elderberry'],
+        value: null,
+        itemLabelBuilder: (item) => item,
+        label: 'Select Fruit',
+        hint: 'No fruit selected',
+        helperText: 'Choose your favorite fruit',
+        onChanged: (value) {
+          debugPrint('Selected: $value');
+        },
+      ),
+    ),
+  );
+}
+
+// ============================================================================
+// Story 8: Large List Dropdown (100+ items with search)
+// ============================================================================
+
+@widgetbook.UseCase(name: 'Large List Dropdown', type: AppDropdown)
+Widget largeListDropdown(BuildContext context) {
+  final items = List.generate(150, (index) => 'Item ${index + 1}');
+
+  return Center(
+    child: SizedBox(
+      width: 350,
+      child: AppDropdown<String>.withSearch(
+        items: items,
+        itemLabelBuilder: (item) => item,
+        label: 'Select Item',
+        hint: 'Search from 150 items...',
+        helperText: 'Large scrollable list with search',
+        onChanged: (value) {
+          debugPrint('Selected: $value');
+        },
+      ),
+    ),
+  );
+}
+
+// ============================================================================
+// Bonus Story: Dropdown with Rich Items (Icon + Subtitle)
+// ============================================================================
+
+@widgetbook.UseCase(name: 'Rich Items Dropdown', type: AppDropdown)
+Widget richItemsDropdown(BuildContext context) {
+  final items = [
+    const AppDropdownItem<String>(
+      value: 'pending',
+      label: 'Pending',
+      icon: Icons.pending,
+      subtitle: 'Awaiting review',
+    ),
+    const AppDropdownItem<String>(
+      value: 'approved',
+      label: 'Approved',
+      icon: Icons.check_circle,
+      subtitle: 'Ready to proceed',
+    ),
+    const AppDropdownItem<String>(
+      value: 'rejected',
+      label: 'Rejected',
+      icon: Icons.cancel,
+      subtitle: 'Needs revision',
+    ),
+    const AppDropdownItem<String>(
+      value: 'archived',
+      label: 'Archived',
+      icon: Icons.archive,
+      subtitle: 'No longer active',
+    ),
+  ];
+
+  return Center(
+    child: SizedBox(
+      width: 350,
+      child: Builder(
+        builder: (context) => AppDropdown<AppDropdownItem<String>>(
+          items: items,
+          itemLabelBuilder: (item) => item.label,
+          customItemBuilder: (item) => item.buildWidget(context),
+          label: 'Select Status',
+          hint: 'Choose item status',
+          helperText: 'Items with icons and subtitles',
+          onChanged: (value) {
+            debugPrint('Selected: ${value?.label}');
+          },
+        ),
+      ),
+    ),
+  );
+}

--- a/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_password_field_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_password_field_stories.dart
@@ -1,2 +1,445 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/core_kit.dart';
+
+/// Basic password field with visibility toggle
+@widgetbook.UseCase(name: 'Basic', type: AppPasswordField)
+Widget basicPasswordField(BuildContext context) {
+  return const Padding(
+    padding: EdgeInsets.all(16.0),
+    child: AppPasswordField(label: 'Password', hint: 'Enter your password'),
+  );
+}
+
+/// Password field with strength indicator
+@widgetbook.UseCase(name: 'With Strength Indicator', type: AppPasswordField)
+Widget passwordFieldWithStrength(BuildContext context) {
+  return const Padding(
+    padding: EdgeInsets.all(16.0),
+    child: AppPasswordField(
+      label: 'Create Password',
+      hint: 'Choose a strong password',
+      showStrengthIndicator: true,
+      helperText:
+          'Use at least 8 characters with mixed case, numbers, and symbols',
+    ),
+  );
+}
+
+/// Password confirmation field pair with dynamic matching validation
+@widgetbook.UseCase(name: 'Password Confirmation', type: AppPasswordField)
+Widget passwordConfirmationFields(BuildContext context) {
+  return const _PasswordConfirmationExample();
+}
+
+class _PasswordConfirmationExample extends StatefulWidget {
+  const _PasswordConfirmationExample();
+
+  @override
+  State<_PasswordConfirmationExample> createState() =>
+      _PasswordConfirmationExampleState();
+}
+
+class _PasswordConfirmationExampleState
+    extends State<_PasswordConfirmationExample> {
+  final _passwordController = TextEditingController();
+  final _confirmController = TextEditingController();
+  String? _confirmError;
+
+  @override
+  void initState() {
+    super.initState();
+    _passwordController.addListener(_validateConfirmation);
+    _confirmController.addListener(_validateConfirmation);
+  }
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    _confirmController.dispose();
+    super.dispose();
+  }
+
+  void _validateConfirmation() {
+    setState(() {
+      if (_confirmController.text.isEmpty) {
+        _confirmError = null;
+      } else if (_passwordController.text != _confirmController.text) {
+        _confirmError = 'Passwords do not match';
+      } else {
+        _confirmError = null;
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Password Confirmation',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 16),
+          AppPasswordField(
+            controller: _passwordController,
+            label: 'New Password',
+            hint: 'Enter new password',
+            showStrengthIndicator: true,
+            helperText: 'Choose a strong password',
+          ),
+          const SizedBox(height: 16),
+          AppPasswordField(
+            controller: _confirmController,
+            label: 'Confirm Password',
+            hint: 'Re-enter your password',
+            errorText: _confirmError,
+          ),
+          if (_confirmError == null && _confirmController.text.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 8.0, left: 12.0),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.check_circle,
+                    size: 16,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    'Passwords match',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.primary,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Password field with dynamic validation errors
+@widgetbook.UseCase(name: 'With Validation Error', type: AppPasswordField)
+Widget passwordFieldWithError(BuildContext context) {
+  return const _ValidationErrorExample();
+}
+
+class _ValidationErrorExample extends StatefulWidget {
+  const _ValidationErrorExample();
+
+  @override
+  State<_ValidationErrorExample> createState() =>
+      _ValidationErrorExampleState();
+}
+
+class _ValidationErrorExampleState extends State<_ValidationErrorExample> {
+  final _controller = TextEditingController();
+  String? _errorText;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(_validatePassword);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _validatePassword() {
+    setState(() {
+      final password = _controller.text;
+
+      if (password.isEmpty) {
+        _errorText = null;
+      } else if (password.length < 8) {
+        _errorText = 'Password must be at least 8 characters';
+      } else if (!RegExp(r'[A-Z]').hasMatch(password)) {
+        _errorText = 'Password must contain at least one uppercase letter';
+      } else if (!RegExp(r'[a-z]').hasMatch(password)) {
+        _errorText = 'Password must contain at least one lowercase letter';
+      } else if (!RegExp(r'[0-9]').hasMatch(password)) {
+        _errorText = 'Password must contain at least one number';
+      } else if (!RegExp(r'[!@#$%^&*(),.?":{}|<>]').hasMatch(password)) {
+        _errorText = 'Password must contain at least one special character';
+      } else {
+        _errorText = null;
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Dynamic Validation',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Type a password to see validation errors change dynamically',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 16),
+          AppPasswordField(
+            controller: _controller,
+            label: 'Password',
+            hint: 'Enter your password',
+            errorText: _errorText,
+            showStrengthIndicator: true,
+          ),
+          const SizedBox(height: 16),
+          _buildValidationChecklist(context),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildValidationChecklist(BuildContext context) {
+    final password = _controller.text;
+    final hasMinLength = password.length >= 8;
+    final hasUppercase = RegExp(r'[A-Z]').hasMatch(password);
+    final hasLowercase = RegExp(r'[a-z]').hasMatch(password);
+    final hasNumber = RegExp(r'[0-9]').hasMatch(password);
+    final hasSpecialChar = RegExp(r'[!@#$%^&*(),.?":{}|<>]').hasMatch(password);
+
+    return Container(
+      padding: const EdgeInsets.all(12.0),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Password Requirements:',
+            style: Theme.of(
+              context,
+            ).textTheme.labelMedium?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          _buildCheckItem(context, 'At least 8 characters', hasMinLength),
+          _buildCheckItem(context, 'One uppercase letter', hasUppercase),
+          _buildCheckItem(context, 'One lowercase letter', hasLowercase),
+          _buildCheckItem(context, 'One number', hasNumber),
+          _buildCheckItem(context, 'One special character', hasSpecialChar),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCheckItem(BuildContext context, String text, bool isValid) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 4.0),
+      child: Row(
+        children: [
+          Icon(
+            isValid ? Icons.check_circle : Icons.circle_outlined,
+            size: 16,
+            color: isValid
+                ? Theme.of(context).colorScheme.primary
+                : Theme.of(context).colorScheme.outline,
+          ),
+          const SizedBox(width: 8),
+          Text(
+            text,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: isValid
+                  ? Theme.of(context).colorScheme.primary
+                  : Theme.of(context).colorScheme.onSurfaceVariant,
+              decoration: isValid ? TextDecoration.lineThrough : null,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Disabled password field
+@widgetbook.UseCase(name: 'Disabled', type: AppPasswordField)
+Widget disabledPasswordField(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: AppPasswordField(
+      label: 'Password',
+      hint: 'Enter your password',
+      enabled: false,
+      controller: TextEditingController(text: 'disabled_password'),
+    ),
+  );
+}
+
+/// Password field with copy prevention
+@widgetbook.UseCase(name: 'With Copy Prevention', type: AppPasswordField)
+Widget passwordFieldWithCopyPrevention(BuildContext context) {
+  return const Padding(
+    padding: EdgeInsets.all(16.0),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        AppPasswordField(
+          label: 'Secure Password',
+          hint: 'Copy/paste disabled',
+          preventCopyPaste: true,
+          helperText: 'Copy and paste operations are disabled for security',
+        ),
+      ],
+    ),
+  );
+}
+
+/// Login form password field variant
+@widgetbook.UseCase(name: 'Login Form Variant', type: AppPasswordField)
+Widget loginFormPasswordField(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text('Sign In', style: Theme.of(context).textTheme.headlineMedium),
+        const SizedBox(height: 24),
+        const AppTextField(
+          label: 'Email',
+          hint: 'your@email.com',
+          prefixIcon: Icons.email_outlined,
+          keyboardType: TextInputType.emailAddress,
+        ),
+        const SizedBox(height: 16),
+        const AppPasswordField(
+          label: 'Password',
+          hint: 'Enter your password',
+          showLockIcon: true,
+          textInputAction: TextInputAction.done,
+        ),
+        const SizedBox(height: 8),
+        Align(
+          alignment: Alignment.centerRight,
+          child: TextButton(
+            onPressed: () {},
+            child: const Text('Forgot Password?'),
+          ),
+        ),
+        const SizedBox(height: 16),
+        ElevatedButton(
+          onPressed: () {},
+          style: ElevatedButton.styleFrom(
+            minimumSize: const Size.fromHeight(48),
+          ),
+          child: const Text('Sign In'),
+        ),
+      ],
+    ),
+  );
+}
+
+/// Registration form password field with requirements
+@widgetbook.UseCase(name: 'Registration Form Variant', type: AppPasswordField)
+Widget registrationFormPasswordField(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          'Create Account',
+          style: Theme.of(context).textTheme.headlineMedium,
+        ),
+        const SizedBox(height: 24),
+        const AppTextField(
+          label: 'Full Name',
+          hint: 'John Doe',
+          prefixIcon: Icons.person_outline,
+        ),
+        const SizedBox(height: 16),
+        const AppTextField(
+          label: 'Email',
+          hint: 'your@email.com',
+          prefixIcon: Icons.email_outlined,
+          keyboardType: TextInputType.emailAddress,
+        ),
+        const SizedBox(height: 16),
+        const AppPasswordField(
+          label: 'Password',
+          hint: 'Create a strong password',
+          showStrengthIndicator: true,
+          showLockIcon: true,
+        ),
+        const SizedBox(height: 8),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Password Requirements:',
+                style: Theme.of(
+                  context,
+                ).textTheme.labelSmall?.copyWith(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 4),
+              _buildRequirement(context, 'At least 8 characters'),
+              _buildRequirement(context, 'Mix of uppercase & lowercase'),
+              _buildRequirement(context, 'At least one number'),
+              _buildRequirement(context, 'At least one special character'),
+            ],
+          ),
+        ),
+        const SizedBox(height: 16),
+        const AppPasswordField(
+          label: 'Confirm Password',
+          hint: 'Re-enter your password',
+        ),
+        const SizedBox(height: 24),
+        ElevatedButton(
+          onPressed: () {},
+          style: ElevatedButton.styleFrom(
+            minimumSize: const Size.fromHeight(48),
+          ),
+          child: const Text('Create Account'),
+        ),
+      ],
+    ),
+  );
+}
+
+Widget _buildRequirement(BuildContext context, String text) {
+  return Padding(
+    padding: const EdgeInsets.only(top: 2.0),
+    child: Row(
+      children: [
+        Icon(
+          Icons.check_circle_outline,
+          size: 16,
+          color: Theme.of(context).colorScheme.outline,
+        ),
+        const SizedBox(width: 8),
+        Text(
+          text,
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    ),
+  );
+}

--- a/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_radio_group_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_radio_group_stories.dart
@@ -1,2 +1,498 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/core_kit.dart';
+
+// 1. Default - Basic vertical radio group
+@widgetbook.UseCase(name: 'Default', type: AppRadioGroup)
+Widget appRadioGroupDefault(BuildContext context) {
+  return const _DefaultRadioGroupStory();
+}
+
+class _DefaultRadioGroupStory extends StatefulWidget {
+  const _DefaultRadioGroupStory();
+
+  @override
+  State<_DefaultRadioGroupStory> createState() =>
+      _DefaultRadioGroupStoryState();
+}
+
+class _DefaultRadioGroupStoryState extends State<_DefaultRadioGroupStory> {
+  String? selectedValue;
+
+  @override
+  Widget build(BuildContext context) {
+    return _RadioGroupWrapper(
+      child: AppRadioGroup<String>(
+        label: 'Select an option',
+        value: selectedValue,
+        options: const [
+          RadioOption(value: 'option1', label: 'Option 1'),
+          RadioOption(value: 'option2', label: 'Option 2'),
+          RadioOption(value: 'option3', label: 'Option 3'),
+        ],
+        onChanged: (value) {
+          setState(() => selectedValue = value);
+        },
+      ),
+    );
+  }
+}
+
+// 2. Horizontal Layout
+@widgetbook.UseCase(name: 'Horizontal Layout', type: AppRadioGroup)
+Widget appRadioGroupHorizontal(BuildContext context) {
+  return const _HorizontalRadioGroupStory();
+}
+
+class _HorizontalRadioGroupStory extends StatefulWidget {
+  const _HorizontalRadioGroupStory();
+
+  @override
+  State<_HorizontalRadioGroupStory> createState() =>
+      _HorizontalRadioGroupStoryState();
+}
+
+class _HorizontalRadioGroupStoryState
+    extends State<_HorizontalRadioGroupStory> {
+  String? selectedValue;
+
+  @override
+  Widget build(BuildContext context) {
+    return _RadioGroupWrapper(
+      child: AppRadioGroup<String>(
+        label: 'Layout Direction',
+        value: selectedValue,
+        direction: Axis.horizontal,
+        options: const [
+          RadioOption(value: 'left', label: 'Left'),
+          RadioOption(value: 'center', label: 'Center'),
+          RadioOption(value: 'right', label: 'Right'),
+        ],
+        onChanged: (value) {
+          setState(() => selectedValue = value);
+        },
+      ),
+    );
+  }
+}
+
+// 3. With Icons
+@widgetbook.UseCase(name: 'With Icons', type: AppRadioGroup)
+Widget appRadioGroupWithIcons(BuildContext context) {
+  return const _WithIconsRadioGroupStory();
+}
+
+class _WithIconsRadioGroupStory extends StatefulWidget {
+  const _WithIconsRadioGroupStory();
+
+  @override
+  State<_WithIconsRadioGroupStory> createState() =>
+      _WithIconsRadioGroupStoryState();
+}
+
+class _WithIconsRadioGroupStoryState extends State<_WithIconsRadioGroupStory> {
+  String? selectedValue;
+
+  @override
+  Widget build(BuildContext context) {
+    return _RadioGroupWrapper(
+      child: AppRadioGroup<String>(
+        label: 'Payment Method',
+        value: selectedValue,
+        options: const [
+          RadioOption(
+            value: 'card',
+            label: 'Credit Card',
+            icon: Icons.credit_card,
+          ),
+          RadioOption(value: 'cash', label: 'Cash', icon: Icons.money),
+          RadioOption(
+            value: 'transfer',
+            label: 'Bank Transfer',
+            icon: Icons.account_balance,
+          ),
+        ],
+        onChanged: (value) {
+          setState(() => selectedValue = value);
+        },
+      ),
+    );
+  }
+}
+
+// 4. With Descriptions
+@widgetbook.UseCase(name: 'With Descriptions', type: AppRadioGroup)
+Widget appRadioGroupWithDescriptions(BuildContext context) {
+  return const _WithDescriptionsRadioGroupStory();
+}
+
+class _WithDescriptionsRadioGroupStory extends StatefulWidget {
+  const _WithDescriptionsRadioGroupStory();
+
+  @override
+  State<_WithDescriptionsRadioGroupStory> createState() =>
+      _WithDescriptionsRadioGroupStoryState();
+}
+
+class _WithDescriptionsRadioGroupStoryState
+    extends State<_WithDescriptionsRadioGroupStory> {
+  String? selectedValue;
+
+  @override
+  Widget build(BuildContext context) {
+    return _RadioGroupWrapper(
+      child: AppRadioGroup<String>(
+        label: 'Shipping Method',
+        value: selectedValue,
+        options: const [
+          RadioOption(
+            value: 'standard',
+            label: 'Standard Shipping',
+            description: 'Delivery in 5-7 business days',
+            icon: Icons.local_shipping,
+          ),
+          RadioOption(
+            value: 'express',
+            label: 'Express Shipping',
+            description: 'Delivery in 2-3 business days',
+            icon: Icons.delivery_dining,
+          ),
+          RadioOption(
+            value: 'overnight',
+            label: 'Overnight Shipping',
+            description: 'Next business day delivery',
+            icon: Icons.flight,
+          ),
+        ],
+        onChanged: (value) {
+          setState(() => selectedValue = value);
+        },
+      ),
+    );
+  }
+}
+
+// 5. Pre-selected
+@widgetbook.UseCase(name: 'Pre-selected', type: AppRadioGroup)
+Widget appRadioGroupPreselected(BuildContext context) {
+  return const _PreselectedRadioGroupStory();
+}
+
+class _PreselectedRadioGroupStory extends StatefulWidget {
+  const _PreselectedRadioGroupStory();
+
+  @override
+  State<_PreselectedRadioGroupStory> createState() =>
+      _PreselectedRadioGroupStoryState();
+}
+
+class _PreselectedRadioGroupStoryState
+    extends State<_PreselectedRadioGroupStory> {
+  String? selectedValue = 'email';
+
+  @override
+  Widget build(BuildContext context) {
+    return _RadioGroupWrapper(
+      child: AppRadioGroup<String>(
+        label: 'Notification Preference',
+        value: selectedValue,
+        options: const [
+          RadioOption(value: 'email', label: 'Email'),
+          RadioOption(value: 'sms', label: 'SMS'),
+          RadioOption(value: 'push', label: 'Push Notification'),
+        ],
+        onChanged: (value) {
+          setState(() => selectedValue = value);
+        },
+      ),
+    );
+  }
+}
+
+// 6. Disabled Group
+@widgetbook.UseCase(name: 'Disabled', type: AppRadioGroup)
+Widget appRadioGroupDisabled(BuildContext context) {
+  return const _DisabledRadioGroupStory();
+}
+
+class _DisabledRadioGroupStory extends StatefulWidget {
+  const _DisabledRadioGroupStory();
+
+  @override
+  State<_DisabledRadioGroupStory> createState() =>
+      _DisabledRadioGroupStoryState();
+}
+
+class _DisabledRadioGroupStoryState extends State<_DisabledRadioGroupStory> {
+  String? selectedValue;
+
+  @override
+  Widget build(BuildContext context) {
+    return _RadioGroupWrapper(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Disabled entire group
+          AppRadioGroup<String>(
+            label: 'Disabled Group',
+            enabled: false,
+            value: 'option1',
+            options: const [
+              RadioOption(value: 'option1', label: 'Selected but disabled'),
+              RadioOption(value: 'option2', label: 'Not selected'),
+            ],
+            onChanged: (value) {},
+          ),
+          const SizedBox(height: 24),
+          // Individual option disabled
+          AppRadioGroup<String>(
+            label: 'Individual Option Disabled',
+            value: selectedValue,
+            options: const [
+              RadioOption(value: 'available', label: 'Available Option'),
+              RadioOption(
+                value: 'unavailable',
+                label: 'Unavailable Option',
+                enabled: false,
+              ),
+            ],
+            onChanged: (value) {
+              setState(() => selectedValue = value);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// 7. Error State
+@widgetbook.UseCase(name: 'Error State', type: AppRadioGroup)
+Widget appRadioGroupError(BuildContext context) {
+  return const _ErrorRadioGroupStory();
+}
+
+class _ErrorRadioGroupStory extends StatefulWidget {
+  const _ErrorRadioGroupStory();
+
+  @override
+  State<_ErrorRadioGroupStory> createState() => _ErrorRadioGroupStoryState();
+}
+
+class _ErrorRadioGroupStoryState extends State<_ErrorRadioGroupStory> {
+  String? selectedValue;
+
+  @override
+  Widget build(BuildContext context) {
+    return _RadioGroupWrapper(
+      child: AppRadioGroup<String>(
+        label: 'Select Required Field',
+        value: selectedValue,
+        error: selectedValue == null,
+        errorText: selectedValue == null
+            ? 'Please select an option to continue'
+            : null,
+        options: const [
+          RadioOption(value: 'accept', label: 'Accept terms and conditions'),
+          RadioOption(value: 'decline', label: 'Decline'),
+        ],
+        onChanged: (value) {
+          setState(() => selectedValue = value);
+        },
+      ),
+    );
+  }
+}
+
+// 8. All States - Comprehensive comparison
+@widgetbook.UseCase(name: 'All States', type: AppRadioGroup)
+Widget appRadioGroupAllStates(BuildContext context) {
+  return const _AllStatesRadioGroupStory();
+}
+
+class _AllStatesRadioGroupStory extends StatefulWidget {
+  const _AllStatesRadioGroupStory();
+
+  @override
+  State<_AllStatesRadioGroupStory> createState() =>
+      _AllStatesRadioGroupStoryState();
+}
+
+class _AllStatesRadioGroupStoryState extends State<_AllStatesRadioGroupStory> {
+  String? unselectedValue;
+  String? selectedValue = 'a';
+  String? labelValue;
+  String? errorValue;
+  String? iconValue = 'star';
+  String? horizontalValue = 'yes';
+
+  @override
+  Widget build(BuildContext context) {
+    return _RadioGroupWrapper(
+      child: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Unselected
+            _buildSection(
+              'Unselected',
+              AppRadioGroup<String>(
+                value: unselectedValue,
+                options: const [
+                  RadioOption(value: 'a', label: 'Choice A'),
+                  RadioOption(value: 'b', label: 'Choice B'),
+                ],
+                onChanged: (value) {
+                  setState(() => unselectedValue = value);
+                },
+              ),
+            ),
+
+            const SizedBox(height: 16),
+
+            // Selected
+            _buildSection(
+              'Selected',
+              AppRadioGroup<String>(
+                value: selectedValue,
+                options: const [
+                  RadioOption(value: 'a', label: 'Choice A'),
+                  RadioOption(value: 'b', label: 'Choice B'),
+                ],
+                onChanged: (value) {
+                  setState(() => selectedValue = value);
+                },
+              ),
+            ),
+
+            const SizedBox(height: 16),
+
+            // With Label
+            _buildSection(
+              'With Group Label',
+              AppRadioGroup<String>(
+                label: 'Group Label',
+                value: labelValue,
+                options: const [
+                  RadioOption(value: 'a', label: 'Choice A'),
+                  RadioOption(value: 'b', label: 'Choice B'),
+                ],
+                onChanged: (value) {
+                  setState(() => labelValue = value);
+                },
+              ),
+            ),
+
+            const SizedBox(height: 16),
+
+            // Disabled
+            _buildSection(
+              'Disabled',
+              AppRadioGroup<String>(
+                enabled: false,
+                value: 'a',
+                options: const [
+                  RadioOption(value: 'a', label: 'Choice A'),
+                  RadioOption(value: 'b', label: 'Choice B'),
+                ],
+                onChanged: (value) {},
+              ),
+            ),
+
+            const SizedBox(height: 16),
+
+            // Error
+            _buildSection(
+              'Error State',
+              AppRadioGroup<String>(
+                value: errorValue,
+                error: true,
+                errorText: 'Selection required',
+                options: const [
+                  RadioOption(value: 'a', label: 'Choice A'),
+                  RadioOption(value: 'b', label: 'Choice B'),
+                ],
+                onChanged: (value) {
+                  setState(() => errorValue = value);
+                },
+              ),
+            ),
+
+            const SizedBox(height: 16),
+
+            // With Icons
+            _buildSection(
+              'With Icons',
+              AppRadioGroup<String>(
+                value: iconValue,
+                options: const [
+                  RadioOption(value: 'star', label: 'Star', icon: Icons.star),
+                  RadioOption(
+                    value: 'heart',
+                    label: 'Heart',
+                    icon: Icons.favorite,
+                  ),
+                ],
+                onChanged: (value) {
+                  setState(() => iconValue = value);
+                },
+              ),
+            ),
+
+            const SizedBox(height: 16),
+
+            // Horizontal
+            _buildSection(
+              'Horizontal Layout',
+              AppRadioGroup<String>(
+                direction: Axis.horizontal,
+                value: horizontalValue,
+                options: const [
+                  RadioOption(value: 'yes', label: 'Yes'),
+                  RadioOption(value: 'no', label: 'No'),
+                ],
+                onChanged: (value) {
+                  setState(() => horizontalValue = value);
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// Helper widget for consistent padding
+class _RadioGroupWrapper extends StatelessWidget {
+  const _RadioGroupWrapper({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(padding: const EdgeInsets.all(16.0), child: child);
+  }
+}
+
+// Helper function for All States story
+Widget _buildSection(String title, Widget content) {
+  return Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Text(
+        title,
+        style: const TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.bold,
+          color: Colors.grey,
+        ),
+      ),
+      const SizedBox(height: 8),
+      content,
+    ],
+  );
+}

--- a/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_search_field_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_search_field_stories.dart
@@ -1,2 +1,623 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:core_kit/core_kit.dart';
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+/// Basic search field with debouncing
+@widgetbook.UseCase(name: 'Basic', type: AppSearchField)
+Widget basicSearchField(BuildContext context) {
+  return const _BasicSearchDemo();
+}
+
+class _BasicSearchDemo extends StatefulWidget {
+  const _BasicSearchDemo();
+
+  @override
+  State<_BasicSearchDemo> createState() => _BasicSearchDemoState();
+}
+
+class _BasicSearchDemoState extends State<_BasicSearchDemo> {
+  final List<String> _debouncedQueries = [];
+  final List<String> _submittedQueries = [];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Basic Search with Debouncing',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            AppSearchField(
+              hint: 'Type to search...',
+              onSearchChanged: (query) {
+                setState(() {
+                  _debouncedQueries.insert(0, query);
+                  if (_debouncedQueries.length > 3) {
+                    _debouncedQueries.removeLast();
+                  }
+                });
+                debugPrint('🔍 Search changed (debounced after 300ms): $query');
+              },
+              onSearchSubmitted: (query) {
+                setState(() {
+                  _submittedQueries.insert(0, query);
+                  if (_submittedQueries.length > 3) {
+                    _submittedQueries.removeLast();
+                  }
+                });
+                debugPrint('⚡ Search submitted (immediate): $query');
+              },
+            ),
+            const SizedBox(height: 24),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Icon(
+                            Icons.timer_outlined,
+                            size: 16,
+                            color: Theme.of(context).colorScheme.primary,
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            'Debounced (300ms)',
+                            style: Theme.of(context).textTheme.titleSmall,
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 8),
+                      Container(
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: Theme.of(
+                            context,
+                          ).colorScheme.primaryContainer.withValues(alpha: 0.3),
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.primary.withValues(alpha: 0.3),
+                          ),
+                        ),
+                        child: _debouncedQueries.isEmpty
+                            ? Text(
+                                'Start typing to see debounced queries',
+                                style: Theme.of(context).textTheme.bodySmall
+                                    ?.copyWith(fontStyle: FontStyle.italic),
+                              )
+                            : Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: _debouncedQueries.asMap().entries.map(
+                                  (entry) {
+                                    final index = entry.key;
+                                    final query = entry.value;
+                                    return Padding(
+                                      padding: EdgeInsets.only(
+                                        bottom:
+                                            index < _debouncedQueries.length - 1
+                                            ? 4
+                                            : 0,
+                                      ),
+                                      child: Text(
+                                        query.isEmpty
+                                            ? '(cleared)'
+                                            : '"$query"',
+                                        style: Theme.of(
+                                          context,
+                                        ).textTheme.bodySmall,
+                                      ),
+                                    );
+                                  },
+                                ).toList(),
+                              ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Icon(
+                            Icons.send,
+                            size: 16,
+                            color: Theme.of(context).colorScheme.secondary,
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            'Submitted (Enter)',
+                            style: Theme.of(context).textTheme.titleSmall,
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 8),
+                      Container(
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: Theme.of(context)
+                              .colorScheme
+                              .secondaryContainer
+                              .withValues(alpha: 0.3),
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.secondary.withValues(alpha: 0.3),
+                          ),
+                        ),
+                        child: _submittedQueries.isEmpty
+                            ? Text(
+                                'Press Enter to submit',
+                                style: Theme.of(context).textTheme.bodySmall
+                                    ?.copyWith(fontStyle: FontStyle.italic),
+                              )
+                            : Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: _submittedQueries.asMap().entries.map(
+                                  (entry) {
+                                    final index = entry.key;
+                                    final query = entry.value;
+                                    return Padding(
+                                      padding: EdgeInsets.only(
+                                        bottom:
+                                            index < _submittedQueries.length - 1
+                                            ? 4
+                                            : 0,
+                                      ),
+                                      child: Text(
+                                        query.isEmpty ? '(empty)' : '"$query"',
+                                        style: Theme.of(
+                                          context,
+                                        ).textTheme.bodySmall,
+                                      ),
+                                    );
+                                  },
+                                ).toList(),
+                              ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: Theme.of(
+                  context,
+                ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.info_outline,
+                    size: 16,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'Debounced: Triggered 300ms after you stop typing\nSubmitted: Triggered immediately when you press Enter',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Search field with custom hint text
+@widgetbook.UseCase(name: 'Custom Hint', type: AppSearchField)
+Widget customHintSearchField(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Product Search', style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 8),
+        AppSearchField(
+          hint: 'Search products...',
+          onSearchChanged: (query) {
+            debugPrint('Product search: $query');
+          },
+        ),
+        const SizedBox(height: 16),
+        Text('User Search', style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 8),
+        AppSearchField(
+          hint: 'Search users by name or email...',
+          onSearchChanged: (query) {
+            debugPrint('User search: $query');
+          },
+        ),
+      ],
+    ),
+  );
+}
+
+/// Search field with clear button interaction
+@widgetbook.UseCase(name: 'With Clear Button', type: AppSearchField)
+Widget searchFieldWithClearButton(BuildContext context) {
+  final controller = TextEditingController(text: 'Initial search query');
+
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Clear button appears when text is entered',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 8),
+        AppSearchField(
+          controller: controller,
+          hint: 'Search...',
+          onSearchChanged: (query) {
+            debugPrint('Search: $query');
+          },
+        ),
+      ],
+    ),
+  );
+}
+
+/// Search field with loading indicator
+@widgetbook.UseCase(name: 'Loading State', type: AppSearchField)
+Widget loadingSearchField(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Searching...', style: Theme.of(context).textTheme.bodyMedium),
+        const SizedBox(height: 8),
+        const AppSearchField(hint: 'Search products...', isLoading: true),
+      ],
+    ),
+  );
+}
+
+/// Search field with auto-focus enabled
+@widgetbook.UseCase(name: 'Auto Focus', type: AppSearchField)
+Widget autoFocusSearchField(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Field automatically focused on mount',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 8),
+        AppSearchField(
+          hint: 'Start typing...',
+          autofocus: true,
+          onSearchChanged: (query) {
+            debugPrint('Search: $query');
+          },
+        ),
+      ],
+    ),
+  );
+}
+
+/// Search field with immediate submit action
+@widgetbook.UseCase(name: 'Submit Action', type: AppSearchField)
+Widget submitActionSearchField(BuildContext context) {
+  return const _SubmitActionDemo();
+}
+
+class _SubmitActionDemo extends StatefulWidget {
+  const _SubmitActionDemo();
+
+  @override
+  State<_SubmitActionDemo> createState() => _SubmitActionDemoState();
+}
+
+class _SubmitActionDemoState extends State<_SubmitActionDemo> {
+  final List<String> _submittedQueries = [];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Press Enter/Search button to submit',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            AppSearchField(
+              hint: 'Search and press Enter...',
+              clearOnSubmit: true,
+              onSearchSubmitted: (query) {
+                setState(() {
+                  _submittedQueries.insert(0, query);
+                  if (_submittedQueries.length > 5) {
+                    _submittedQueries.removeLast();
+                  }
+                });
+                debugPrint('⚡ Search submitted immediately: $query');
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text('Submitted: $query'),
+                    duration: const Duration(seconds: 2),
+                    behavior: SnackBarBehavior.floating,
+                  ),
+                );
+              },
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Submitted Searches (last 5):',
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+            const SizedBox(height: 8),
+            if (_submittedQueries.isEmpty)
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Text(
+                  'No searches submitted yet. Type and press Enter.',
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodySmall?.copyWith(fontStyle: FontStyle.italic),
+                ),
+              )
+            else
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: _submittedQueries.asMap().entries.map((entry) {
+                    final index = entry.key;
+                    final query = entry.value;
+                    return Padding(
+                      padding: EdgeInsets.only(
+                        bottom: index < _submittedQueries.length - 1 ? 4 : 0,
+                      ),
+                      child: Row(
+                        children: [
+                          Icon(
+                            Icons.history,
+                            size: 16,
+                            color: Theme.of(context).colorScheme.primary,
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              query.isEmpty ? '(empty query)' : query,
+                              style: Theme.of(context).textTheme.bodySmall,
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  }).toList(),
+                ),
+              ),
+            const SizedBox(height: 16),
+            Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: Theme.of(
+                  context,
+                ).colorScheme.primaryContainer.withValues(alpha: 0.3),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.primary.withValues(alpha: 0.3),
+                ),
+              ),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.info_outline,
+                    size: 16,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'Field clears automatically after submit (clearOnSubmit: true)',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Disabled search field state
+@widgetbook.UseCase(name: 'Disabled', type: AppSearchField)
+Widget disabledSearchField(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Disabled search field',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 8),
+        const AppSearchField(hint: 'Search disabled...', enabled: false),
+      ],
+    ),
+  );
+}
+
+/// Search field integrated with results list
+@widgetbook.UseCase(name: 'With Results', type: AppSearchField)
+Widget searchFieldWithResults(BuildContext context) {
+  return const _SearchWithResultsDemo();
+}
+
+/// Demo widget showing search integration with results
+class _SearchWithResultsDemo extends StatefulWidget {
+  const _SearchWithResultsDemo();
+
+  @override
+  State<_SearchWithResultsDemo> createState() => _SearchWithResultsDemoState();
+}
+
+class _SearchWithResultsDemoState extends State<_SearchWithResultsDemo> {
+  final List<String> _allItems = [
+    'Apple',
+    'Banana',
+    'Cherry',
+    'Date',
+    'Elderberry',
+    'Fig',
+    'Grape',
+    'Honeydew',
+    'Kiwi',
+    'Lemon',
+    'Mango',
+    'Orange',
+    'Papaya',
+    'Quince',
+    'Raspberry',
+    'Strawberry',
+    'Tangerine',
+    'Watermelon',
+  ];
+
+  List<String> _filteredItems = [];
+  bool _isLoading = false;
+  String _currentQuery = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _filteredItems = _allItems;
+  }
+
+  void _performSearch(String query) {
+    setState(() {
+      _isLoading = true;
+      _currentQuery = query;
+    });
+
+    // Simulate API delay
+    Future.delayed(const Duration(milliseconds: 500), () {
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        if (query.isEmpty) {
+          _filteredItems = _allItems;
+        } else {
+          _filteredItems = _allItems
+              .where((item) => item.toLowerCase().contains(query.toLowerCase()))
+              .toList();
+        }
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: AppSearchField(
+            hint: 'Search fruits...',
+            isLoading: _isLoading,
+            onSearchChanged: _performSearch,
+          ),
+        ),
+        Expanded(child: _buildResults()),
+      ],
+    );
+  }
+
+  Widget _buildResults() {
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_filteredItems.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.search_off,
+              size: 64,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'No results found for "$_currentQuery"',
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+          ],
+        ),
+      );
+    }
+
+    return ListView.builder(
+      itemCount: _filteredItems.length,
+      itemBuilder: (context, index) {
+        final item = _filteredItems[index];
+        return ListTile(
+          leading: const Icon(Icons.fastfood),
+          title: Text(item),
+          onTap: () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('Selected: $item'),
+                duration: const Duration(seconds: 1),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_slider_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_slider_stories.dart
@@ -1,2 +1,561 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/widgets/inputs/app_slider.dart';
+
+// 1. Basic Continuous Slider - Simple value selection (Interactive)
+@widgetbook.UseCase(name: 'Basic Continuous', type: AppSlider)
+Widget appSliderBasicContinuous(BuildContext context) {
+  return const _BasicContinuousDemo();
+}
+
+class _BasicContinuousDemo extends StatefulWidget {
+  const _BasicContinuousDemo();
+
+  @override
+  State<_BasicContinuousDemo> createState() => _BasicContinuousDemoState();
+}
+
+class _BasicContinuousDemoState extends State<_BasicContinuousDemo> {
+  double _value = 50;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Current Value: ${_value.toStringAsFixed(1)}',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 16),
+          AppSlider(
+            value: _value,
+            min: 0,
+            max: 100,
+            label: 'Volume',
+            showMinMaxIndicators: true,
+            onChanged: (value) => setState(() => _value = value),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// 2. Discrete Slider - Snap to divisions (Interactive)
+@widgetbook.UseCase(name: 'Discrete with Divisions', type: AppSlider)
+Widget appSliderDiscrete(BuildContext context) {
+  return const _DiscreteDemo();
+}
+
+class _DiscreteDemo extends StatefulWidget {
+  const _DiscreteDemo();
+
+  @override
+  State<_DiscreteDemo> createState() => _DiscreteDemoState();
+}
+
+class _DiscreteDemoState extends State<_DiscreteDemo> {
+  double _rating = 3;
+  double _quality = 5;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Rating: ${_rating.toInt()}/5',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            AppSlider(
+              value: _rating,
+              min: 0,
+              max: 5,
+              divisions: 5,
+              label: 'Rating',
+              showValueLabel: true,
+              showMinMaxIndicators: true,
+              onChanged: (value) => setState(() => _rating = value),
+            ),
+            const SizedBox(height: 32),
+            Text(
+              'Quality Level: ${_quality.toInt()}/10',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            AppSlider(
+              value: _quality,
+              min: 0,
+              max: 10,
+              divisions: 10,
+              label: 'Quality',
+              showValueLabel: true,
+              onChanged: (value) => setState(() => _quality = value),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// 3. Range Slider - Min/Max selection (Interactive)
+@widgetbook.UseCase(name: 'Range Slider', type: AppSlider)
+Widget appSliderRange(BuildContext context) {
+  return const _RangeSliderDemo();
+}
+
+class _RangeSliderDemo extends StatefulWidget {
+  const _RangeSliderDemo();
+
+  @override
+  State<_RangeSliderDemo> createState() => _RangeSliderDemoState();
+}
+
+class _RangeSliderDemoState extends State<_RangeSliderDemo> {
+  RangeValues _priceRange = const RangeValues(100, 500);
+  RangeValues _ageRange = const RangeValues(18, 65);
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Price Range: \$${_priceRange.start.toInt()} - \$${_priceRange.end.toInt()}',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            AppSlider.range(
+              values: _priceRange,
+              min: 0,
+              max: 1000,
+              divisions: 20,
+              label: 'Price Range',
+              showValueLabel: true,
+              showMinMaxIndicators: true,
+              labelFormatter: (value) => '\$${value.toInt()}',
+              onRangeChanged: (values) => setState(() => _priceRange = values),
+            ),
+            const SizedBox(height: 32),
+            Text(
+              'Age Range: ${_ageRange.start.toInt()} - ${_ageRange.end.toInt()} years',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            AppSlider.range(
+              values: _ageRange,
+              min: 0,
+              max: 100,
+              label: 'Age Range',
+              showValueLabel: true,
+              showMinMaxIndicators: true,
+              onRangeChanged: (values) => setState(() => _ageRange = values),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// 4. With Value Labels - Always visible labels (Interactive)
+@widgetbook.UseCase(name: 'With Value Labels', type: AppSlider)
+Widget appSliderValueLabels(BuildContext context) {
+  return const _ValueLabelsDemo();
+}
+
+class _ValueLabelsDemo extends StatefulWidget {
+  const _ValueLabelsDemo();
+
+  @override
+  State<_ValueLabelsDemo> createState() => _ValueLabelsDemoState();
+}
+
+class _ValueLabelsDemoState extends State<_ValueLabelsDemo> {
+  double _brightness = 75;
+  double _temperature = 22;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Drag the sliders to see value labels',
+              style: TextStyle(fontStyle: FontStyle.italic, fontSize: 12),
+            ),
+            const SizedBox(height: 24),
+            AppSlider(
+              value: _brightness,
+              min: 0,
+              max: 100,
+              label: 'Brightness',
+              showValueLabel: true,
+              showMinMaxIndicators: true,
+              labelFormatter: (value) => '${value.toInt()}%',
+              onChanged: (value) => setState(() => _brightness = value),
+            ),
+            const SizedBox(height: 32),
+            AppSlider(
+              value: _temperature,
+              min: 10,
+              max: 35,
+              label: 'Temperature',
+              showValueLabel: true,
+              divisions: 25,
+              showMinMaxIndicators: true,
+              labelFormatter: (value) => '${value.toInt()}°C',
+              onChanged: (value) => setState(() => _temperature = value),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// 5. Custom Formatter - Currency, percentage, custom formats (Interactive)
+@widgetbook.UseCase(name: 'Custom Formatter', type: AppSlider)
+Widget appSliderCustomFormatter(BuildContext context) {
+  return const _CustomFormatterDemo();
+}
+
+class _CustomFormatterDemo extends StatefulWidget {
+  const _CustomFormatterDemo();
+
+  @override
+  State<_CustomFormatterDemo> createState() => _CustomFormatterDemoState();
+}
+
+class _CustomFormatterDemoState extends State<_CustomFormatterDemo> {
+  double _price = 499.99;
+  double _discount = 25;
+  double _distance = 5.5;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Currency: \$${_price.toStringAsFixed(2)}',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            AppSlider(
+              value: _price,
+              min: 0,
+              max: 1000,
+              label: 'Price',
+              showValueLabel: true,
+              showMinMaxIndicators: true,
+              labelFormatter: (value) => '\$${value.toStringAsFixed(2)}',
+              onChanged: (value) => setState(() => _price = value),
+            ),
+            const SizedBox(height: 32),
+            Text(
+              'Percentage: ${_discount.toInt()}%',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            AppSlider(
+              value: _discount,
+              min: 0,
+              max: 100,
+              divisions: 20,
+              label: 'Discount',
+              showValueLabel: true,
+              showMinMaxIndicators: true,
+              labelFormatter: (value) => '${value.toInt()}%',
+              onChanged: (value) => setState(() => _discount = value),
+            ),
+            const SizedBox(height: 32),
+            Text(
+              'Distance: ${_distance.toStringAsFixed(1)} km',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            AppSlider(
+              value: _distance,
+              min: 0,
+              max: 50,
+              label: 'Search Radius',
+              showValueLabel: true,
+              showMinMaxIndicators: true,
+              labelFormatter: (value) => '${value.toStringAsFixed(1)} km',
+              onChanged: (value) => setState(() => _distance = value),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// 6. Disabled State - Non-interactive demonstration
+@widgetbook.UseCase(name: 'Disabled State', type: AppSlider)
+Widget appSliderDisabled(BuildContext context) {
+  return SingleChildScrollView(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: const [
+          Text('Enabled Slider', style: TextStyle(fontWeight: FontWeight.bold)),
+          SizedBox(height: 8),
+          AppSlider(
+            value: 75,
+            min: 0,
+            max: 100,
+            label: 'Enabled (interactive)',
+            showMinMaxIndicators: true,
+            onChanged: null, // Will be enabled in stateful version if needed
+          ),
+          SizedBox(height: 24),
+          Text(
+            'Disabled Slider (onChanged = null)',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          SizedBox(height: 8),
+          AppSlider(
+            value: 50,
+            min: 0,
+            max: 100,
+            label: 'Disabled (non-interactive)',
+            showMinMaxIndicators: true,
+            onChanged: null,
+          ),
+          SizedBox(height: 24),
+          Text(
+            'Disabled via enabled property',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          SizedBox(height: 8),
+          AppSlider(
+            value: 30,
+            min: 0,
+            max: 100,
+            label: 'System managed (disabled)',
+            enabled: false,
+            showMinMaxIndicators: true,
+            onChanged: _dummyCallback,
+          ),
+          SizedBox(height: 24),
+          Text(
+            'Disabled Range Slider',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          SizedBox(height: 8),
+          AppSlider.range(
+            values: RangeValues(20, 80),
+            min: 0,
+            max: 100,
+            label: 'Disabled range',
+            showMinMaxIndicators: true,
+            onRangeChanged: null,
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+void _dummyCallback(double value) {
+  // This won't be called when enabled = false
+}
+
+// 7. With Min/Max Indicators - Show bounds labels (Interactive)
+@widgetbook.UseCase(name: 'With Min/Max Indicators', type: AppSlider)
+Widget appSliderMinMaxIndicators(BuildContext context) {
+  return const _MinMaxIndicatorsDemo();
+}
+
+class _MinMaxIndicatorsDemo extends StatefulWidget {
+  const _MinMaxIndicatorsDemo();
+
+  @override
+  State<_MinMaxIndicatorsDemo> createState() => _MinMaxIndicatorsDemoState();
+}
+
+class _MinMaxIndicatorsDemoState extends State<_MinMaxIndicatorsDemo> {
+  double _temperature1 = 20;
+  double _temperature2 = 20;
+  double _speed = 60;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Without Indicators',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            AppSlider(
+              value: _temperature1,
+              min: -10,
+              max: 40,
+              label: 'Temperature',
+              onChanged: (value) => setState(() => _temperature1 = value),
+            ),
+            const SizedBox(height: 24),
+            const Text(
+              'With Indicators',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            AppSlider(
+              value: _temperature2,
+              min: -10,
+              max: 40,
+              label: 'Temperature',
+              showMinMaxIndicators: true,
+              labelFormatter: (value) => '${value.toInt()}°C',
+              onChanged: (value) => setState(() => _temperature2 = value),
+            ),
+            const SizedBox(height: 32),
+            const Text(
+              'With Custom Formatted Indicators',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            AppSlider(
+              value: _speed,
+              min: 0,
+              max: 120,
+              divisions: 24,
+              label: 'Speed',
+              showMinMaxIndicators: true,
+              showValueLabel: true,
+              labelFormatter: (value) => '${value.toInt()} km/h',
+              onChanged: (value) => setState(() => _speed = value),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// 8. Real-World Examples - Common use cases (Interactive)
+@widgetbook.UseCase(name: 'Real-World Examples', type: AppSlider)
+Widget appSliderRealWorld(BuildContext context) {
+  return const _RealWorldDemo();
+}
+
+class _RealWorldDemo extends StatefulWidget {
+  const _RealWorldDemo();
+
+  @override
+  State<_RealWorldDemo> createState() => _RealWorldDemoState();
+}
+
+class _RealWorldDemoState extends State<_RealWorldDemo> {
+  double _volume = 50;
+  double _brightness = 75;
+  RangeValues _priceFilter = const RangeValues(0, 500);
+  double _fontScale = 1.0;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Common Use Cases',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 24),
+            // Volume Control
+            const Icon(Icons.volume_up, size: 32),
+            const SizedBox(height: 8),
+            AppSlider(
+              value: _volume,
+              min: 0,
+              max: 100,
+              label: 'Volume',
+              showValueLabel: true,
+              labelFormatter: (value) => '${value.toInt()}%',
+              onChanged: (value) => setState(() => _volume = value),
+            ),
+            const SizedBox(height: 32),
+            // Brightness Control
+            const Icon(Icons.brightness_6, size: 32),
+            const SizedBox(height: 8),
+            AppSlider(
+              value: _brightness,
+              min: 0,
+              max: 100,
+              label: 'Screen Brightness',
+              showValueLabel: true,
+              labelFormatter: (value) => '${value.toInt()}%',
+              onChanged: (value) => setState(() => _brightness = value),
+            ),
+            const SizedBox(height: 32),
+            // Price Range Filter
+            const Icon(Icons.filter_list, size: 32),
+            const SizedBox(height: 8),
+            Text(
+              'Price: \$${_priceFilter.start.toInt()} - \$${_priceFilter.end.toInt()}',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            AppSlider.range(
+              values: _priceFilter,
+              min: 0,
+              max: 1000,
+              divisions: 20,
+              label: 'Price Filter',
+              showValueLabel: true,
+              showMinMaxIndicators: true,
+              labelFormatter: (value) => '\$${value.toInt()}',
+              onRangeChanged: (values) => setState(() => _priceFilter = values),
+            ),
+            const SizedBox(height: 32),
+            // Font Size
+            const Icon(Icons.text_fields, size: 32),
+            const SizedBox(height: 8),
+            AppSlider(
+              value: _fontScale,
+              min: 0.5,
+              max: 2.0,
+              divisions: 15,
+              label: 'Font Scale',
+              showValueLabel: true,
+              labelFormatter: (value) => '${value.toStringAsFixed(1)}x',
+              showMinMaxIndicators: true,
+              onChanged: (value) => setState(() => _fontScale = value),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Preview text at ${_fontScale.toStringAsFixed(1)}x scale',
+              style: Theme.of(
+                context,
+              ).textTheme.bodyLarge?.copyWith(fontSize: 16 * _fontScale),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_switch_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_switch_stories.dart
@@ -1,2 +1,529 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/widgets/inputs/app_switch.dart';
+
+// 1. Default Switch - Basic toggle (Interactive)
+@widgetbook.UseCase(name: 'Default', type: AppSwitch)
+Widget appSwitchDefault(BuildContext context) {
+  return const _DefaultSwitchDemo();
+}
+
+class _DefaultSwitchDemo extends StatefulWidget {
+  const _DefaultSwitchDemo();
+
+  @override
+  State<_DefaultSwitchDemo> createState() => _DefaultSwitchDemoState();
+}
+
+class _DefaultSwitchDemoState extends State<_DefaultSwitchDemo> {
+  bool _value = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: AppSwitch(
+        value: _value,
+        label: 'Toggle switch',
+        onChanged: (value) => setState(() => _value = value),
+      ),
+    );
+  }
+}
+
+// 2. States - All switch states (Static - for comparison)
+@widgetbook.UseCase(name: 'All States', type: AppSwitch)
+Widget appSwitchStates(BuildContext context) {
+  return SingleChildScrollView(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: const [
+          Text('On (Active)', style: TextStyle(fontWeight: FontWeight.bold)),
+          AppSwitch(value: true, label: 'Switch is on', onChanged: null),
+          SizedBox(height: 16),
+          Text('Off (Inactive)', style: TextStyle(fontWeight: FontWeight.bold)),
+          AppSwitch(value: false, label: 'Switch is off', onChanged: null),
+          SizedBox(height: 16),
+          Text('Disabled On', style: TextStyle(fontWeight: FontWeight.bold)),
+          AppSwitch(value: true, label: 'Disabled (on state)', onChanged: null),
+          SizedBox(height: 16),
+          Text('Disabled Off', style: TextStyle(fontWeight: FontWeight.bold)),
+          AppSwitch(
+            value: false,
+            label: 'Disabled (off state)',
+            onChanged: null,
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+// 3. With Labels - Label variations (Interactive)
+@widgetbook.UseCase(name: 'With Labels', type: AppSwitch)
+Widget appSwitchLabels(BuildContext context) {
+  return const _LabelsDemo();
+}
+
+class _LabelsDemo extends StatefulWidget {
+  const _LabelsDemo();
+
+  @override
+  State<_LabelsDemo> createState() => _LabelsDemoState();
+}
+
+class _LabelsDemoState extends State<_LabelsDemo> {
+  bool _noLabel = true;
+  bool _shortLabel = true;
+  bool _longLabel = false;
+  bool _darkMode = true;
+  bool _notifications = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'No Label (Switch Only)',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            AppSwitch(
+              value: _noLabel,
+              onChanged: (value) => setState(() => _noLabel = value),
+            ),
+            const SizedBox(height: 24),
+            const Text(
+              'Short Label',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            AppSwitch(
+              value: _shortLabel,
+              label: 'Wi-Fi',
+              onChanged: (value) => setState(() => _shortLabel = value),
+            ),
+            const SizedBox(height: 24),
+            const Text(
+              'Long Label',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            AppSwitch(
+              value: _longLabel,
+              label: 'Automatically connect to available wireless networks',
+              onChanged: (value) => setState(() => _longLabel = value),
+            ),
+            const SizedBox(height: 24),
+            const Text(
+              'With Subtitle (Additional Context)',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            AppSwitch(
+              value: _darkMode,
+              label: 'Dark mode',
+              subtitle: 'Use dark theme across the app for better visibility',
+              onChanged: (value) => setState(() => _darkMode = value),
+            ),
+            const SizedBox(height: 16),
+            AppSwitch(
+              value: _notifications,
+              label: 'Push notifications',
+              subtitle: 'Receive notifications about important updates',
+              onChanged: (value) => setState(() => _notifications = value),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// 4. With Icons - Icon integration (Interactive)
+@widgetbook.UseCase(name: 'With Icons', type: AppSwitch)
+Widget appSwitchIcons(BuildContext context) {
+  return const _IconsDemo();
+}
+
+class _IconsDemo extends StatefulWidget {
+  const _IconsDemo();
+
+  @override
+  State<_IconsDemo> createState() => _IconsDemoState();
+}
+
+class _IconsDemoState extends State<_IconsDemo> {
+  bool _wifi = true;
+  bool _bluetooth = true;
+  bool _airplane = false;
+  bool _notifications = true;
+  bool _location = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Leading Icon + Switch',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+            AppSwitch(
+              value: _wifi,
+              icon: Icons.wifi,
+              label: 'Wi-Fi',
+              subtitle: 'Connect to wireless networks',
+              onChanged: (value) => setState(() => _wifi = value),
+            ),
+            const SizedBox(height: 16),
+            AppSwitch(
+              value: _bluetooth,
+              icon: Icons.bluetooth,
+              label: 'Bluetooth',
+              subtitle: 'Connect to nearby devices',
+              onChanged: (value) => setState(() => _bluetooth = value),
+            ),
+            const SizedBox(height: 16),
+            AppSwitch(
+              value: _airplane,
+              icon: Icons.airplanemode_active,
+              label: 'Airplane mode',
+              subtitle: 'Disable all wireless connections',
+              onChanged: (value) => setState(() => _airplane = value),
+            ),
+            const SizedBox(height: 16),
+            AppSwitch(
+              value: _notifications,
+              icon: Icons.notifications,
+              label: 'Notifications',
+              subtitle: 'Show notifications on lock screen',
+              onChanged: (value) => setState(() => _notifications = value),
+            ),
+            const SizedBox(height: 16),
+            AppSwitch(
+              value: _location,
+              icon: Icons.location_on,
+              label: 'Location services',
+              subtitle: 'Allow apps to use your location',
+              onChanged: (value) => setState(() => _location = value),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// 5. Settings List - Realistic settings UI (Interactive - Critical!)
+@widgetbook.UseCase(name: 'Settings List', type: AppSwitch)
+Widget appSwitchSettingsList(BuildContext context) {
+  return const _SettingsListDemo();
+}
+
+class _SettingsListDemo extends StatefulWidget {
+  const _SettingsListDemo();
+
+  @override
+  State<_SettingsListDemo> createState() => _SettingsListDemoState();
+}
+
+class _SettingsListDemoState extends State<_SettingsListDemo> {
+  // Network & Connectivity
+  bool _wifi = true;
+  bool _bluetooth = true;
+  bool _airplane = false;
+
+  // Notifications
+  bool _pushNotifications = true;
+  bool _vibrate = false;
+
+  // Privacy
+  bool _location = true;
+  bool _camera = false;
+  bool _microphone = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: ListView(
+        children: [
+          // Network & Connectivity Section
+          const Padding(
+            padding: EdgeInsets.all(16.0),
+            child: Text(
+              'Network & Connectivity',
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.bold,
+                color: Colors.grey,
+              ),
+            ),
+          ),
+          AppSwitch(
+            value: _wifi,
+            icon: Icons.wifi,
+            label: 'Wi-Fi',
+            subtitle: 'Connected to My Network',
+            onChanged: (value) => setState(() => _wifi = value),
+          ),
+          const Divider(height: 1),
+          AppSwitch(
+            value: _bluetooth,
+            icon: Icons.bluetooth,
+            label: 'Bluetooth',
+            onChanged: (value) => setState(() => _bluetooth = value),
+          ),
+          const Divider(height: 1),
+          AppSwitch(
+            value: _airplane,
+            icon: Icons.airplanemode_active,
+            label: 'Airplane mode',
+            onChanged: (value) => setState(() => _airplane = value),
+          ),
+          const SizedBox(height: 24),
+
+          // Notifications Section
+          const Padding(
+            padding: EdgeInsets.all(16.0),
+            child: Text(
+              'Notifications',
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.bold,
+                color: Colors.grey,
+              ),
+            ),
+          ),
+          AppSwitch(
+            value: _pushNotifications,
+            icon: Icons.notifications,
+            label: 'Push notifications',
+            subtitle: 'Show notifications on lock screen',
+            onChanged: (value) => setState(() => _pushNotifications = value),
+          ),
+          const Divider(height: 1),
+          AppSwitch(
+            value: _vibrate,
+            icon: Icons.vibration,
+            label: 'Vibrate',
+            onChanged: (value) => setState(() => _vibrate = value),
+          ),
+          const Divider(height: 1),
+          // Do not disturb - Disabled
+          const AppSwitch(
+            value: false,
+            icon: Icons.volume_off,
+            label: 'Do not disturb',
+            subtitle: 'Disabled by administrator',
+            onChanged: null,
+          ),
+          const SizedBox(height: 24),
+
+          // Privacy Section
+          const Padding(
+            padding: EdgeInsets.all(16.0),
+            child: Text(
+              'Privacy',
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.bold,
+                color: Colors.grey,
+              ),
+            ),
+          ),
+          AppSwitch(
+            value: _location,
+            icon: Icons.location_on,
+            label: 'Location services',
+            subtitle: 'Allow apps to use your location',
+            onChanged: (value) => setState(() => _location = value),
+          ),
+          const Divider(height: 1),
+          AppSwitch(
+            value: _camera,
+            icon: Icons.camera_alt,
+            label: 'Camera access',
+            onChanged: (value) => setState(() => _camera = value),
+          ),
+          const Divider(height: 1),
+          AppSwitch(
+            value: _microphone,
+            icon: Icons.mic,
+            label: 'Microphone access',
+            onChanged: (value) => setState(() => _microphone = value),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// 6. Theme Variations - Light, dark, and custom colors (Interactive)
+@widgetbook.UseCase(name: 'Theme Variations', type: AppSwitch)
+Widget appSwitchThemeVariations(BuildContext context) {
+  return const _ThemeVariationsDemo();
+}
+
+class _ThemeVariationsDemo extends StatefulWidget {
+  const _ThemeVariationsDemo();
+
+  @override
+  State<_ThemeVariationsDemo> createState() => _ThemeVariationsDemoState();
+}
+
+class _ThemeVariationsDemoState extends State<_ThemeVariationsDemo> {
+  bool _defaultOn = true;
+  bool _defaultOff = false;
+  bool _greenSwitch = true;
+  bool _orangeSwitch = true;
+  bool _blueSwitch = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Toggle theme in Widgetbook to see variations',
+              style: TextStyle(fontStyle: FontStyle.italic, fontSize: 12),
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'Default Colors',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            AppSwitch(
+              value: _defaultOn,
+              label: 'On (uses primary color)',
+              onChanged: (value) => setState(() => _defaultOn = value),
+            ),
+            const SizedBox(height: 8),
+            AppSwitch(
+              value: _defaultOff,
+              label: 'Off (uses surface color)',
+              onChanged: (value) => setState(() => _defaultOff = value),
+            ),
+            const SizedBox(height: 24),
+            const Text(
+              'Custom Brand Colors',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            AppSwitch(
+              value: _greenSwitch,
+              label: 'Green switch',
+              activeColor: Colors.white,
+              activeTrackColor: Colors.green,
+              onChanged: (value) => setState(() => _greenSwitch = value),
+            ),
+            const SizedBox(height: 8),
+            AppSwitch(
+              value: _orangeSwitch,
+              label: 'Orange switch',
+              activeColor: Colors.white,
+              activeTrackColor: Colors.deepOrange,
+              onChanged: (value) => setState(() => _orangeSwitch = value),
+            ),
+            const SizedBox(height: 8),
+            AppSwitch(
+              value: _blueSwitch,
+              label: 'Blue switch',
+              activeColor: Colors.white,
+              activeTrackColor: Colors.blue,
+              onChanged: (value) => setState(() => _blueSwitch = value),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// 7. Real-World Examples (Interactive)
+@widgetbook.UseCase(name: 'Real-World Examples', type: AppSwitch)
+Widget appSwitchExamples(BuildContext context) {
+  return const _RealWorldDemo();
+}
+
+class _RealWorldDemo extends StatefulWidget {
+  const _RealWorldDemo();
+
+  @override
+  State<_RealWorldDemo> createState() => _RealWorldDemoState();
+}
+
+class _RealWorldDemoState extends State<_RealWorldDemo> {
+  bool _darkMode = true;
+  bool _autoSave = false;
+  bool _cloudBackup = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Common Use Cases',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
+            AppSwitch(
+              value: _darkMode,
+              icon: Icons.dark_mode,
+              label: 'Dark mode',
+              subtitle: 'Reduces eye strain in low light',
+              onChanged: (value) => setState(() => _darkMode = value),
+            ),
+            const SizedBox(height: 16),
+            AppSwitch(
+              value: _autoSave,
+              icon: Icons.save_alt,
+              label: 'Auto-save',
+              subtitle: 'Automatically save changes',
+              onChanged: (value) => setState(() => _autoSave = value),
+            ),
+            const SizedBox(height: 16),
+            AppSwitch(
+              value: _cloudBackup,
+              icon: Icons.backup,
+              label: 'Cloud backup',
+              subtitle: 'Back up to cloud storage',
+              onChanged: (value) => setState(() => _cloudBackup = value),
+            ),
+            const SizedBox(height: 16),
+            // Analytics - Disabled (managed by organization)
+            const AppSwitch(
+              value: false,
+              icon: Icons.analytics,
+              label: 'Analytics',
+              subtitle: 'Managed by organization policy',
+              onChanged: null,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_text_field_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/inputs/app_text_field_stories.dart
@@ -1,2 +1,374 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:core_kit/core_kit.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+/// Widgetbook stories for [AppTextField] component.
+///
+/// Demonstrates various configurations and use cases for the Material Design 3
+/// text field component, including basic fields, validation states, specialized
+/// input types, and interactive features.
+
+@widgetbook.UseCase(name: 'Basic', type: AppTextField)
+Widget buildAppTextFieldBasicUseCase(BuildContext context) {
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          AppTextField(
+            label: 'Full Name',
+            hint: 'Enter your full name',
+            helperText: 'Your first and last name',
+            onChanged: (value) => debugPrint('Name: $value'),
+          ),
+          const SizedBox(height: 24),
+          AppTextField(
+            label: 'Bio',
+            hint: 'Tell us about yourself',
+            helperText: 'Optional',
+            textCapitalization: TextCapitalization.sentences,
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'With Validation Error', type: AppTextField)
+Widget buildAppTextFieldErrorUseCase(BuildContext context) {
+  final emailController = TextEditingController(text: 'invalid-email');
+  final passwordController = TextEditingController(text: '123');
+
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          AppTextField(
+            controller: emailController,
+            label: 'Email',
+            hint: 'example@email.com',
+            errorText: 'Please enter a valid email address',
+            keyboardType: TextInputType.emailAddress,
+          ),
+          const SizedBox(height: 24),
+          AppTextField(
+            controller: passwordController,
+            label: 'Password',
+            hint: 'Enter password',
+            errorText: 'Password must be at least 8 characters',
+            obscureText: true,
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Multiline (Text Area)', type: AppTextField)
+Widget buildAppTextFieldMultilineUseCase(BuildContext context) {
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          AppTextField.multiline(
+            label: 'Description',
+            hint: 'Enter a detailed description...',
+            helperText: 'Maximum 500 characters',
+            maxLength: 500,
+            maxLines: 5,
+            minLines: 3,
+          ),
+          const SizedBox(height: 24),
+          AppTextField.multiline(
+            label: 'Comments',
+            hint: 'Share your thoughts',
+            maxLines: 8,
+            minLines: 4,
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'With Icons', type: AppTextField)
+Widget buildAppTextFieldWithIconsUseCase(BuildContext context) {
+  final searchController = TextEditingController();
+  final passwordController = TextEditingController();
+
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          AppTextField(
+            controller: searchController,
+            label: 'Search',
+            hint: 'Search for items...',
+            prefixIcon: Icons.search,
+            suffixIcon: Icons.clear,
+            onSuffixIconTap: () {
+              searchController.clear();
+              debugPrint('Search cleared');
+            },
+          ),
+          const SizedBox(height: 24),
+          AppTextField(
+            controller: passwordController,
+            label: 'Password',
+            hint: 'Enter your password',
+            prefixIcon: Icons.lock_outline,
+            suffixIcon: Icons.visibility_off,
+            obscureText: true,
+            onSuffixIconTap: () {
+              debugPrint('Toggle password visibility');
+            },
+          ),
+          const SizedBox(height: 24),
+          AppTextField(
+            label: 'Email',
+            hint: 'your.email@example.com',
+            prefixIcon: Icons.email_outlined,
+            keyboardType: TextInputType.emailAddress,
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'States (Disabled & Read-only)', type: AppTextField)
+Widget buildAppTextFieldStatesUseCase(BuildContext context) {
+  final disabledController = TextEditingController(text: 'Disabled content');
+  final readOnlyController = TextEditingController(
+    text: 'Read-only content that can be selected',
+  );
+
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const AppTextField(
+            label: 'Enabled Field',
+            hint: 'You can type here',
+            helperText: 'This field is enabled',
+          ),
+          const SizedBox(height: 24),
+          AppTextField(
+            controller: disabledController,
+            label: 'Disabled Field',
+            hint: 'Cannot type here',
+            helperText: 'This field is disabled',
+            enabled: false,
+          ),
+          const SizedBox(height: 24),
+          AppTextField(
+            controller: readOnlyController,
+            label: 'Read-only Field',
+            hint: 'Can select but not edit',
+            helperText: 'This field is read-only',
+            readOnly: true,
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Numeric Input with Formatter', type: AppTextField)
+Widget buildAppTextFieldNumericUseCase(BuildContext context) {
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          AppTextField.numeric(
+            label: 'Age',
+            hint: 'Enter your age',
+            maxLength: 3,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+          ),
+          const SizedBox(height: 24),
+          AppTextField.phone(
+            label: 'Phone Number',
+            hint: '(123) 456-7890',
+            prefixIcon: Icons.phone_outlined,
+            inputFormatters: [
+              FilteringTextInputFormatter.digitsOnly,
+              LengthLimitingTextInputFormatter(10),
+              _PhoneNumberFormatter(),
+            ],
+          ),
+          const SizedBox(height: 24),
+          AppTextField.numeric(
+            label: 'Quantity',
+            hint: '0',
+            prefixIcon: Icons.shopping_cart_outlined,
+            helperText: 'Enter quantity to purchase',
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Email & URL Input', type: AppTextField)
+Widget buildAppTextFieldEmailUrlUseCase(BuildContext context) {
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          AppTextField.email(
+            label: 'Email Address',
+            hint: 'your.email@example.com',
+            prefixIcon: Icons.email_outlined,
+            helperText: 'We will never share your email',
+          ),
+          const SizedBox(height: 24),
+          AppTextField.url(
+            label: 'Website',
+            hint: 'https://example.com',
+            prefixIcon: Icons.link,
+            helperText: 'Enter your website URL',
+          ),
+          const SizedBox(height: 24),
+          AppTextField.email(
+            label: 'Confirm Email',
+            hint: 'Re-enter your email',
+            prefixIcon: Icons.email_outlined,
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Search Field Variant', type: AppTextField)
+Widget buildAppTextFieldSearchUseCase(BuildContext context) {
+  final searchController = TextEditingController();
+
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          AppTextField(
+            controller: searchController,
+            hint: 'Search products...',
+            prefixIcon: Icons.search,
+            suffixIcon: Icons.clear,
+            onSuffixIconTap: () {
+              searchController.clear();
+            },
+            textInputAction: TextInputAction.search,
+            onSubmitted: (value) {
+              debugPrint('Search submitted: $value');
+            },
+          ),
+          const SizedBox(height: 24),
+          AppTextField(
+            hint: 'Search locations...',
+            prefixIcon: Icons.location_on_outlined,
+            suffixIcon: Icons.my_location,
+            textInputAction: TextInputAction.search,
+            onSuffixIconTap: () {
+              debugPrint('Use current location');
+            },
+          ),
+          const SizedBox(height: 24),
+          AppTextField(
+            hint: 'Search users...',
+            prefixIcon: Icons.person_search,
+            textInputAction: TextInputAction.search,
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Character Counter & Max Length', type: AppTextField)
+Widget buildAppTextFieldCharacterCounterUseCase(BuildContext context) {
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const AppTextField(
+            label: 'Username',
+            hint: 'Choose a username',
+            helperText: 'Must be between 3-20 characters',
+            maxLength: 20,
+          ),
+          const SizedBox(height: 24),
+          AppTextField.multiline(
+            label: 'Tweet',
+            hint: 'What\'s happening?',
+            maxLength: 280,
+            maxLines: 4,
+            minLines: 2,
+          ),
+          const SizedBox(height: 24),
+          const AppTextField(
+            label: 'Bio',
+            hint: 'Tell us about yourself',
+            maxLength: 150,
+            showCharacterCounter: true,
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+/// Custom phone number formatter
+class _PhoneNumberFormatter extends TextInputFormatter {
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    final text = newValue.text;
+
+    if (text.isEmpty) {
+      return newValue;
+    }
+
+    final buffer = StringBuffer();
+    for (int i = 0; i < text.length && i < 10; i++) {
+      if (i == 0) {
+        buffer.write('(');
+      }
+      buffer.write(text[i]);
+      if (i == 2) {
+        buffer.write(') ');
+      } else if (i == 5) {
+        buffer.write('-');
+      }
+    }
+
+    final formatted = buffer.toString();
+    return TextEditingValue(
+      text: formatted,
+      selection: TextSelection.collapsed(offset: formatted.length),
+    );
+  }
+}

--- a/widgetbook_kit/lib/stories/core_kit/widgets/surfaces/app_card_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/surfaces/app_card_stories.dart
@@ -1,2 +1,282 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/widgets/surfaces/app_card.dart';
+import 'package:core_kit/theme/app_spacing.dart';
+
+@widgetbook.UseCase(name: 'Default', type: AppCard)
+Widget appCardDefault(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(AppSpacing.md),
+    child: AppCard(
+      padding: const EdgeInsets.all(AppSpacing.md),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            'Default Card (Level 1)',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          const Text(
+            'This is the default card variant with 1dp elevation and medium radius.',
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'All Variants', type: AppCard)
+Widget appCardVariants(BuildContext context) {
+  return SingleChildScrollView(
+    padding: const EdgeInsets.all(AppSpacing.md),
+    child: Column(
+      children: [
+        _buildVariantExample(
+          context,
+          'Flat (Level 0)',
+          AppCard.flat(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: const Text('Flat Card\nNo elevation, blends with surface'),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        _buildVariantExample(
+          context,
+          'Default (Level 1)',
+          AppCard(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: const Text('Default AppCard\nStandard 1dp elevation'),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        _buildVariantExample(
+          context,
+          'Elevated (Level 2/3)',
+          AppCard.elevated(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: const Text(
+              'Elevated Card\nHigher elevation (3dp) for emphasis',
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        _buildVariantExample(
+          context,
+          'Outlined (Level 0)',
+          AppCard.outlined(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: const Text('Outlined Card\nBordered with no elevation'),
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+Widget _buildVariantExample(BuildContext context, String title, Widget card) {
+  return Column(
+    crossAxisAlignment: CrossAxisAlignment.stretch,
+    children: [
+      Text(title, style: Theme.of(context).textTheme.labelLarge),
+      const SizedBox(height: AppSpacing.xs),
+      card,
+    ],
+  );
+}
+
+@widgetbook.UseCase(name: 'Interactive', type: AppCard)
+Widget appCardInteractive(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(AppSpacing.md),
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AppCard(
+          onTap: () {},
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  const Icon(Icons.touch_app),
+                  const SizedBox(width: AppSpacing.sm),
+                  Text(
+                    'Tappable Card',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              const Text(
+                'Tap this card to see the ripple effect. The ripple is clipped to the card shape.',
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        AppCard.outlined(
+          onTap: () {},
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: const SizedBox(
+            width: double.infinity,
+            child: Text('Tappable Outlined Card', textAlign: TextAlign.center),
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Content Types', type: AppCard)
+Widget appCardContentTypes(BuildContext context) {
+  return SingleChildScrollView(
+    padding: const EdgeInsets.all(AppSpacing.md),
+    child: Column(
+      children: [
+        // List Card
+        AppCard(
+          child: Column(
+            children: [
+              ListTile(
+                leading: const Icon(Icons.image),
+                title: const Text('List Tile within Card'),
+                subtitle: const Text('Using ListTile for consistency'),
+              ),
+              const Divider(height: 1),
+              ListTile(
+                leading: const Icon(Icons.description),
+                title: const Text('Second Item'),
+                onTap: () {},
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        // Media Card
+        AppCard(
+          clipBehavior: Clip.antiAlias,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                height: 150,
+                color: Colors.grey.shade300,
+                alignment: Alignment.center,
+                child: const Icon(Icons.image, size: 48, color: Colors.grey),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(AppSpacing.md),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Media Card',
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: AppSpacing.xs),
+                    const Text(
+                      'Card with an image (placeholder) and content below.',
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Elevation Levels', type: AppCard)
+Widget appCardElevations(BuildContext context) {
+  return SingleChildScrollView(
+    padding: const EdgeInsets.all(AppSpacing.md),
+    child: Column(
+      children: [
+        for (final elevation in [0.0, 1.0, 3.0, 6.0, 8.0, 12.0])
+          Padding(
+            padding: const EdgeInsets.only(bottom: AppSpacing.md),
+            child: AppCard(
+              elevation: elevation,
+              padding: const EdgeInsets.all(AppSpacing.md),
+              child: SizedBox(
+                width: double.infinity,
+                child: Text('Elevation ${elevation.toInt()}'),
+              ),
+            ),
+          ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Custom Styling', type: AppCard)
+Widget appCardCustom(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(AppSpacing.md),
+    child: AppCard(
+      color: Theme.of(context).colorScheme.primaryContainer,
+      borderRadius: const BorderRadius.only(
+        topLeft: Radius.circular(20),
+        bottomRight: Radius.circular(20),
+      ),
+      padding: const EdgeInsets.all(24),
+      elevation: 5,
+      shadowColor: Colors.red.withValues(alpha: 0.5),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: const [
+          Text('Custom Styled Card'),
+          SizedBox(height: 8),
+          Text('Custom color, radius, padding, and shadow.'),
+        ],
+      ),
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Interactive Playground', type: AppCard)
+Widget appCardPlayground(BuildContext context) {
+  final elevation = context.knobs.double.slider(
+    label: 'Elevation',
+    initialValue: 1,
+    min: 0,
+    max: 12,
+  );
+
+  final onTapEnabled = context.knobs.boolean(
+    label: 'Enable onTap',
+    initialValue: true,
+  );
+
+  final isOutlined = context.knobs.boolean(
+    label: 'Is Outlined',
+    initialValue: false,
+  );
+
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(AppSpacing.md),
+      child: isOutlined
+          ? AppCard.outlined(
+              onTap: onTapEnabled ? () {} : null,
+              padding: const EdgeInsets.all(AppSpacing.md),
+              child: const Text('Playground Card (Outlined)'),
+            )
+          : AppCard(
+              elevation: elevation,
+              onTap: onTapEnabled ? () {} : null,
+              padding: const EdgeInsets.all(AppSpacing.md),
+              child: Text('Playground Card (Elev: $elevation)'),
+            ),
+    ),
+  );
+}

--- a/widgetbook_kit/lib/stories/core_kit/widgets/surfaces/app_list_tile_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/surfaces/app_list_tile_stories.dart
@@ -1,2 +1,655 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:core_kit/core_kit.dart';
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+// ============================================================================
+// Story 1: Default List Tile - Basic one-line
+// ============================================================================
+
+/// Default list tile with leading icon and trailing chevron.
+@widgetbook.UseCase(name: 'Default', type: AppListTile)
+Widget appListTileDefault(BuildContext context) {
+  return Scaffold(
+    body: ListView(
+      children: [
+        AppListTile(
+          leading: const Icon(Icons.star),
+          title: context.knobs.string(
+            label: 'Title',
+            initialValue: 'List item',
+          ),
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+// ============================================================================
+// Story 2: Line Variations - One, two, three lines
+// ============================================================================
+
+/// One-line list tile with title only.
+@widgetbook.UseCase(name: 'One Line', type: AppListTile)
+Widget appListTileOneLine(BuildContext context) {
+  return Scaffold(
+    body: ListView(
+      children: [
+        AppListTile(
+          leading: const Icon(Icons.inbox),
+          title: 'Inbox',
+          trailing: const Text('24'),
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const Icon(Icons.send),
+          title: 'Sent',
+          trailing: const Text('8'),
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const Icon(Icons.drafts),
+          title: 'Drafts',
+          trailing: const Text('3'),
+          onTap: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+/// Two-line list tile with title and subtitle.
+@widgetbook.UseCase(name: 'Two Line', type: AppListTile)
+Widget appListTileTwoLine(BuildContext context) {
+  return Scaffold(
+    body: ListView(
+      children: [
+        AppListTile(
+          leading: const CircleAvatar(child: Icon(Icons.folder)),
+          title: 'Documents',
+          subtitle: '24 files',
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const CircleAvatar(child: Icon(Icons.photo)),
+          title: 'Photos',
+          subtitle: '156 items',
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const CircleAvatar(child: Icon(Icons.music_note)),
+          title: 'Music',
+          subtitle: '42 songs',
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+/// Three-line list tile with extended subtitle.
+@widgetbook.UseCase(name: 'Three Line', type: AppListTile)
+Widget appListTileThreeLine(BuildContext context) {
+  return Scaffold(
+    body: ListView(
+      children: [
+        AppListTile(
+          leading: const CircleAvatar(
+            backgroundImage: NetworkImage('https://i.pravatar.cc/150?img=1'),
+          ),
+          title: 'John Doe',
+          subtitle: 'Hey! How are you doing today?\nSent 2 hours ago',
+          isThreeLine: true,
+          trailing: const Text('12:30'),
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const CircleAvatar(
+            backgroundImage: NetworkImage('https://i.pravatar.cc/150?img=2'),
+          ),
+          title: 'Jane Smith',
+          subtitle: 'Can we schedule a meeting for tomorrow?\nSent 5 hours ago',
+          isThreeLine: true,
+          trailing: const Text('09:15'),
+          onTap: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+// ============================================================================
+// Story 3: With Leading Widgets
+// ============================================================================
+
+/// List tiles with various leading widgets.
+@widgetbook.UseCase(name: 'Leading Widgets', type: AppListTile)
+Widget appListTileLeading(BuildContext context) {
+  return Scaffold(
+    body: ListView(
+      children: [
+        // Icon (24dp)
+        AppListTile(
+          leading: const Icon(Icons.settings, size: 24),
+          title: 'Settings',
+          subtitle: 'App preferences',
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        // Avatar (40dp)
+        AppListTile(
+          leading: const CircleAvatar(radius: 20, child: Icon(Icons.person)),
+          title: 'John Doe',
+          subtitle: 'Software Engineer',
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        // Checkbox
+        AppListTile(
+          leading: Checkbox(
+            value: context.knobs.boolean(
+              label: 'Checkbox checked',
+              initialValue: false,
+            ),
+            onChanged: (_) {},
+          ),
+          title: 'Select item',
+          subtitle: 'Optional description',
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        // Image thumbnail
+        AppListTile(
+          leading: Container(
+            width: 56,
+            height: 56,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(8),
+              image: const DecorationImage(
+                image: NetworkImage('https://picsum.photos/100'),
+                fit: BoxFit.cover,
+              ),
+            ),
+          ),
+          title: 'Photo Album',
+          subtitle: 'Summer vacation 2024',
+          onTap: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+// ============================================================================
+// Story 4: With Trailing Widgets
+// ============================================================================
+
+/// List tiles with various trailing widgets.
+@widgetbook.UseCase(name: 'Trailing Widgets', type: AppListTile)
+Widget appListTileTrailing(BuildContext context) {
+  return Scaffold(
+    body: ListView(
+      children: [
+        // Chevron icon (navigation)
+        AppListTile(
+          leading: const Icon(Icons.account_circle),
+          title: 'Profile',
+          subtitle: 'View your profile',
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        // Info icon
+        AppListTile(
+          leading: const Icon(Icons.info_outline),
+          title: 'About',
+          trailing: const Icon(Icons.info),
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        // Switch toggle
+        AppListTile(
+          leading: const Icon(Icons.notifications),
+          title: 'Notifications',
+          subtitle: 'Enable push notifications',
+          trailing: Switch(
+            value: context.knobs.boolean(
+              label: 'Notifications enabled',
+              initialValue: true,
+            ),
+            onChanged: (_) {},
+          ),
+        ),
+        const Divider(height: 1),
+        // Text (timestamp)
+        AppListTile(
+          leading: const CircleAvatar(child: Icon(Icons.message)),
+          title: 'New Message',
+          subtitle: 'Hey, how are you?',
+          trailing: const Text('2:30 PM', style: TextStyle(fontSize: 12)),
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        // Icon button
+        AppListTile(
+          leading: const Icon(Icons.favorite),
+          title: 'Favorites',
+          subtitle: '5 items',
+          trailing: IconButton(
+            icon: const Icon(Icons.more_vert),
+            onPressed: () {},
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+// ============================================================================
+// Story 5: States - Default, Selected, Disabled, Hover, Pressed
+// ============================================================================
+
+/// List tiles in various interaction states.
+@widgetbook.UseCase(name: 'States', type: AppListTile)
+Widget appListTileStates(BuildContext context) {
+  final selectedState = context.knobs.boolean(
+    label: 'Selected',
+    initialValue: false,
+  );
+  final enabledState = context.knobs.boolean(
+    label: 'Enabled',
+    initialValue: true,
+  );
+
+  return Scaffold(
+    body: ListView(
+      children: [
+        // Default state
+        AppListTile(
+          leading: const Icon(Icons.home),
+          title: 'Home',
+          subtitle: 'Default state',
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        // Selected state
+        AppListTile(
+          leading: const Icon(Icons.star),
+          title: 'Favorites',
+          subtitle: 'Selected state',
+          trailing: const Icon(Icons.chevron_right),
+          selected: selectedState,
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        // Disabled state
+        AppListTile(
+          leading: const Icon(Icons.block),
+          title: 'Disabled',
+          subtitle: 'Cannot interact',
+          trailing: const Icon(Icons.chevron_right),
+          enabled: enabledState,
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        // Pressed state (has ripple on tap)
+        AppListTile(
+          leading: const Icon(Icons.touch_app),
+          title: 'Press Me',
+          subtitle: 'Tap to see ripple effect',
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+// ============================================================================
+// Story 6: Dense Mode - Compact layout
+// ============================================================================
+
+/// Dense mode list tiles with reduced height.
+@widgetbook.UseCase(name: 'Dense Mode', type: AppListTile)
+Widget appListTileDense(BuildContext context) {
+  final denseMode = context.knobs.boolean(
+    label: 'Dense Mode',
+    initialValue: true,
+  );
+
+  return Scaffold(
+    appBar: AppBar(
+      title: Text(denseMode ? 'Dense Mode (48dp)' : 'Regular Mode (56dp)'),
+    ),
+    body: ListView(
+      children: [
+        AppListTile(
+          leading: const Icon(Icons.inbox, size: 20),
+          title: 'Inbox',
+          trailing: const Text('24'),
+          dense: denseMode,
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const Icon(Icons.send, size: 20),
+          title: 'Sent',
+          trailing: const Text('8'),
+          dense: denseMode,
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const Icon(Icons.drafts, size: 20),
+          title: 'Drafts',
+          trailing: const Text('3'),
+          dense: denseMode,
+          onTap: () {},
+        ),
+        const SizedBox(height: 16),
+        const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            'Dense two-line (64dp vs 72dp)',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+        ),
+        AppListTile(
+          leading: const Icon(Icons.folder, size: 20),
+          title: 'Documents',
+          subtitle: '24 files',
+          trailing: const Icon(Icons.chevron_right),
+          dense: denseMode,
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const Icon(Icons.photo, size: 20),
+          title: 'Photos',
+          subtitle: '156 items',
+          trailing: const Icon(Icons.chevron_right),
+          dense: denseMode,
+          onTap: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+// ============================================================================
+// Story 7: Common Patterns - Real-world examples
+// ============================================================================
+
+/// Common list tile patterns used in real apps.
+@widgetbook.UseCase(name: 'Common Patterns', type: AppListTile)
+Widget appListTilePatterns(BuildContext context) {
+  return Scaffold(
+    appBar: AppBar(title: const Text('Settings')),
+    body: ListView(
+      children: [
+        const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            'Settings List',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+        ),
+        AppListTile(
+          leading: const Icon(Icons.wifi),
+          title: 'Wi-Fi',
+          subtitle: 'MyNetwork',
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () {},
+        ),
+        AppListTile(
+          leading: const Icon(Icons.bluetooth),
+          title: 'Bluetooth',
+          subtitle: 'Off',
+          trailing: Switch(value: false, onChanged: (_) {}),
+        ),
+        const Divider(),
+        const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            'Contact List',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+        ),
+        AppListTile(
+          leading: const CircleAvatar(
+            backgroundImage: NetworkImage('https://i.pravatar.cc/150?img=3'),
+          ),
+          title: 'Alice Johnson',
+          subtitle: 'Hey, are you free tomorrow?',
+          trailing: const Text('2 min ago'),
+          onTap: () {},
+        ),
+        AppListTile(
+          leading: const CircleAvatar(
+            backgroundImage: NetworkImage('https://i.pravatar.cc/150?img=4'),
+          ),
+          title: 'Bob Williams',
+          subtitle: 'Thanks for the help!',
+          trailing: const Text('1 hour ago'),
+          onTap: () {},
+        ),
+        const Divider(),
+        const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            'Navigation Menu',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+        ),
+        AppListTile(
+          leading: const Icon(Icons.home),
+          title: 'Home',
+          onTap: () {},
+        ),
+        AppListTile(
+          leading: const Icon(Icons.person),
+          title: 'Profile',
+          onTap: () {},
+        ),
+        AppListTile(
+          leading: const Icon(Icons.settings),
+          title: 'Settings',
+          onTap: () {},
+        ),
+        const Divider(),
+        const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            'Selectable List',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+        ),
+        AppListTile(
+          leading: Checkbox(value: true, onChanged: (_) {}),
+          title: 'Item 1',
+          subtitle: 'First selected item',
+          onTap: () {},
+        ),
+        AppListTile(
+          leading: Checkbox(value: false, onChanged: (_) {}),
+          title: 'Item 2',
+          subtitle: 'Second unselected item',
+          onTap: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+// ============================================================================
+// Story 8: Theme Variations - Light/Dark modes
+// ============================================================================
+
+/// List tiles in different theme modes.
+@widgetbook.UseCase(name: 'Theme Variations', type: AppListTile)
+Widget appListTileThemes(BuildContext context) {
+  return Scaffold(
+    body: ListView(
+      children: [
+        const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            'Theme automatically adapts to light/dark mode.\nUse the theme switcher in Widgetbook toolbar.',
+            textAlign: TextAlign.center,
+          ),
+        ),
+        const Divider(),
+        AppListTile(
+          leading: const Icon(Icons.brightness_6),
+          title: 'Theme Mode',
+          subtitle: 'Automatically adapts to light/dark',
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const Icon(Icons.star),
+          title: 'Selected Item',
+          subtitle: 'Shows secondaryContainer background',
+          selected: true,
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const Icon(Icons.palette),
+          title: 'Custom Tile Color',
+          subtitle: 'Using primaryContainer',
+          tileColor: Theme.of(context).colorScheme.primaryContainer,
+          onTap: () {},
+        ),
+        const Divider(height: 1),
+        AppListTile(
+          leading: const Icon(Icons.color_lens),
+          title: 'Custom Selected Color',
+          subtitle: 'Using tertiaryContainer',
+          selected: true,
+          selectedTileColor: Theme.of(context).colorScheme.tertiaryContainer,
+          onTap: () {},
+        ),
+      ],
+    ),
+  );
+}
+
+// ============================================================================
+// Story 9: Interactive Playground - Full customization
+// ============================================================================
+
+/// Interactive playground to customize all list tile properties.
+@widgetbook.UseCase(name: 'Interactive Playground', type: AppListTile)
+Widget appListTilePlayground(BuildContext context) {
+  // Title and subtitle
+  final title = context.knobs.string(
+    label: 'Title',
+    initialValue: 'List Item Title',
+  );
+  final subtitle = context.knobs.string(
+    label: 'Subtitle',
+    initialValue: 'Optional subtitle text',
+  );
+  final showSubtitle = context.knobs.boolean(
+    label: 'Show Subtitle',
+    initialValue: true,
+  );
+
+  // Leading widget options
+  final leadingType = context.knobs.object.dropdown(
+    label: 'Leading Widget',
+    options: ['None', 'Icon', 'Avatar', 'Checkbox'],
+    labelBuilder: (option) => option,
+    initialOption: 'Icon',
+  );
+
+  // Trailing widget options
+  final trailingType = context.knobs.object.dropdown(
+    label: 'Trailing Widget',
+    options: ['None', 'Icon', 'Chevron', 'Switch', 'Text'],
+    labelBuilder: (option) => option,
+    initialOption: 'Chevron',
+  );
+
+  // States
+  final selected = context.knobs.boolean(
+    label: 'Selected',
+    initialValue: false,
+  );
+  final enabled = context.knobs.boolean(label: 'Enabled', initialValue: true);
+  final dense = context.knobs.boolean(label: 'Dense Mode', initialValue: false);
+  final isThreeLine = context.knobs.boolean(
+    label: 'Three Line',
+    initialValue: false,
+  );
+
+  // Build leading widget
+  Widget? leading;
+  switch (leadingType) {
+    case 'Icon':
+      leading = const Icon(Icons.star);
+    case 'Avatar':
+      leading = const CircleAvatar(child: Icon(Icons.person));
+    case 'Checkbox':
+      leading = Checkbox(value: selected, onChanged: (_) {});
+    case 'None':
+      leading = null;
+  }
+
+  // Build trailing widget
+  Widget? trailing;
+  switch (trailingType) {
+    case 'Icon':
+      trailing = const Icon(Icons.info);
+    case 'Chevron':
+      trailing = const Icon(Icons.chevron_right);
+    case 'Switch':
+      trailing = Switch(value: selected, onChanged: (_) {});
+    case 'Text':
+      trailing = const Text('12:30');
+    case 'None':
+      trailing = null;
+  }
+
+  return Scaffold(
+    appBar: AppBar(title: const Text('Interactive Playground')),
+    body: ListView(
+      children: [
+        const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            'Use the knobs panel to customize the list tile properties.',
+            textAlign: TextAlign.center,
+          ),
+        ),
+        const Divider(),
+        AppListTile(
+          leading: leading,
+          title: title,
+          subtitle: showSubtitle ? subtitle : null,
+          trailing: trailing,
+          selected: selected,
+          enabled: enabled,
+          dense: dense,
+          isThreeLine: isThreeLine,
+          onTap: () {},
+        ),
+      ],
+    ),
+  );
+}

--- a/widgetbook_kit/lib/stories/core_kit/widgets/surfaces/app_section_header_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/widgets/surfaces/app_section_header_stories.dart
@@ -1,2 +1,369 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/widgets/surfaces/app_section_header.dart';
+import 'package:core_kit/theme/app_spacing.dart';
+
+@widgetbook.UseCase(name: 'Default', type: AppSectionHeader)
+Widget appSectionHeaderDefault(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(AppSpacing.md),
+    child: AppSectionHeader(
+      title: context.knobs.string(
+        label: 'Title',
+        initialValue: 'Section Title',
+      ),
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'With Subtitle', type: AppSectionHeader)
+Widget appSectionHeaderWithSubtitle(BuildContext context) {
+  return const Padding(
+    padding: EdgeInsets.all(AppSpacing.md),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AppSectionHeader(
+          title: 'Account Settings',
+          subtitle: 'Manage your account preferences and security',
+        ),
+        SizedBox(height: AppSpacing.lg),
+        AppSectionHeader(
+          title: 'Privacy',
+          subtitle: 'Control who can see your information',
+        ),
+        SizedBox(height: AppSpacing.lg),
+        AppSectionHeader(
+          title: 'Notifications',
+          subtitle: 'Choose how you want to be notified',
+        ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'With Leading', type: AppSectionHeader)
+Widget appSectionHeaderWithLeading(BuildContext context) {
+  return const Padding(
+    padding: EdgeInsets.all(AppSpacing.md),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AppSectionHeader(
+          leading: Icon(Icons.person, size: 20),
+          title: 'Profile',
+        ),
+        SizedBox(height: AppSpacing.md),
+        AppSectionHeader(
+          leading: Icon(Icons.lock, size: 20),
+          title: 'Security',
+        ),
+        SizedBox(height: AppSpacing.md),
+        AppSectionHeader(
+          leading: Icon(Icons.notifications, size: 20),
+          title: 'Notifications',
+        ),
+        SizedBox(height: AppSpacing.md),
+        AppSectionHeader(
+          leading: Icon(Icons.palette, size: 20),
+          title: 'Appearance',
+          subtitle: 'Customize your app experience',
+        ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'With Trailing', type: AppSectionHeader)
+Widget appSectionHeaderWithTrailing(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(AppSpacing.md),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AppSectionHeader(
+          title: 'Recent Files',
+          trailing: TextButton(
+            onPressed: () {},
+            child: const Text('Clear all'),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        AppSectionHeader(
+          title: 'Favorites',
+          trailing: IconButton(
+            onPressed: () {},
+            icon: const Icon(Icons.edit, size: 20),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        AppSectionHeader(
+          title: 'Downloads',
+          subtitle: '12 items pending',
+          trailing: TextButton(onPressed: () {}, child: const Text('View all')),
+        ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'With Divider', type: AppSectionHeader)
+Widget appSectionHeaderWithDivider(BuildContext context) {
+  return Padding(
+    padding: const EdgeInsets.all(AppSpacing.md),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          'Divider Below (Default)',
+          style: Theme.of(context).textTheme.labelLarge,
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        const AppSectionHeader(
+          title: 'Section with divider below',
+          showDivider: true,
+          dividerPosition: DividerPosition.below,
+        ),
+        const SizedBox(height: AppSpacing.lg),
+        Text('Divider Above', style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: AppSpacing.sm),
+        const AppSectionHeader(
+          title: 'Section with divider above',
+          showDivider: true,
+          dividerPosition: DividerPosition.above,
+        ),
+        const SizedBox(height: AppSpacing.lg),
+        Text('Divider Both', style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: AppSpacing.sm),
+        const AppSectionHeader(
+          title: 'Section with dividers on both sides',
+          showDivider: true,
+          dividerPosition: DividerPosition.both,
+        ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Settings List Example', type: AppSectionHeader)
+Widget appSectionHeaderSettingsList(BuildContext context) {
+  return const _SettingsListContent();
+}
+
+/// Stateful widget for Settings List Example to demonstrate realistic usage
+class _SettingsListContent extends StatefulWidget {
+  const _SettingsListContent();
+
+  @override
+  State<_SettingsListContent> createState() => _SettingsListContentState();
+}
+
+class _SettingsListContentState extends State<_SettingsListContent> {
+  bool _biometricLogin = true;
+  bool _pushNotifications = true;
+  bool _emailNotifications = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const AppSectionHeader(title: 'Account', isUpperCase: true),
+          ListTile(
+            leading: const Icon(Icons.person),
+            title: const Text('Profile'),
+            subtitle: const Text('john.doe@example.com'),
+            onTap: () {},
+          ),
+          ListTile(
+            leading: const Icon(Icons.email),
+            title: const Text('Email'),
+            onTap: () {},
+          ),
+          ListTile(
+            leading: const Icon(Icons.phone),
+            title: const Text('Phone number'),
+            onTap: () {},
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          const AppSectionHeader(
+            title: 'Privacy & Security',
+            isUpperCase: true,
+          ),
+          ListTile(
+            leading: const Icon(Icons.lock),
+            title: const Text('Password'),
+            subtitle: const Text('Last changed 30 days ago'),
+            onTap: () {},
+          ),
+          ListTile(
+            leading: const Icon(Icons.fingerprint),
+            title: const Text('Biometric login'),
+            trailing: Switch(
+              value: _biometricLogin,
+              onChanged: (value) => setState(() => _biometricLogin = value),
+            ),
+          ),
+          ListTile(
+            leading: const Icon(Icons.security),
+            title: const Text('Two-factor authentication'),
+            onTap: () {},
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          const AppSectionHeader(title: 'Notifications', isUpperCase: true),
+          ListTile(
+            leading: const Icon(Icons.notifications),
+            title: const Text('Push notifications'),
+            trailing: Switch(
+              value: _pushNotifications,
+              onChanged: (value) => setState(() => _pushNotifications = value),
+            ),
+          ),
+          ListTile(
+            leading: const Icon(Icons.mail_outline),
+            title: const Text('Email notifications'),
+            trailing: Switch(
+              value: _emailNotifications,
+              onChanged: (value) => setState(() => _emailNotifications = value),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+@widgetbook.UseCase(name: 'Theme Variations', type: AppSectionHeader)
+Widget appSectionHeaderThemeVariations(BuildContext context) {
+  final colorScheme = Theme.of(context).colorScheme;
+
+  return Padding(
+    padding: const EdgeInsets.all(AppSpacing.md),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text('Default Theme', style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: AppSpacing.sm),
+        const AppSectionHeader(
+          title: 'Default Section Header',
+          subtitle: 'Uses theme colors automatically',
+        ),
+        const SizedBox(height: AppSpacing.lg),
+        Text(
+          'With Background Color',
+          style: Theme.of(context).textTheme.labelLarge,
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        AppSectionHeader(
+          title: 'Highlighted Section',
+          subtitle: 'With primary container background',
+          backgroundColor: colorScheme.primaryContainer,
+        ),
+        const SizedBox(height: AppSpacing.lg),
+        Text('Custom Colors', style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: AppSpacing.sm),
+        AppSectionHeader(
+          title: 'Custom Styled Section',
+          subtitle: 'With custom text colors',
+          textStyle: TextStyle(
+            color: colorScheme.primary,
+            fontWeight: FontWeight.bold,
+            fontSize: 16,
+          ),
+          subtitleStyle: TextStyle(
+            color: colorScheme.secondary,
+            fontStyle: FontStyle.italic,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.lg),
+        Text(
+          'Sticky Header Style',
+          style: Theme.of(context).textTheme.labelLarge,
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        AppSectionHeader(
+          title: 'Sticky Section',
+          backgroundColor: colorScheme.surface,
+          showDivider: true,
+          dividerPosition: DividerPosition.below,
+        ),
+      ],
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Interactive Playground', type: AppSectionHeader)
+Widget appSectionHeaderPlayground(BuildContext context) {
+  final title = context.knobs.string(
+    label: 'Title',
+    initialValue: 'Section Header',
+  );
+
+  final subtitle = context.knobs.stringOrNull(
+    label: 'Subtitle',
+    initialValue: null,
+  );
+
+  final showLeading = context.knobs.boolean(
+    label: 'Show Leading Icon',
+    initialValue: false,
+  );
+
+  final showTrailing = context.knobs.boolean(
+    label: 'Show Trailing Action',
+    initialValue: false,
+  );
+
+  final isUpperCase = context.knobs.boolean(
+    label: 'Uppercase Title',
+    initialValue: false,
+  );
+
+  final showDivider = context.knobs.boolean(
+    label: 'Show Divider',
+    initialValue: false,
+  );
+
+  final dividerPositionOptions = context.knobs.object.dropdown<DividerPosition>(
+    label: 'Divider Position',
+    options: DividerPosition.values,
+    labelBuilder: (value) => value.name,
+  );
+
+  final showBackground = context.knobs.boolean(
+    label: 'Show Background',
+    initialValue: false,
+  );
+
+  final colorScheme = Theme.of(context).colorScheme;
+
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(AppSpacing.md),
+      child: AppSectionHeader(
+        title: title,
+        subtitle: subtitle,
+        leading: showLeading ? const Icon(Icons.settings, size: 20) : null,
+        trailing: showTrailing
+            ? TextButton(onPressed: () {}, child: const Text('Action'))
+            : null,
+        isUpperCase: isUpperCase,
+        showDivider: showDivider,
+        dividerPosition: dividerPositionOptions,
+        backgroundColor: showBackground
+            ? colorScheme.surfaceContainerLow
+            : null,
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
## ✅ What was implemented
- 5 semantic error types (network, server, notFound, permission, generic)
- 2 display variants (full-screen, compact)
- Named constructors for common scenarios
- Action buttons with retry and secondary actions
- Comprehensive Dartdoc documentation

## 🎨 Material Design 3 Compliance
- Typography: headlineSmall/titleLarge
- Icon sizes: 64dp (full-screen), 48dp (compact)
- Proper spacing and colors from theme

## 📚 Widgetbook Stories
11 interactive examples covering all error types

## 🧪 Test Coverage
✅ 29 passing, 2 skipped

## ✅ Verification
- Code formatting: ✅ Passed
- Static analysis: ✅ No issues
- SPDX compliance: ✅ All files

Ready for review!