### PR TITLE
fix(sync): befora pack 2 ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,16 @@ jobs:
           channel: 'stable'
           cache: true
 
+      - name: Install Melos
+        run: dart pub global activate melos
+
+      - name: Bootstrap packages
+        run: melos bootstrap
+
+      - name: Generate Widgetbook files
+        working-directory: widgetbook_kit
+        run: flutter pub run build_runner build --delete-conflicting-outputs
+
       - name: Run Flutter analyze
         run: melos run analyze
 
@@ -78,6 +88,12 @@ jobs:
           flutter-version: '3.x'
           channel: 'stable'
           cache: true
+
+      - name: Install Melos
+        run: dart pub global activate melos
+
+      - name: Bootstrap packages
+        run: melos bootstrap
 
       - name: Run tests
         run: melos run test

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "storybook": "pnpm widgetbook:web",
     "build-storybook": "pnpm widgetbook:build",
     "ci:format": "dart format --set-exit-if-changed .",
-    "ci:analyze": "pnpm bootstrap && pnpm analyze",
+    "ci:analyze": "pnpm bootstrap && pnpm widgetbook:generate && pnpm analyze",
     "ci:test": "pnpm bootstrap && pnpm test",
     "ci:local": "pnpm ci:format && pnpm ci:analyze && pnpm ci:test"
   },

--- a/packages/core_kit/lib/widgets/buttons/app_button.dart
+++ b/packages/core_kit/lib/widgets/buttons/app_button.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 /// and full-width layouts. All variants follow Material Design 3 guidelines
 /// and automatically adapt to the app's theme.
 ///
+///
 /// ## Usage
 ///
 /// ```dart


### PR DESCRIPTION
Fixing ci and husky problems before pack 2 sync 

---

This pull request includes a minor update to the `ci:analyze` script in `package.json` to ensure widgetbook code generation runs before analysis, and a small documentation formatting change in `app_button.dart`.

- **Build and CI Improvements:**
  * Updated the `ci:analyze` script in `package.json` to run `widgetbook:generate` before `analyze`, ensuring generated files are up-to-date for analysis.

- **Documentation:**
  * Added a blank line to improve documentation formatting in `app_button.dart`.