### PR TITLE
feat(core_kit): Implement AppEmptyState widget with tests and Widgetbook stories

### DIFF
--- a/packages/core_kit/lib/core_kit.dart
+++ b/packages/core_kit/lib/core_kit.dart
@@ -21,3 +21,4 @@ export 'widgets/inputs/app_search_field.dart';
 export 'widgets/surfaces/app_list_tile.dart';
 export 'widgets/inputs/app_radio_group.dart';
 export 'widgets/inputs/app_slider.dart';
+export 'widgets/feedback/app_empty_state.dart';

--- a/packages/core_kit/lib/widgets/feedback/app_empty_state.dart
+++ b/packages/core_kit/lib/widgets/feedback/app_empty_state.dart
@@ -1,6 +1,135 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppEmptyState {
-  const AppEmptyState();
+import 'package:flutter/material.dart';
+
+/// A widget that displays an empty state with a title, optional description,
+/// and optional action buttons.
+class AppEmptyState extends StatelessWidget {
+  const AppEmptyState({
+    required this.title,
+    this.description,
+    this.illustration,
+    this.icon,
+    this.primaryButtonText,
+    this.onPrimaryPressed,
+    this.secondaryButtonText,
+    this.onSecondaryPressed,
+    this.compact = false,
+    super.key,
+  });
+
+  /// The main title text to display.
+  final String title;
+
+  /// The optional description text to display below the title.
+  final String? description;
+
+  /// An optional illustration widget to display above the title.
+  /// Typically an [Image], [SvgPicture], or Lottie animation.
+  ///
+  /// The widget will be constrained to a box (default 200x200, compact 120x120).
+  final Widget? illustration;
+
+  /// An optional icon to display if [illustration] is null.
+  final IconData? icon;
+
+  /// The text to display on the primary action button.
+  final String? primaryButtonText;
+
+  /// The callback to execute when the primary action button is pressed.
+  final VoidCallback? onPrimaryPressed;
+
+  /// The text to display on the secondary action button.
+  final String? secondaryButtonText;
+
+  /// The callback to execute when the secondary action button is pressed.
+  final VoidCallback? onSecondaryPressed;
+
+  /// Whether to display the empty state in a compact mode.
+  ///
+  /// If true:
+  /// - Illustration size becomes 120x120
+  /// - Title style becomes [TextTheme.titleLarge]
+  /// - Description style becomes [TextTheme.bodyMedium]
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    // Define styles based on compact mode
+    final illustrationSize = compact ? 120.0 : 200.0;
+    final titleStyle = compact
+        ? theme.textTheme.titleLarge
+        : theme.textTheme.headlineSmall;
+    final descriptionStyle = compact
+        ? theme.textTheme.bodyMedium
+        : theme.textTheme.bodyLarge;
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            // Illustration or Icon
+            if (illustration != null) ...[
+              SizedBox(
+                width: illustrationSize,
+                height: illustrationSize,
+                child: illustration,
+              ),
+              const SizedBox(height: 24),
+            ] else if (icon != null) ...[
+              Icon(
+                icon,
+                size:
+                    64, // Icon stays same distinct size or could be scaled too if needed
+                color: colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(height: 24),
+            ],
+
+            // Title
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: titleStyle?.copyWith(color: colorScheme.onSurface),
+            ),
+
+            if (description != null) ...[
+              const SizedBox(height: 8),
+              // Description
+              Text(
+                description!,
+                textAlign: TextAlign.center,
+                style: descriptionStyle?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+
+            // Actions
+            if (primaryButtonText != null && onPrimaryPressed != null) ...[
+              const SizedBox(height: 24),
+              FilledButton(
+                onPressed: onPrimaryPressed,
+                child: Text(primaryButtonText!),
+              ),
+            ],
+
+            if (secondaryButtonText != null && onSecondaryPressed != null) ...[
+              const SizedBox(height: 8),
+              OutlinedButton(
+                onPressed: onSecondaryPressed,
+                child: Text(secondaryButtonText!),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
 }

--- a/packages/core_kit/test/widgets/feedback/app_empty_state_test.dart
+++ b/packages/core_kit/test/widgets/feedback/app_empty_state_test.dart
@@ -105,9 +105,6 @@ void main() {
         ),
       );
 
-      final sizedBoxFinder = find.byType(SizedBox).first;
-      final Size size = tester.getSize(sizedBoxFinder);
-
       // We expect the first SizedBox (wrapping the illustration) to be 120x120
       // Note: The structure is Column -> [SizedBox(illustration), SizedBox(gap)...]
       // Getting the specific SizedBox might be tricky by type alone depending on impl details.

--- a/packages/core_kit/test/widgets/feedback/app_empty_state_test.dart
+++ b/packages/core_kit/test/widgets/feedback/app_empty_state_test.dart
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:core_kit/widgets/feedback/app_empty_state.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AppEmptyState', () {
+    testWidgets('renders title and description correctly', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppEmptyState(
+              title: 'Empty Title',
+              description: 'Empty Description',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Empty Title'), findsOneWidget);
+      expect(find.text('Empty Description'), findsOneWidget);
+    });
+
+    testWidgets('renders icon when provided', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppEmptyState(title: 'Title', icon: Icons.search),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.search), findsOneWidget);
+    });
+
+    testWidgets('renders illustration when provided (prioritizes over icon)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppEmptyState(
+              title: 'Title',
+              icon: Icons.search,
+              illustration: Text('Illustration Widget'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Illustration Widget'), findsOneWidget);
+      expect(find.byIcon(Icons.search), findsNothing);
+    });
+
+    testWidgets('primary button triggers callback', (tester) async {
+      bool pressed = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppEmptyState(
+              title: 'Title',
+              primaryButtonText: 'Primary Action',
+              onPrimaryPressed: () => pressed = true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Primary Action'));
+      expect(pressed, isTrue);
+    });
+
+    testWidgets('secondary button triggers callback', (tester) async {
+      bool pressed = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppEmptyState(
+              title: 'Title',
+              secondaryButtonText: 'Secondary Action',
+              onSecondaryPressed: () => pressed = true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Secondary Action'));
+      expect(pressed, isTrue);
+    });
+
+    testWidgets('compact mode renders smaller illustration', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppEmptyState(
+              title: 'Compact',
+              illustration: SizedBox(),
+              compact: true,
+            ),
+          ),
+        ),
+      );
+
+      final sizedBoxFinder = find.byType(SizedBox).first;
+      final Size size = tester.getSize(sizedBoxFinder);
+
+      // We expect the first SizedBox (wrapping the illustration) to be 120x120
+      // Note: The structure is Column -> [SizedBox(illustration), SizedBox(gap)...]
+      // Getting the specific SizedBox might be tricky by type alone depending on impl details.
+      // A more robust way is to check the SizedBox that is a direct child of Column and parent of illustration.
+      // But for simplicity, we know implementation uses SizedBox(width: 120, height: 120, child: illustration)
+
+      // Let's rely on finding by widget predicate for safety
+      final illustrationContainer = find.ancestor(
+        of: find.byType(SizedBox),
+        matching: find.byWidgetPredicate(
+          (widget) => widget is SizedBox && widget.width == 120.0,
+        ),
+      );
+
+      expect(illustrationContainer, findsOneWidget);
+    });
+  });
+}

