### PR TITLE
feat(core_kit): add AppBodyText widget with Material Design 3 typography

### DIFF
--- a/packages/core_kit/lib/typography/app_body_text.dart
+++ b/packages/core_kit/lib/typography/app_body_text.dart
@@ -1,6 +1,212 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppBodyText {
-  const AppBodyText();
+import 'package:flutter/material.dart';
+
+/// A convenience widget for displaying body text with Material Design 3 styling.
+///
+/// [AppBodyText] provides a simple API for rendering body text (main content text)
+/// with consistent typography from the app's theme. It automatically applies the
+/// appropriate text style from [TextTheme] based on the variant.
+///
+/// ## Variants
+///
+/// - [AppBodyText.large] - 16sp, 400 weight, 0.5 letter spacing
+/// - [AppBodyText.medium] - 14sp, 400 weight, 0.25 letter spacing (default)
+/// - [AppBodyText.small] - 12sp, 400 weight, 0.4 letter spacing
+///
+/// ## Common Use Cases
+///
+/// - Paragraph text in articles or descriptions
+/// - Main content text in cards
+/// - Form helper text
+/// - List item descriptions
+/// - Dialog body text
+///
+/// ## Example Usage
+///
+/// ```dart
+/// // Default body text (medium)
+/// AppBodyText('This is body text')
+///
+/// // Large body text
+/// AppBodyText.large('This is large body text')
+///
+/// // Small body text with semantic color
+/// AppBodyText.small(
+///   'This is small body text',
+///   color: Theme.of(context).colorScheme.onSurfaceVariant,
+/// )
+///
+/// // Bold body text
+/// AppBodyText(
+///   'This is bold text',
+///   fontWeight: FontWeight.bold,
+/// )
+///
+/// // Body text with overflow handling
+/// AppBodyText(
+///   'This is a very long text that might overflow',
+///   maxLines: 2,
+///   overflow: TextOverflow.ellipsis,
+/// )
+/// ```
+///
+/// See also:
+///
+/// - [Text] - The underlying Flutter text widget
+/// - [TextTheme] - Material Design 3 text theme
+/// - [AppCaption] - For caption text
+/// - [AppLabel] - For label text
+class AppBodyText extends StatelessWidget {
+  /// Creates a body text widget with medium variant (default).
+  ///
+  /// The [data] parameter must not be null.
+  const AppBodyText(
+    this.data, {
+    this.color,
+    this.fontWeight,
+    this.textAlign,
+    this.maxLines,
+    this.overflow,
+    this.softWrap,
+    this.textDirection,
+    this.semanticsLabel,
+    super.key,
+  }) : _variant = _BodyTextVariant.medium;
+
+  /// Creates a body text widget with large variant (16sp).
+  ///
+  /// Use this for emphasized or primary content that needs more prominence.
+  const AppBodyText.large(
+    this.data, {
+    this.color,
+    this.fontWeight,
+    this.textAlign,
+    this.maxLines,
+    this.overflow,
+    this.softWrap,
+    this.textDirection,
+    this.semanticsLabel,
+    super.key,
+  }) : _variant = _BodyTextVariant.large;
+
+  /// Creates a body text widget with medium variant (14sp).
+  const AppBodyText.medium(
+    this.data, {
+    this.color,
+    this.fontWeight,
+    this.textAlign,
+    this.maxLines,
+    this.overflow,
+    this.softWrap,
+    this.textDirection,
+    this.semanticsLabel,
+    super.key,
+  }) : _variant = _BodyTextVariant.medium;
+
+  /// Creates a body text widget with small variant (12sp).
+  const AppBodyText.small(
+    this.data, {
+    this.color,
+    this.fontWeight,
+    this.textAlign,
+    this.maxLines,
+    this.overflow,
+    this.softWrap,
+    this.textDirection,
+    this.semanticsLabel,
+    super.key,
+  }) : _variant = _BodyTextVariant.small;
+
+  /// The text to display.
+  final String data;
+
+  /// The color to use when drawing the text.
+  ///
+  /// If null, uses the color from the text style in the theme.
+  final Color? color;
+
+  /// The font weight to use when drawing the text.
+  ///
+  /// If null, uses the weight from the text style (typically 400).
+  final FontWeight? fontWeight;
+
+  /// How the text should be aligned horizontally.
+  final TextAlign? textAlign;
+
+  /// An optional maximum number of lines for the text to span.
+  ///
+  /// If the text exceeds the given number of lines, it will be truncated
+  /// according to [overflow].
+  final int? maxLines;
+
+  /// How visual overflow should be handled.
+  ///
+  /// If [maxLines] is specified, this determines what happens when the text
+  /// would otherwise overflow. Supported values for Material Design 3:
+  /// - [TextOverflow.clip] - Clip the overflowing text (default)
+  /// - [TextOverflow.ellipsis] - Use an ellipsis (...) to indicate overflow
+  final TextOverflow? overflow;
+
+  /// Whether the text should break at soft line breaks.
+  ///
+  /// If false, the glyphs in the text will be positioned as if there was
+  /// unlimited horizontal space.
+  final bool? softWrap;
+
+  /// The directionality of the text.
+  ///
+  /// This decides how [textAlign] values like [TextAlign.start] and
+  /// [TextAlign.end] are interpreted.
+  final TextDirection? textDirection;
+
+  /// An alternative semantics label for this text.
+  ///
+  /// If present, the semantics of this widget will contain this value instead
+  /// of the actual text. This is useful for replacing abbreviations or
+  /// shorthands with their expanded forms for screen readers.
+  final String? semanticsLabel;
+
+  /// The text variant (large, medium, or small).
+  final _BodyTextVariant _variant;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+
+    // Select the appropriate text style based on variant
+    final baseStyle = switch (_variant) {
+      _BodyTextVariant.large => textTheme.bodyLarge,
+      _BodyTextVariant.medium => textTheme.bodyMedium,
+      _BodyTextVariant.small => textTheme.bodySmall,
+    };
+
+    // Apply custom color and font weight if provided
+    final style = baseStyle?.copyWith(color: color, fontWeight: fontWeight);
+
+    return Text(
+      data,
+      style: style,
+      textAlign: textAlign,
+      maxLines: maxLines,
+      overflow: overflow,
+      softWrap: softWrap,
+      textDirection: textDirection,
+      semanticsLabel: semanticsLabel,
+    );
+  }
+}
+
+/// Internal enum for body text variants.
+enum _BodyTextVariant {
+  /// Large body text (16sp, 400 weight, 0.5 letter spacing).
+  large,
+
+  /// Medium body text (14sp, 400 weight, 0.25 letter spacing).
+  medium,
+
+  /// Small body text (12sp, 400 weight, 0.4 letter spacing).
+  small,
 }