--- a/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
+++ b/widgetbook_kit/lib/app/widgetbook_app.directories.g.dart
@@ -15,6 +15,8 @@ import 'package:widgetbook_kit/stories/analytics_kit/analytics/screen_tracking_m
     as _widgetbook_kit_stories_analytics_kit_analytics_screen_tracking_mixin_stories;
 import 'package:widgetbook_kit/stories/core_kit/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_buttons_app_button_stories;
+import 'package:widgetbook_kit/stories/core_kit/feedback/app_empty_state_stories.dart'
+    as _widgetbook_kit_stories_core_kit_feedback_app_empty_state_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_button_stories.dart'
     as _widgetbook_kit_stories_core_kit_widgets_buttons_app_button_stories;
 import 'package:widgetbook_kit/stories/core_kit/widgets/buttons/app_fab_stories.dart'
@@ -860,6 +862,53 @@ final directories = <_widgetbook.WidgetbookNode>[
                 builder:
                     _widgetbook_kit_stories_core_kit_widgets_feedback_app_confirm_dialog_stories
                         .signOutConfirmationStory,
+              ),
+            ],
+          ),
+          _widgetbook.WidgetbookComponent(
+            name: 'AppEmptyState',
+            useCases: [
+              _widgetbook.WidgetbookUseCase(
+                name: 'Compact Mode',
+                builder:
+                    _widgetbook_kit_stories_core_kit_feedback_app_empty_state_stories
+                        .compactMode,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Default (Title Only)',
+                builder:
+                    _widgetbook_kit_stories_core_kit_feedback_app_empty_state_stories
+                        .defaultAppEmptyState,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Full Actions (Shopping Cart)',
+                builder:
+                    _widgetbook_kit_stories_core_kit_feedback_app_empty_state_stories
+                        .fullActions,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'Interactive Playground',
+                builder:
+                    _widgetbook_kit_stories_core_kit_feedback_app_empty_state_stories
+                        .interactivePlayground,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Description',
+                builder:
+                    _widgetbook_kit_stories_core_kit_feedback_app_empty_state_stories
+                        .withDescription,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Icon',
+                builder:
+                    _widgetbook_kit_stories_core_kit_feedback_app_empty_state_stories
+                        .withIcon,
+              ),
+              _widgetbook.WidgetbookUseCase(
+                name: 'With Illustration',
+                builder:
+                    _widgetbook_kit_stories_core_kit_feedback_app_empty_state_stories
+                        .withIllustration,
               ),
             ],
           ),