--- a/packages/core_kit/test/typography/app_body_text_test.dart
+++ b/packages/core_kit/test/typography/app_body_text_test.dart
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:core_kit/typography/app_body_text.dart';
+
+void main() {
+  group('AppBodyText Tests', () {
+    testWidgets('AppBodyText renders with default text', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: AppBodyText('Test body text'))),
+      );
+
+      expect(find.text('Test body text'), findsOneWidget);
+      expect(find.byType(Text), findsOneWidget);
+    });
+
+    testWidgets('AppBodyText.large uses bodyLarge style', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppBodyText.large('Large text')),
+        ),
+      );
+
+      final textWidget = tester.widget<Text>(find.byType(Text));
+      final textTheme = Theme.of(tester.element(find.byType(Text))).textTheme;
+
+      expect(textWidget.style?.fontSize, textTheme.bodyLarge?.fontSize);
+      expect(textWidget.style?.fontWeight, textTheme.bodyLarge?.fontWeight);
+      expect(find.text('Large text'), findsOneWidget);
+    });
+
+    testWidgets('AppBodyText.medium uses bodyMedium style', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppBodyText.medium('Medium text')),
+        ),
+      );
+
+      final textWidget = tester.widget<Text>(find.byType(Text));
+      final textTheme = Theme.of(tester.element(find.byType(Text))).textTheme;
+
+      expect(textWidget.style?.fontSize, textTheme.bodyMedium?.fontSize);
+      expect(textWidget.style?.fontWeight, textTheme.bodyMedium?.fontWeight);
+      expect(find.text('Medium text'), findsOneWidget);
+    });
+
+    testWidgets('AppBodyText.small uses bodySmall style', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppBodyText.small('Small text')),
+        ),
+      );
+
+      final textWidget = tester.widget<Text>(find.byType(Text));
+      final textTheme = Theme.of(tester.element(find.byType(Text))).textTheme;
+
+      expect(textWidget.style?.fontSize, textTheme.bodySmall?.fontSize);
+      expect(textWidget.style?.fontWeight, textTheme.bodySmall?.fontWeight);
+      expect(find.text('Small text'), findsOneWidget);
+    });
+
+    testWidgets('AppBodyText applies custom color', (tester) async {
+      const customColor = Colors.blue;
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppBodyText('Colored text', color: customColor)),
+        ),
+      );
+
+      final textWidget = tester.widget<Text>(find.byType(Text));
+      expect(textWidget.style?.color, customColor);
+    });
+
+    testWidgets('AppBodyText applies custom font weight', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppBodyText('Bold text', fontWeight: FontWeight.bold),
+          ),
+        ),
+      );
+
+      final textWidget = tester.widget<Text>(find.byType(Text));
+      expect(textWidget.style?.fontWeight, FontWeight.bold);
+    });
+
+    testWidgets('AppBodyText applies text alignment', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppBodyText('Centered text', textAlign: TextAlign.center),
+          ),
+        ),
+      );
+
+      final textWidget = tester.widget<Text>(find.byType(Text));
+      expect(textWidget.textAlign, TextAlign.center);
+    });
+
+    testWidgets('AppBodyText applies maxLines', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppBodyText('Text with max lines', maxLines: 2)),
+        ),
+      );
+
+      final textWidget = tester.widget<Text>(find.byType(Text));
+      expect(textWidget.maxLines, 2);
+    });
+
+    testWidgets('AppBodyText applies overflow', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppBodyText(
+              'Text with overflow',
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ),
+      );
+
+      final textWidget = tester.widget<Text>(find.byType(Text));
+      expect(textWidget.overflow, TextOverflow.ellipsis);
+    });
+
+    testWidgets('AppBodyText applies softWrap', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppBodyText('Text with no soft wrap', softWrap: false),
+          ),
+        ),
+      );
+
+      final textWidget = tester.widget<Text>(find.byType(Text));
+      expect(textWidget.softWrap, false);
+    });
+
+    testWidgets('AppBodyText applies text direction', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppBodyText(
+              'Text with RTL direction',
+              textDirection: TextDirection.rtl,
+            ),
+          ),
+        ),
+      );
+
+      final textWidget = tester.widget<Text>(find.byType(Text));
+      expect(textWidget.textDirection, TextDirection.rtl);
+    });
+
+    testWidgets('AppBodyText applies semantics label', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppBodyText(
+              'Text with semantics',
+              semanticsLabel: 'Custom semantics label',
+            ),
+          ),
+        ),
+      );
+
+      final textWidget = tester.widget<Text>(find.byType(Text));
+      expect(textWidget.semanticsLabel, 'Custom semantics label');
+    });
+
+    testWidgets('AppBodyText combines multiple properties correctly', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AppBodyText.medium(
+              'Combined properties text',
+              color: Colors.red,
+              fontWeight: FontWeight.bold,
+              textAlign: TextAlign.right,
+              maxLines: 3,
+              overflow: TextOverflow.fade,
+            ),
+          ),
+        ),
+      );
+
+      final textWidget = tester.widget<Text>(find.byType(Text));
+      expect(textWidget.style?.color, Colors.red);
+      expect(textWidget.style?.fontWeight, FontWeight.bold);
+      expect(textWidget.textAlign, TextAlign.right);
+      expect(textWidget.maxLines, 3);
+      expect(textWidget.overflow, TextOverflow.fade);
+    });
+
+    testWidgets('AppBodyText default constructor uses medium variant', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: AppBodyText('Default variant text')),
+        ),
+      );
+
+      final textWidget = tester.widget<Text>(find.byType(Text));
+      final textTheme = Theme.of(tester.element(find.byType(Text))).textTheme;
+
+      // Default constructor should use bodyMedium style
+      expect(textWidget.style?.fontSize, textTheme.bodyMedium?.fontSize);
+    });
+  });
+}