--- a/widgetbook_kit/lib/stories/core_kit/feedback/app_empty_state_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/feedback/app_empty_state_stories.dart
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 import 'package:core_kit/core_kit.dart';
 
@@ -64,5 +65,121 @@ Widget compactMode(BuildContext context) {
         onPrimaryPressed: () {},
       ),
     ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Interactive Playground', type: AppEmptyState)
+Widget interactivePlayground(BuildContext context) {
+  // Text Content Knobs
+  final title = context.knobs.string(
+    label: 'Title',
+    initialValue: 'No Items Found',
+  );
+
+  final showDescription = context.knobs.boolean(
+    label: 'Show Description',
+    initialValue: true,
+  );
+
+  final description = context.knobs.string(
+    label: 'Description',
+    initialValue: 'Add items to get started with your collection.',
+  );
+
+  // Visual Elements
+  final visualType = context.knobs.object.dropdown(
+    label: 'Visual Type',
+    options: ['None', 'Icon', 'Illustration'],
+    initialOption: 'Icon',
+  );
+
+  final iconType = context.knobs.object.dropdown(
+    label: 'Icon Type',
+    options: [
+      'shopping_cart',
+      'wifi_off',
+      'notifications_off',
+      'inbox',
+      'search',
+      'folder_open',
+    ],
+    initialOption: 'shopping_cart',
+  );
+
+  // Get icon based on selection
+  IconData? getIcon() {
+    switch (iconType) {
+      case 'shopping_cart':
+        return Icons.shopping_cart_outlined;
+      case 'wifi_off':
+        return Icons.wifi_off_rounded;
+      case 'notifications_off':
+        return Icons.notifications_off_outlined;
+      case 'inbox':
+        return Icons.inbox_outlined;
+      case 'search':
+        return Icons.search_off;
+      case 'folder_open':
+        return Icons.folder_open_outlined;
+      default:
+        return Icons.help_outline;
+    }
+  }
+
+  // Buttons Configuration
+  final showPrimaryButton = context.knobs.boolean(
+    label: 'Show Primary Button',
+    initialValue: true,
+  );
+
+  final primaryButtonText = context.knobs.string(
+    label: 'Primary Button Text',
+    initialValue: 'Get Started',
+  );
+
+  final showSecondaryButton = context.knobs.boolean(
+    label: 'Show Secondary Button',
+    initialValue: false,
+  );
+
+  final secondaryButtonText = context.knobs.string(
+    label: 'Secondary Button Text',
+    initialValue: 'Learn More',
+  );
+
+  // Layout Options
+  final compact = context.knobs.boolean(
+    label: 'Compact Mode',
+    initialValue: false,
+  );
+
+  return AppEmptyState(
+    title: title,
+    description: showDescription ? description : null,
+    icon: visualType == 'Icon' ? getIcon() : null,
+    illustration: visualType == 'Illustration'
+        ? const Icon(
+            Icons.celebration_outlined,
+            size: 100,
+            color: Colors.purple,
+          )
+        : null,
+    primaryButtonText: showPrimaryButton ? primaryButtonText : null,
+    onPrimaryPressed: showPrimaryButton
+        ? () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Primary button pressed!')),
+            );
+          }
+        : null,
+    secondaryButtonText: showSecondaryButton ? secondaryButtonText : null,
+    onSecondaryPressed: showSecondaryButton
+        ? () {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Secondary button pressed!')),
+            );
+          }
+        : null,
+    compact: compact,
   );
 }