--- a/widgetbook_kit/lib/stories/core_kit/typography/app_body_text_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/typography/app_body_text_stories.dart
@@ -5,13 +5,15 @@ import 'package:flutter/material.dart';
 import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 import 'package:core_kit/typography/app_body_text.dart';
+import 'package:core_kit/layout/gap.dart';
+import 'package:core_kit/theme/app_spacing.dart';
 
 /// Default body text variant (medium).
 @widgetbook.UseCase(name: 'Default (Medium)', type: AppBodyText)
 Widget defaultBodyText(BuildContext context) {
   return const Center(
     child: Padding(
-      padding: EdgeInsets.all(16.0),
+      padding: EdgeInsets.all(AppSpacing.md),
       child: AppBodyText(
         'This is default body text. It uses the medium variant with 14sp font size.',
       ),
@@ -24,7 +26,7 @@ Widget defaultBodyText(BuildContext context) {
 Widget allVariants(BuildContext context) {
   return const Center(
     child: Padding(
-      padding: EdgeInsets.all(16.0),
+      padding: EdgeInsets.all(AppSpacing.md),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -32,11 +34,11 @@ Widget allVariants(BuildContext context) {
           AppBodyText.large(
             'Large: 16sp font size. Perfect for primary content.',
           ),
-          SizedBox(height: 16),
+          VGap.md(),
           AppBodyText.medium(
             'Medium: 14sp font size (default). Great for standard content.',
           ),
-          SizedBox(height: 16),
+          VGap.md(),
           AppBodyText.small(
             'Small: 12sp font size. Ideal for tertiary content or footnotes.',
           ),
@@ -53,7 +55,7 @@ Widget semanticColors(BuildContext context) {
 
   return Center(
     child: Padding(
-      padding: const EdgeInsets.all(16.0),
+      padding: const EdgeInsets.all(AppSpacing.md),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -62,22 +64,22 @@ Widget semanticColors(BuildContext context) {
             'Default: onSurface color (uses theme default).',
             color: colorScheme.onSurface,
           ),
-          const SizedBox(height: 16),
+          const VGap.md(),
           AppBodyText(
             'Primary: for emphasized content.',
             color: colorScheme.primary,
           ),
-          const SizedBox(height: 16),
+          const VGap.md(),
           AppBodyText(
             'Secondary: for secondary content.',
             color: colorScheme.secondary,
           ),
-          const SizedBox(height: 16),
+          const VGap.md(),
           AppBodyText(
             'Error: for error messages or warnings.',
             color: colorScheme.error,
           ),
-          const SizedBox(height: 16),
+          const VGap.md(),
           AppBodyText(
             'OnSurfaceVariant: for subtle or de-emphasized text.',
             color: colorScheme.onSurfaceVariant,
@@ -93,13 +95,13 @@ Widget semanticColors(BuildContext context) {
 Widget boldWeight(BuildContext context) {
   return const Center(
     child: Padding(
-      padding: EdgeInsets.all(16.0),
+      padding: EdgeInsets.all(AppSpacing.md),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           AppBodyText('Regular weight body text (400).'),
-          SizedBox(height: 16),
+          VGap.md(),
           AppBodyText(
             'Bold weight body text (700).',
             fontWeight: FontWeight.bold,
@@ -115,7 +117,7 @@ Widget boldWeight(BuildContext context) {
 Widget overflowHandling(BuildContext context) {
   return const Center(
     child: Padding(
-      padding: EdgeInsets.all(16.0),
+      padding: EdgeInsets.all(AppSpacing.md),
       child: SizedBox(
         width: 200,
         child: Column(
@@ -127,7 +129,7 @@ Widget overflowHandling(BuildContext context) {
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
             ),
-            SizedBox(height: 16),
+            VGap.md(),
             AppBodyText(
               'This is a very long body text that will overflow and clip at the end.',
               maxLines: 2,
@@ -150,14 +152,14 @@ Widget textAlignment(BuildContext context) {
 
   return const Center(
     child: Padding(
-      padding: EdgeInsets.all(16.0),
+      padding: EdgeInsets.all(AppSpacing.md),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
           AppBodyText(longText, textAlign: TextAlign.left),
-          SizedBox(height: 16),
+          VGap.md(),
           AppBodyText(longText, textAlign: TextAlign.center),
-          SizedBox(height: 16),
+          VGap.md(),
           AppBodyText(longText, textAlign: TextAlign.right),
         ],
       ),
@@ -277,6 +279,6 @@ Widget interactivePlayground(BuildContext context) {
   };
 
   return Center(
-    child: Padding(padding: const EdgeInsets.all(16.0), child: widget),
+    child: Padding(padding: const EdgeInsets.all(AppSpacing.md), child: widget),
   );
 }

--- a/widgetbook_kit/lib/stories/core_kit/typography/app_body_text_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/typography/app_body_text_stories.dart
@@ -1,2 +1,282 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/typography/app_body_text.dart';
+
+/// Default body text variant (medium).
+@widgetbook.UseCase(name: 'Default (Medium)', type: AppBodyText)
+Widget defaultBodyText(BuildContext context) {
+  return const Center(
+    child: Padding(
+      padding: EdgeInsets.all(16.0),
+      child: AppBodyText(
+        'This is default body text. It uses the medium variant with 14sp font size.',
+      ),
+    ),
+  );
+}
+
+/// All three body text variants displayed together.
+@widgetbook.UseCase(name: 'Variants', type: AppBodyText)
+Widget allVariants(BuildContext context) {
+  return const Center(
+    child: Padding(
+      padding: EdgeInsets.all(16.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          AppBodyText.large(
+            'Large: 16sp font size. Perfect for primary content.',
+          ),
+          SizedBox(height: 16),
+          AppBodyText.medium(
+            'Medium: 14sp font size (default). Great for standard content.',
+          ),
+          SizedBox(height: 16),
+          AppBodyText.small(
+            'Small: 12sp font size. Ideal for tertiary content or footnotes.',
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+/// Body text with semantic colors from Material Design 3.
+@widgetbook.UseCase(name: 'Color Overrides', type: AppBodyText)
+Widget semanticColors(BuildContext context) {
+  final colorScheme = Theme.of(context).colorScheme;
+
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          AppBodyText(
+            'Default: onSurface color (uses theme default).',
+            color: colorScheme.onSurface,
+          ),
+          const SizedBox(height: 16),
+          AppBodyText(
+            'Primary: for emphasized content.',
+            color: colorScheme.primary,
+          ),
+          const SizedBox(height: 16),
+          AppBodyText(
+            'Secondary: for secondary content.',
+            color: colorScheme.secondary,
+          ),
+          const SizedBox(height: 16),
+          AppBodyText(
+            'Error: for error messages or warnings.',
+            color: colorScheme.error,
+          ),
+          const SizedBox(height: 16),
+          AppBodyText(
+            'OnSurfaceVariant: for subtle or de-emphasized text.',
+            color: colorScheme.onSurfaceVariant,
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+/// Body text with different font weight variations.
+@widgetbook.UseCase(name: 'Weight Variations', type: AppBodyText)
+Widget boldWeight(BuildContext context) {
+  return const Center(
+    child: Padding(
+      padding: EdgeInsets.all(16.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          AppBodyText('Regular weight body text (400).'),
+          SizedBox(height: 16),
+          AppBodyText(
+            'Bold weight body text (700).',
+            fontWeight: FontWeight.bold,
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+/// Body text with overflow handling strategies.
+@widgetbook.UseCase(name: 'Text Overflow', type: AppBodyText)
+Widget overflowHandling(BuildContext context) {
+  return const Center(
+    child: Padding(
+      padding: EdgeInsets.all(16.0),
+      child: SizedBox(
+        width: 200,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            AppBodyText(
+              'This is a very long body text that will overflow and show ellipsis at the end.',
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+            SizedBox(height: 16),
+            AppBodyText(
+              'This is a very long body text that will overflow and clip at the end.',
+              maxLines: 2,
+              overflow: TextOverflow.clip,
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+/// Body text with different text alignments.
+@widgetbook.UseCase(name: 'Text Alignment', type: AppBodyText)
+Widget textAlignment(BuildContext context) {
+  const longText =
+      'This is a longer text that demonstrates text alignment. '
+      'It contains multiple sentences to show how the alignment works with '
+      'wrapped text across several lines.';
+
+  return const Center(
+    child: Padding(
+      padding: EdgeInsets.all(16.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          AppBodyText(longText, textAlign: TextAlign.left),
+          SizedBox(height: 16),
+          AppBodyText(longText, textAlign: TextAlign.center),
+          SizedBox(height: 16),
+          AppBodyText(longText, textAlign: TextAlign.right),
+        ],
+      ),
+    ),
+  );
+}
+
+/// Interactive playground for [AppBodyText] widget.
+///
+/// Allows real-time testing of all component properties.
+@widgetbook.UseCase(name: 'Interactive Playground', type: AppBodyText)
+Widget interactivePlayground(BuildContext context) {
+  final variant = context.knobs.object.dropdown(
+    label: 'Variant',
+    options: const ['large', 'medium', 'small'],
+    labelBuilder: (value) => value,
+  );
+
+  final text = context.knobs.string(
+    label: 'Text',
+    initialValue: 'This is body text for your content.',
+  );
+
+  final colorOption = context.knobs.object.dropdown(
+    label: 'Color',
+    options: const [
+      'default',
+      'primary',
+      'secondary',
+      'error',
+      'onSurfaceVariant',
+    ],
+    labelBuilder: (value) => value,
+  );
+
+  final colorScheme = Theme.of(context).colorScheme;
+  final color = switch (colorOption) {
+    'primary' => colorScheme.primary,
+    'secondary' => colorScheme.secondary,
+    'error' => colorScheme.error,
+    'onSurfaceVariant' => colorScheme.onSurfaceVariant,
+    _ => null, // default uses theme's onSurface
+  };
+
+  final fontWeight = context.knobs.object.dropdown(
+    label: 'Font Weight',
+    options: const ['regular', 'bold'],
+    labelBuilder: (value) => value,
+  );
+
+  final textAlign = context.knobs.object.dropdown(
+    label: 'Text Align',
+    options: const ['left', 'center', 'right'],
+    labelBuilder: (value) => value,
+  );
+
+  final maxLinesEnabled = context.knobs.boolean(
+    label: 'Max Lines Enabled',
+    initialValue: false,
+  );
+
+  final maxLines = maxLinesEnabled
+      ? context.knobs.int.slider(
+          label: 'Max Lines',
+          initialValue: 2,
+          min: 1,
+          max: 5,
+        )
+      : null;
+
+  final overflow = maxLinesEnabled
+      ? context.knobs.object.dropdown(
+          label: 'Overflow',
+          options: const ['clip', 'ellipsis'],
+          labelBuilder: (value) => value,
+        )
+      : 'clip';
+
+  final weight = fontWeight == 'bold' ? FontWeight.bold : FontWeight.normal;
+
+  final alignment = switch (textAlign) {
+    'center' => TextAlign.center,
+    'right' => TextAlign.right,
+    _ => TextAlign.left,
+  };
+
+  final overflowValue = switch (overflow) {
+    'ellipsis' => TextOverflow.ellipsis,
+    _ => TextOverflow.clip,
+  };
+
+  final widget = switch (variant) {
+    'medium' => AppBodyText.medium(
+      text,
+      color: color,
+      fontWeight: weight,
+      textAlign: alignment,
+      maxLines: maxLines,
+      overflow: overflowValue,
+    ),
+    'small' => AppBodyText.small(
+      text,
+      color: color,
+      fontWeight: weight,
+      textAlign: alignment,
+      maxLines: maxLines,
+      overflow: overflowValue,
+    ),
+    _ => AppBodyText.large(
+      text,
+      color: color,
+      fontWeight: weight,
+      textAlign: alignment,
+      maxLines: maxLines,
+      overflow: overflowValue,
+    ),
+  };
+
+  return Center(
+    child: Padding(padding: const EdgeInsets.all(16.0), child: widget),
+  );
+}


### PR DESCRIPTION
# Pull Request

## 📄 Summary

This pull request introduces a new reusable `AppBodyText` widget for consistent Material Design 3 body text styling across the app. It provides multiple variants (large, medium, small), supports customization (color, weight, alignment, overflow, etc.), and is thoroughly documented and tested. Additionally, comprehensive Widgetbook stories are added to demonstrate and interactively test all features.

The most important changes are:

**New Widget Implementation and Documentation**
- Introduced the `AppBodyText` widget in `app_body_text.dart`, supporting large, medium, and small variants, with extensive API documentation, customization options, and usage examples.

**Testing**
- Added a full test suite in `app_body_text_test.dart` covering rendering, variant styles, property overrides, and combinations of features to ensure reliability and correct behavior.

**Storybook/Widgetbook Integration**
- Created Widgetbook stories in `app_body_text_stories.dart` to showcase all variants, color and weight customizations, overflow handling, text alignment, and an interactive playground for live property adjustments.

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Packages (packages/*)
- [x] Widgetbook Kit (widgetbook_kit/)
- [ ] Documentation (docs/)
- [ ] CI / Infra (.github/)

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: <type>/<short-description> (e.g., feat/login-screen)
- [x] My PR title starts with one of the approved types listed above
- [x] My Dart code is formatted (dart format . or flutter format .)
- [x] I ran static analysis (flutter analyze) and resolved warnings
- [x] I ran tests successfully (flutter test)
- [x] I updated / checked pubspec.yaml and pubspec.lock for dependency changes
- [x] For UI changes, I added screenshots and/or updated golden tests (if applicable)
- [x] I linked related issues using keywords like Closes #42
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

Closes #26 

---

## 💬 Additional Notes 

### ✨ Implementation
- **Material Design 3 Typography Widget** with 3 variants (large/16sp, medium/14sp, small/12sp)
- **9 Customizable Properties**: color, fontWeight, textAlign, maxLines, overflow, softWrap, textDirection, semanticsLabel
- **MD3 Semantic Colors**: onSurface, primary, secondary, error, onSurfaceVariant
- **MD3 Compliant**: Only clip/ellipsis overflow, left/center/right alignment, max 5 lines

### 🧪 Testing & Quality
- ✅ **14 unit tests** - 100% passing
- ✅ **7 Widgetbook stories** - Interactive playground + 6 use cases
- ✅ **Zero issues** - flutter analyze clean
- ✅ **Full documentation** - Comprehensive Dartdoc with examples
- 
### 🎯 Key Features
- Default variant: **medium** (MD3 standard)
- Theme-aware: Uses `Theme.of(context).textTheme`
- Conditional knobs: Overflow only available when maxLines enabled