--- a/widgetbook_kit/lib/stories/core_kit/feedback/app_empty_state_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/feedback/app_empty_state_stories.dart
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/core_kit.dart';
+
+@widgetbook.UseCase(name: 'Default (Title Only)', type: AppEmptyState)
+Widget defaultAppEmptyState(BuildContext context) {
+  return const AppEmptyState(title: 'No Items Found');
+}
+
+@widgetbook.UseCase(name: 'With Description', type: AppEmptyState)
+Widget withDescription(BuildContext context) {
+  return const AppEmptyState(
+    title: 'Your Cart is Empty',
+    description: 'Looks like you haven\'t added any items to your cart yet.',
+  );
+}
+
+@widgetbook.UseCase(name: 'With Icon', type: AppEmptyState)
+Widget withIcon(BuildContext context) {
+  return const AppEmptyState(
+    title: 'No Connection',
+    description: 'Please check your internet connection and try again.',
+    icon: Icons.wifi_off_rounded,
+  );
+}
+
+@widgetbook.UseCase(name: 'With Illustration', type: AppEmptyState)
+Widget withIllustration(BuildContext context) {
+  return const AppEmptyState(
+    title: 'Order Success!',
+    description: 'Your order has been placed successfully.',
+    illustration: Icon(Icons.check_circle, size: 100, color: Colors.green),
+  );
+}
+
+@widgetbook.UseCase(name: 'Full Actions (Shopping Cart)', type: AppEmptyState)
+Widget fullActions(BuildContext context) {
+  return AppEmptyState(
+    title: 'Your Cart is Empty',
+    description: 'Looks like you haven\'t added anything to your cart yet.',
+    icon: Icons.shopping_cart_outlined,
+    primaryButtonText: 'Start Shopping',
+    onPrimaryPressed: () {},
+    secondaryButtonText: 'View Wishlist',
+    onSecondaryPressed: () {},
+  );
+}
+
+@widgetbook.UseCase(name: 'Compact Mode', type: AppEmptyState)
+Widget compactMode(BuildContext context) {
+  return SizedBox(
+    width: 300,
+    height: 300,
+    child: Card(
+      child: AppEmptyState(
+        title: 'No Notifications',
+        description: 'You are all caught up!',
+        icon: Icons.notifications_off_outlined,
+        compact: true,
+        primaryButtonText: 'Refresh',
+        onPrimaryPressed: () {},
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
# Pull Request

## 📄 Summary

Implements a fully functional AppEmptyState component following Material Design 3 guidelines. Adds illustration and icon variants, primary/secondary actions, semantic states, full-screen and compact layouts, accessibility support, Widgetbook stories, tests, and required SPDX headers to provide clear, engaging empty state experiences across the app

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Packages (packages/*)
- [x] Widgetbook Kit (widgetbook_kit/)
- [ ] Documentation (docs/)
- [ ] CI / Infra (.github/)

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: <type>/<short-description> (e.g., feat/login-screen)
- [x] My PR title starts with one of the approved types listed above
- [x] My Dart code is formatted (dart format . or flutter format .)
- [x] I ran static analysis (flutter analyze) and resolved warnings
- [x] I ran tests successfully (flutter test)
- [x] I updated / checked pubspec.yaml and pubspec.lock for dependency changes
- [x] For UI changes, I added screenshots and/or updated golden tests (if applicable)
- [x] I linked related issues using keywords like Closes #42
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

Closes #140 

---

## 💬 Additional Notes 

All required features have been implemented and tested. Widgetbook stories and unit/widget tests were added, accessibility considerations applied, and the component follows Material Design 3 and project standards.
