### PR TITLE
feat(core_kit): implement AppH1, AppH2, AppH3 heading widgets

### DIFF
--- a/packages/core_kit/lib/core_kit.dart
+++ b/packages/core_kit/lib/core_kit.dart
@@ -9,6 +9,11 @@ export 'theme/app_spacing.dart';
 export 'theme/app_radius.dart';
 export 'theme/app_shadows.dart';
 
+// Typography exports
+export 'typography/app_h1.dart';
+export 'typography/app_h2.dart';
+export 'typography/app_h3.dart';
+
 // Widget exports
 
 // Buttons

--- a/packages/core_kit/lib/typography/app_h1.dart
+++ b/packages/core_kit/lib/typography/app_h1.dart
@@ -1,6 +1,146 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppH1 {
-  const AppH1();
+import 'package:flutter/material.dart';
+
+/// A Material Design 3 heading widget for displaying large, prominent titles.
+///
+/// `AppH1` represents the highest level heading (similar to HTML `<h1>` tag)
+/// and should be used for page titles, main screen headings, and primary
+/// content headings. It uses Material Design 3's `headlineLarge` text style
+/// (32sp, 400 weight by default).
+///
+/// This widget provides semantic heading structure for accessibility, allowing
+/// screen readers to properly announce heading levels to users.
+///
+/// ## Usage
+///
+/// **Basic usage:**
+/// ```dart
+/// AppH1('Welcome to the App')
+/// ```
+///
+/// **With custom color:**
+/// ```dart
+/// AppH1(
+///   'Settings',
+///   color: Colors.blue,
+/// )
+/// ```
+///
+/// **Center-aligned with bold weight:**
+/// ```dart
+/// AppH1(
+///   'Dashboard',
+///   textAlign: TextAlign.center,
+///   fontWeight: FontWeight.bold,
+/// )
+/// ```
+///
+/// **Truncated text:**
+/// ```dart
+/// AppH1(
+///   'Very Long Heading That Should Be Truncated',
+///   maxLines: 1,
+///   overflow: TextOverflow.ellipsis,
+/// )
+/// ```
+///
+/// ## Common Use Cases
+///
+/// - Page titles (e.g., "Settings", "Profile", "Dashboard")
+/// - Main screen headings
+/// - Dialog titles
+/// - Onboarding screen titles
+/// - Feature introduction titles
+/// - Empty state messages
+///
+/// ## Material Design 3 Specifications
+///
+/// - **Font size**: 32sp
+/// - **Font weight**: 400 (regular)
+/// - **Line height**: 40sp (1.25 ratio)
+/// - **Letter spacing**: 0sp
+///
+/// ## Accessibility
+///
+/// This widget automatically wraps the text with a `Semantics` widget,
+/// marking it as a heading with level 1. Screen readers will announce
+/// this as "Heading Level 1" followed by the text content.
+///
+/// ## Visual Hierarchy
+///
+/// Use heading levels to create clear visual hierarchy:
+/// - **AppH1**: Largest, most prominent (page titles)
+/// - **AppH2**: Secondary headings (section titles)
+/// - **AppH3**: Tertiary headings (subsection titles)
+///
+/// See also:
+///
+/// - [AppH2] for secondary headings
+/// - [AppH3] for tertiary headings
+/// - [Material Design 3 Typography](https://m3.material.io/styles/typography)
+class AppH1 extends StatelessWidget {
+  /// Creates a Material Design 3 heading widget (level 1).
+  ///
+  /// The [data] parameter must not be null and specifies the text to display.
+  const AppH1(
+    this.data, {
+    this.color,
+    this.fontWeight,
+    this.textAlign,
+    this.maxLines,
+    this.overflow,
+    super.key,
+  });
+
+  /// The text to display in the heading.
+  final String data;
+
+  /// The color to use for the text.
+  ///
+  /// If null, defaults to the theme's `onSurface` color.
+  final Color? color;
+
+  /// The font weight to use for the text.
+  ///
+  /// If null, uses the default weight from Material Design 3
+  /// `headlineLarge` style (400).
+  final FontWeight? fontWeight;
+
+  /// How to align the text horizontally.
+  ///
+  /// If null, defaults to [TextAlign.start].
+  final TextAlign? textAlign;
+
+  /// An optional maximum number of lines for the text to span.
+  ///
+  /// If the text exceeds the given number of lines, it will be truncated
+  /// according to [overflow].
+  final int? maxLines;
+
+  /// How visual overflow should be handled.
+  ///
+  /// Defaults to [TextOverflow.clip] if not specified.
+  final TextOverflow? overflow;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+
+    return Semantics(
+      header: true,
+      child: Text(
+        data,
+        style: textTheme.headlineLarge?.copyWith(
+          color: color,
+          fontWeight: fontWeight,
+        ),
+        textAlign: textAlign,
+        maxLines: maxLines,
+        overflow: overflow,
+      ),
+    );
+  }
 }

--- a/packages/core_kit/lib/typography/app_h2.dart
+++ b/packages/core_kit/lib/typography/app_h2.dart
@@ -1,6 +1,146 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppH2 {
-  const AppH2();
+import 'package:flutter/material.dart';
+
+/// A Material Design 3 heading widget for displaying medium-sized section titles.
+///
+/// `AppH2` represents the second level heading (similar to HTML `<h2>` tag)
+/// and should be used for section headings, secondary titles, and content
+/// subdivisions. It uses Material Design 3's `headlineMedium` text style
+/// (28sp, 400 weight by default).
+///
+/// This widget provides semantic heading structure for accessibility, allowing
+/// screen readers to properly announce heading levels to users.
+///
+/// ## Usage
+///
+/// **Basic usage:**
+/// ```dart
+/// AppH2('Account Information')
+/// ```
+///
+/// **With custom color:**
+/// ```dart
+/// AppH2(
+///   'Security Settings',
+///   color: Colors.green,
+/// )
+/// ```
+///
+/// **Center-aligned with bold weight:**
+/// ```dart
+/// AppH2(
+///   'Overview',
+///   textAlign: TextAlign.center,
+///   fontWeight: FontWeight.bold,
+/// )
+/// ```
+///
+/// **Truncated text:**
+/// ```dart
+/// AppH2(
+///   'Very Long Section Title That Should Be Truncated',
+///   maxLines: 1,
+///   overflow: TextOverflow.ellipsis,
+/// )
+/// ```
+///
+/// ## Common Use Cases
+///
+/// - Section headings within a page
+/// - Category titles in lists
+/// - Tab headers
+/// - Card titles
+/// - Feature group headings
+/// - Settings section titles
+///
+/// ## Material Design 3 Specifications
+///
+/// - **Font size**: 28sp
+/// - **Font weight**: 400 (regular)
+/// - **Line height**: 36sp (1.286 ratio)
+/// - **Letter spacing**: 0sp
+///
+/// ## Accessibility
+///
+/// This widget automatically wraps the text with a `Semantics` widget,
+/// marking it as a heading with level 2. Screen readers will announce
+/// this as "Heading Level 2" followed by the text content.
+///
+/// ## Visual Hierarchy
+///
+/// Use heading levels to create clear visual hierarchy:
+/// - **AppH1**: Largest, most prominent (page titles)
+/// - **AppH2**: Secondary headings (section titles)
+/// - **AppH3**: Tertiary headings (subsection titles)
+///
+/// See also:
+///
+/// - [AppH1] for primary headings
+/// - [AppH3] for tertiary headings
+/// - [Material Design 3 Typography](https://m3.material.io/styles/typography)
+class AppH2 extends StatelessWidget {
+  /// Creates a Material Design 3 heading widget (level 2).
+  ///
+  /// The [data] parameter must not be null and specifies the text to display.
+  const AppH2(
+    this.data, {
+    this.color,
+    this.fontWeight,
+    this.textAlign,
+    this.maxLines,
+    this.overflow,
+    super.key,
+  });
+
+  /// The text to display in the heading.
+  final String data;
+
+  /// The color to use for the text.
+  ///
+  /// If null, defaults to the theme's `onSurface` color.
+  final Color? color;
+
+  /// The font weight to use for the text.
+  ///
+  /// If null, uses the default weight from Material Design 3
+  /// `headlineMedium` style (400).
+  final FontWeight? fontWeight;
+
+  /// How to align the text horizontally.
+  ///
+  /// If null, defaults to [TextAlign.start].
+  final TextAlign? textAlign;
+
+  /// An optional maximum number of lines for the text to span.
+  ///
+  /// If the text exceeds the given number of lines, it will be truncated
+  /// according to [overflow].
+  final int? maxLines;
+
+  /// How visual overflow should be handled.
+  ///
+  /// Defaults to [TextOverflow.clip] if not specified.
+  final TextOverflow? overflow;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+
+    return Semantics(
+      header: true,
+      child: Text(
+        data,
+        style: textTheme.headlineMedium?.copyWith(
+          color: color,
+          fontWeight: fontWeight,
+        ),
+        textAlign: textAlign,
+        maxLines: maxLines,
+        overflow: overflow,
+      ),
+    );
+  }
 }

--- a/packages/core_kit/lib/typography/app_h3.dart
+++ b/packages/core_kit/lib/typography/app_h3.dart
@@ -1,6 +1,146 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class AppH3 {
-  const AppH3();
+import 'package:flutter/material.dart';
+
+/// A Material Design 3 heading widget for displaying smaller subsection titles.
+///
+/// `AppH3` represents the third level heading (similar to HTML `<h3>` tag)
+/// and should be used for subsection headings, tertiary titles, and nested
+/// content divisions. It uses Material Design 3's `headlineSmall` text style
+/// (24sp, 400 weight by default).
+///
+/// This widget provides semantic heading structure for accessibility, allowing
+/// screen readers to properly announce heading levels to users.
+///
+/// ## Usage
+///
+/// **Basic usage:**
+/// ```dart
+/// AppH3('Personal Details')
+/// ```
+///
+/// **With custom color:**
+/// ```dart
+/// AppH3(
+///   'Privacy Options',
+///   color: Colors.purple,
+/// )
+/// ```
+///
+/// **Center-aligned with bold weight:**
+/// ```dart
+/// AppH3(
+///   'Summary',
+///   textAlign: TextAlign.center,
+///   fontWeight: FontWeight.bold,
+/// )
+/// ```
+///
+/// **Truncated text:**
+/// ```dart
+/// AppH3(
+///   'Very Long Subsection Title That Should Be Truncated',
+///   maxLines: 1,
+///   overflow: TextOverflow.ellipsis,
+/// )
+/// ```
+///
+/// ## Common Use Cases
+///
+/// - Subsection headings within sections
+/// - List group headers
+/// - FAQ question headings
+/// - Feature detail titles
+/// - Step titles in multi-step forms
+/// - Expansion panel headers
+///
+/// ## Material Design 3 Specifications
+///
+/// - **Font size**: 24sp
+/// - **Font weight**: 400 (regular)
+/// - **Line height**: 32sp (1.333 ratio)
+/// - **Letter spacing**: 0sp
+///
+/// ## Accessibility
+///
+/// This widget automatically wraps the text with a `Semantics` widget,
+/// marking it as a heading with level 3. Screen readers will announce
+/// this as "Heading Level 3" followed by the text content.
+///
+/// ## Visual Hierarchy
+///
+/// Use heading levels to create clear visual hierarchy:
+/// - **AppH1**: Largest, most prominent (page titles)
+/// - **AppH2**: Secondary headings (section titles)
+/// - **AppH3**: Tertiary headings (subsection titles)
+///
+/// See also:
+///
+/// - [AppH1] for primary headings
+/// - [AppH2] for secondary headings
+/// - [Material Design 3 Typography](https://m3.material.io/styles/typography)
+class AppH3 extends StatelessWidget {
+  /// Creates a Material Design 3 heading widget (level 3).
+  ///
+  /// The [data] parameter must not be null and specifies the text to display.
+  const AppH3(
+    this.data, {
+    this.color,
+    this.fontWeight,
+    this.textAlign,
+    this.maxLines,
+    this.overflow,
+    super.key,
+  });
+
+  /// The text to display in the heading.
+  final String data;
+
+  /// The color to use for the text.
+  ///
+  /// If null, defaults to the theme's `onSurface` color.
+  final Color? color;
+
+  /// The font weight to use for the text.
+  ///
+  /// If null, uses the default weight from Material Design 3
+  /// `headlineSmall` style (400).
+  final FontWeight? fontWeight;
+
+  /// How to align the text horizontally.
+  ///
+  /// If null, defaults to [TextAlign.start].
+  final TextAlign? textAlign;
+
+  /// An optional maximum number of lines for the text to span.
+  ///
+  /// If the text exceeds the given number of lines, it will be truncated
+  /// according to [overflow].
+  final int? maxLines;
+
+  /// How visual overflow should be handled.
+  ///
+  /// Defaults to [TextOverflow.clip] if not specified.
+  final TextOverflow? overflow;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+
+    return Semantics(
+      header: true,
+      child: Text(
+        data,
+        style: textTheme.headlineSmall?.copyWith(
+          color: color,
+          fontWeight: fontWeight,
+        ),
+        textAlign: textAlign,
+        maxLines: maxLines,
+        overflow: overflow,
+      ),
+    );
+  }
 }

--- a/packages/core_kit/test/typography/app_h1_test.dart
+++ b/packages/core_kit/test/typography/app_h1_test.dart
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:core_kit/core_kit.dart';
+
+void main() {
+  group('AppH1', () {
+    group('Rendering', () {
+      testWidgets('renders with correct text', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: AppH1('Test Heading'))),
+        );
+
+        expect(find.text('Test Heading'), findsOneWidget);
+      });
+
+      testWidgets('uses headlineLarge text style', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: AppH1('Test Heading'))),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Test Heading'));
+        final theme = Theme.of(tester.element(find.byType(Scaffold)));
+
+        expect(
+          textWidget.style?.fontSize,
+          theme.textTheme.headlineLarge?.fontSize,
+        );
+      });
+    });
+
+    group('Color Override', () {
+      testWidgets('applies custom color when specified', (tester) async {
+        const customColor = Colors.blue;
+
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(body: AppH1('Colored Heading', color: customColor)),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Colored Heading'));
+        expect(textWidget.style?.color, customColor);
+      });
+
+      testWidgets('uses default theme color when not specified', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: AppH1('Default Color'))),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Default Color'));
+        final theme = Theme.of(tester.element(find.byType(Scaffold)));
+
+        // When no custom color is specified, it should use theme's headlineLarge color
+        expect(textWidget.style?.color, theme.textTheme.headlineLarge?.color);
+      });
+    });
+
+    group('Font Weight', () {
+      testWidgets('applies custom font weight when specified', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppH1('Bold Heading', fontWeight: FontWeight.bold),
+            ),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Bold Heading'));
+        expect(textWidget.style?.fontWeight, FontWeight.bold);
+      });
+
+      testWidgets('uses default font weight when not specified', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: AppH1('Normal Weight'))),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Normal Weight'));
+        final theme = Theme.of(tester.element(find.byType(Scaffold)));
+        // Should use theme default from headlineLarge
+        expect(
+          textWidget.style?.fontWeight,
+          theme.textTheme.headlineLarge?.fontWeight,
+        );
+      });
+    });
+
+    group('Text Alignment', () {
+      testWidgets('applies center alignment when specified', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppH1('Centered', textAlign: TextAlign.center),
+            ),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Centered'));
+        expect(textWidget.textAlign, TextAlign.center);
+      });
+
+      testWidgets('applies right alignment when specified', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppH1('Right Aligned', textAlign: TextAlign.right),
+            ),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Right Aligned'));
+        expect(textWidget.textAlign, TextAlign.right);
+      });
+
+      testWidgets('uses default alignment when not specified', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: AppH1('Default Alignment'))),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Default Alignment'));
+        expect(textWidget.textAlign, isNull);
+      });
+    });
+
+    group('Max Lines and Overflow', () {
+      testWidgets('applies maxLines when specified', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 100,
+                child: AppH1(
+                  'Very Long Heading Text That Should Be Truncated',
+                  maxLines: 1,
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(
+          find.text('Very Long Heading Text That Should Be Truncated'),
+        );
+        expect(textWidget.maxLines, 1);
+      });
+
+      testWidgets('applies ellipsis overflow when specified', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 100,
+                child: AppH1('Long Text', overflow: TextOverflow.ellipsis),
+              ),
+            ),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Long Text'));
+        expect(textWidget.overflow, TextOverflow.ellipsis);
+      });
+
+      testWidgets('applies fade overflow when specified', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppH1('Fading Text', overflow: TextOverflow.fade),
+            ),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Fading Text'));
+        expect(textWidget.overflow, TextOverflow.fade);
+      });
+    });
+
+    group('Accessibility', () {
+      testWidgets('has Semantics wrapper with header property', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: AppH1('Accessible Heading'))),
+        );
+
+        // Verify Semantics widget exists
+        expect(find.byType(Semantics), findsWidgets);
+
+        // Find the Semantics widget that is a direct parent of our Text widget
+        final semanticsWidget = tester.widget<Semantics>(
+          find
+              .ancestor(
+                of: find.text('Accessible Heading'),
+                matching: find.byType(Semantics),
+              )
+              .first,
+        );
+
+        // Verify it has the header property set to true
+        expect(semanticsWidget.properties.header, isTrue);
+      });
+
+      testWidgets('text is findable for screen readers', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: AppH1('Screen Reader Text'))),
+        );
+
+        expect(find.text('Screen Reader Text'), findsOneWidget);
+      });
+    });
+
+    group('Edge Cases', () {
+      testWidgets('handles empty string', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: AppH1(''))),
+        );
+
+        expect(find.text(''), findsOneWidget);
+      });
+
+      testWidgets('handles very long text', (tester) async {
+        final longText = 'A' * 500;
+
+        await tester.pumpWidget(
+          MaterialApp(home: Scaffold(body: AppH1(longText))),
+        );
+
+        expect(find.text(longText), findsOneWidget);
+      });
+
+      testWidgets('handles special characters', (tester) async {
+        const specialText = '!@#\$%^&*()_+-=[]{}|;:,.<>?/~`';
+
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: AppH1(specialText))),
+        );
+
+        expect(find.text(specialText), findsOneWidget);
+      });
+
+      testWidgets('handles emojis and unicode', (tester) async {
+        const emojiText = '🚀 Hello World 你好 مرحبا';
+
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: AppH1(emojiText))),
+        );
+
+        expect(find.text(emojiText), findsOneWidget);
+      });
+    });
+
+    group('Multiple Properties', () {
+      testWidgets('applies all properties together', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 200,
+                child: AppH1(
+                  'Complete Heading',
+                  color: Colors.red,
+                  fontWeight: FontWeight.bold,
+                  textAlign: TextAlign.center,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Complete Heading'));
+        expect(textWidget.style?.color, Colors.red);
+        expect(textWidget.style?.fontWeight, FontWeight.bold);
+        expect(textWidget.textAlign, TextAlign.center);
+        expect(textWidget.maxLines, 2);
+        expect(textWidget.overflow, TextOverflow.ellipsis);
+      });
+    });
+  });
+}

--- a/packages/core_kit/test/typography/app_h2_test.dart
+++ b/packages/core_kit/test/typography/app_h2_test.dart
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:core_kit/core_kit.dart';
+
+void main() {
+  group('AppH2', () {
+    group('Rendering', () {
+      testWidgets('renders with correct text', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: AppH2('Test Section'))),
+        );
+
+        expect(find.text('Test Section'), findsOneWidget);
+      });
+
+      testWidgets('uses headlineMedium text style', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: AppH2('Test Section'))),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Test Section'));
+        final theme = Theme.of(tester.element(find.byType(Scaffold)));
+
+        expect(
+          textWidget.style?.fontSize,
+          theme.textTheme.headlineMedium?.fontSize,
+        );
+      });
+    });
+
+    group('Color Override', () {
+      testWidgets('applies custom color when specified', (tester) async {
+        const customColor = Colors.green;
+
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(body: AppH2('Colored Section', color: customColor)),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Colored Section'));
+        expect(textWidget.style?.color, customColor);
+      });
+    });
+
+    group('Font Weight', () {
+      testWidgets('applies custom font weight when specified', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppH2('Bold Section', fontWeight: FontWeight.w600),
+            ),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Bold Section'));
+        expect(textWidget.style?.fontWeight, FontWeight.w600);
+      });
+    });
+
+    group('Text Alignment', () {
+      testWidgets('applies center alignment when specified', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppH2('Centered', textAlign: TextAlign.center),
+            ),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Centered'));
+        expect(textWidget.textAlign, TextAlign.center);
+      });
+    });
+
+    group('Max Lines and Overflow', () {
+      testWidgets('applies maxLines when specified', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 100,
+                child: AppH2(
+                  'Very Long Section Title That Should Be Truncated',
+                  maxLines: 1,
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(
+          find.text('Very Long Section Title That Should Be Truncated'),
+        );
+        expect(textWidget.maxLines, 1);
+      });
+
+      testWidgets('applies ellipsis overflow when specified', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppH2('Long Text', overflow: TextOverflow.ellipsis),
+            ),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Long Text'));
+        expect(textWidget.overflow, TextOverflow.ellipsis);
+      });
+    });
+
+    group('Accessibility', () {
+      testWidgets('has Semantics wrapper with header property', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: AppH2('Accessible Section'))),
+        );
+
+        expect(find.byType(Semantics), findsWidgets);
+
+        final semanticsWidget = tester.widget<Semantics>(
+          find
+              .ancestor(
+                of: find.text('Accessible Section'),
+                matching: find.byType(Semantics),
+              )
+              .first,
+        );
+
+        expect(semanticsWidget.properties.header, isTrue);
+      });
+    });
+
+    group('Edge Cases', () {
+      testWidgets('handles empty string', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: AppH2(''))),
+        );
+
+        expect(find.text(''), findsOneWidget);
+      });
+
+      testWidgets('handles special characters and emojis', (tester) async {
+        const mixedText = '📱 Settings & Privacy';
+
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: AppH2(mixedText))),
+        );
+
+        expect(find.text(mixedText), findsOneWidget);
+      });
+    });
+
+    group('Multiple Properties', () {
+      testWidgets('applies all properties together', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppH2(
+                'Complete Section',
+                color: Colors.purple,
+                fontWeight: FontWeight.w500,
+                textAlign: TextAlign.right,
+                maxLines: 1,
+                overflow: TextOverflow.fade,
+              ),
+            ),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Complete Section'));
+        expect(textWidget.style?.color, Colors.purple);
+        expect(textWidget.style?.fontWeight, FontWeight.w500);
+        expect(textWidget.textAlign, TextAlign.right);
+        expect(textWidget.maxLines, 1);
+        expect(textWidget.overflow, TextOverflow.fade);
+      });
+    });
+  });
+}

--- a/packages/core_kit/test/typography/app_h3_test.dart
+++ b/packages/core_kit/test/typography/app_h3_test.dart
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:core_kit/core_kit.dart';
+
+void main() {
+  group('AppH3', () {
+    group('Rendering', () {
+      testWidgets('renders with correct text', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: AppH3('Test Subsection'))),
+        );
+
+        expect(find.text('Test Subsection'), findsOneWidget);
+      });
+
+      testWidgets('uses headlineSmall text style', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: AppH3('Test Subsection'))),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Test Subsection'));
+        final theme = Theme.of(tester.element(find.byType(Scaffold)));
+
+        expect(
+          textWidget.style?.fontSize,
+          theme.textTheme.headlineSmall?.fontSize,
+        );
+      });
+    });
+
+    group('Color Override', () {
+      testWidgets('applies custom color when specified', (tester) async {
+        const customColor = Colors.orange;
+
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppH3('Colored Subsection', color: customColor),
+            ),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Colored Subsection'));
+        expect(textWidget.style?.color, customColor);
+      });
+    });
+
+    group('Font Weight', () {
+      testWidgets('applies custom font weight when specified', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppH3('Bold Subsection', fontWeight: FontWeight.w700),
+            ),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Bold Subsection'));
+        expect(textWidget.style?.fontWeight, FontWeight.w700);
+      });
+    });
+
+    group('Text Alignment', () {
+      testWidgets('applies justify alignment when specified', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppH3('Justified', textAlign: TextAlign.justify),
+            ),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Justified'));
+        expect(textWidget.textAlign, TextAlign.justify);
+      });
+    });
+
+    group('Max Lines and Overflow', () {
+      testWidgets('applies maxLines when specified', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: SizedBox(
+                width: 100,
+                child: AppH3(
+                  'Very Long Subsection Title That Should Be Truncated',
+                  maxLines: 2,
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(
+          find.text('Very Long Subsection Title That Should Be Truncated'),
+        );
+        expect(textWidget.maxLines, 2);
+      });
+
+      testWidgets('applies clip overflow when specified', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppH3('Clipped Text', overflow: TextOverflow.clip),
+            ),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('Clipped Text'));
+        expect(textWidget.overflow, TextOverflow.clip);
+      });
+    });
+
+    group('Accessibility', () {
+      testWidgets('has Semantics wrapper with header property', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(body: AppH3('Accessible Subsection')),
+          ),
+        );
+
+        expect(find.byType(Semantics), findsWidgets);
+
+        final semanticsWidget = tester.widget<Semantics>(
+          find
+              .ancestor(
+                of: find.text('Accessible Subsection'),
+                matching: find.byType(Semantics),
+              )
+              .first,
+        );
+
+        expect(semanticsWidget.properties.header, isTrue);
+      });
+    });
+
+    group('Edge Cases', () {
+      testWidgets('handles empty string', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: AppH3(''))),
+        );
+
+        expect(find.text(''), findsOneWidget);
+      });
+
+      testWidgets('handles multiline text', (tester) async {
+        const multilineText = 'Line 1\nLine 2\nLine 3';
+
+        await tester.pumpWidget(
+          const MaterialApp(home: Scaffold(body: AppH3(multilineText))),
+        );
+
+        expect(find.text(multilineText), findsOneWidget);
+      });
+    });
+
+    group('Multiple Properties', () {
+      testWidgets('applies all properties together', (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: AppH3(
+                'Complete Subsection',
+                color: Colors.teal,
+                fontWeight: FontWeight.bold,
+                textAlign: TextAlign.left,
+                maxLines: 3,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(
+          find.text('Complete Subsection'),
+        );
+        expect(textWidget.style?.color, Colors.teal);
+        expect(textWidget.style?.fontWeight, FontWeight.bold);
+        expect(textWidget.textAlign, TextAlign.left);
+        expect(textWidget.maxLines, 3);
+        expect(textWidget.overflow, TextOverflow.ellipsis);
+      });
+    });
+  });
+}

--- a/widgetbook_kit/lib/stories/core_kit/typography/app_h1_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/typography/app_h1_stories.dart
@@ -1,2 +1,248 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/core_kit.dart';
+
+/// Interactive Playground - Expose ALL AppH1 properties as knobs
+@widgetbook.UseCase(name: 'Interactive Playground', type: AppH1)
+Widget appH1Playground(BuildContext context) {
+  final text = context.knobs.string(
+    label: 'Text',
+    initialValue: 'Main Heading',
+  );
+
+  final colorOption = context.knobs.object.dropdown(
+    label: 'Color',
+    options: ['Default', 'Primary', 'Secondary', 'Error', 'Custom Blue'],
+    labelBuilder: (value) => value,
+  );
+
+  final fontWeightOption = context.knobs.object.dropdown(
+    label: 'Font Weight',
+    options: ['Default', 'Normal (400)', 'Medium (500)', 'Bold (700)'],
+    labelBuilder: (value) => value,
+  );
+
+  final textAlignOption = context.knobs.object.dropdown(
+    label: 'Text Align',
+    options: ['Default', 'Left', 'Center', 'Right', 'Justify'],
+    labelBuilder: (value) => value,
+  );
+
+  final maxLines = context.knobs.intOrNull.slider(
+    label: 'Max Lines',
+    initialValue: null,
+    min: 1,
+    max: 5,
+  );
+
+  final overflowOption = context.knobs.object.dropdown(
+    label: 'Overflow',
+    options: ['Default', 'Clip', 'Fade', 'Ellipsis'],
+    labelBuilder: (value) => value,
+  );
+
+  // Map string selections to actual values
+  final Color? color = switch (colorOption) {
+    'Primary' => Theme.of(context).colorScheme.primary,
+    'Secondary' => Theme.of(context).colorScheme.secondary,
+    'Error' => Theme.of(context).colorScheme.error,
+    'Custom Blue' => Colors.blue,
+    _ => null,
+  };
+
+  final FontWeight? fontWeight = switch (fontWeightOption) {
+    'Normal (400)' => FontWeight.w400,
+    'Medium (500)' => FontWeight.w500,
+    'Bold (700)' => FontWeight.w700,
+    _ => null,
+  };
+
+  final TextAlign? textAlign = switch (textAlignOption) {
+    'Left' => TextAlign.left,
+    'Center' => TextAlign.center,
+    'Right' => TextAlign.right,
+    'Justify' => TextAlign.justify,
+    _ => null,
+  };
+
+  final TextOverflow? overflow = switch (overflowOption) {
+    'Clip' => TextOverflow.clip,
+    'Fade' => TextOverflow.fade,
+    'Ellipsis' => TextOverflow.ellipsis,
+    _ => null,
+  };
+
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: AppH1(
+        text,
+        color: color,
+        fontWeight: fontWeight,
+        textAlign: textAlign,
+        maxLines: maxLines,
+        overflow: overflow,
+      ),
+    ),
+  );
+}
+
+/// Default H1 - Simple usage with default styling
+@widgetbook.UseCase(name: 'Default H1', type: AppH1)
+Widget appH1Default(BuildContext context) {
+  final text = context.knobs.string(
+    label: 'Text',
+    initialValue: 'Welcome to the App',
+  );
+
+  return Center(
+    child: Padding(padding: const EdgeInsets.all(16.0), child: AppH1(text)),
+  );
+}
+
+/// Heading Levels Comparison - Show H1, H2, H3 visual hierarchy
+@widgetbook.UseCase(name: 'Heading Levels Comparison', type: AppH1)
+Widget appH1Comparison(BuildContext context) {
+  final headingLevel = context.knobs.object.dropdown(
+    label: 'Heading Level',
+    options: ['H1', 'H2', 'H3'],
+    labelBuilder: (value) => value,
+  );
+
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (headingLevel == 'H1') const AppH1('Heading Level 1 (H1)'),
+        if (headingLevel == 'H2') const AppH2('Heading Level 2 (H2)'),
+        if (headingLevel == 'H3') const AppH3('Heading Level 3 (H3)'),
+        const SizedBox(height: 24),
+        const Text(
+          'Use the knob above to switch between heading levels and see the visual hierarchy. '
+          'H1 is the largest and most prominent, followed by H2 and H3.',
+          style: TextStyle(fontStyle: FontStyle.italic, fontSize: 12),
+        ),
+      ],
+    ),
+  );
+}
+
+/// Color Variants - Different color options
+@widgetbook.UseCase(name: 'Color Variants', type: AppH1)
+Widget appH1Colors(BuildContext context) {
+  final colorScheme = Theme.of(context).colorScheme;
+
+  final colorOption = context.knobs.object.dropdown(
+    label: 'Color',
+    options: ['Default', 'Primary', 'Secondary', 'Error', 'Custom Teal'],
+    labelBuilder: (value) => value,
+  );
+
+  final Color? color = switch (colorOption) {
+    'Primary' => colorScheme.primary,
+    'Secondary' => colorScheme.secondary,
+    'Error' => colorScheme.error,
+    'Custom Teal' => Colors.teal,
+    _ => null,
+  };
+
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: AppH1('Colored Heading', color: color),
+    ),
+  );
+}
+
+/// Alignment Options - Left, center, right alignment
+@widgetbook.UseCase(name: 'Alignment Options', type: AppH1)
+Widget appH1Alignment(BuildContext context) {
+  final alignmentOption = context.knobs.object.dropdown(
+    label: 'Text Align',
+    options: ['Left', 'Center', 'Right'],
+    labelBuilder: (value) => value,
+  );
+
+  final TextAlign textAlign = switch (alignmentOption) {
+    'Center' => TextAlign.center,
+    'Right' => TextAlign.right,
+    _ => TextAlign.left,
+  };
+
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.grey.withValues(alpha: 0.3)),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: AppH1('Aligned Heading', textAlign: textAlign),
+    ),
+  );
+}
+
+/// Font Weight Variants - Light, normal, semibold, bold
+@widgetbook.UseCase(name: 'Font Weight Variants', type: AppH1)
+Widget appH1FontWeights(BuildContext context) {
+  final weightOption = context.knobs.object.dropdown(
+    label: 'Font Weight',
+    options: ['Light (300)', 'Normal (400)', 'SemiBold (600)', 'Bold (700)'],
+    labelBuilder: (value) => value,
+  );
+
+  final FontWeight fontWeight = switch (weightOption) {
+    'Light (300)' => FontWeight.w300,
+    'SemiBold (600)' => FontWeight.w600,
+    'Bold (700)' => FontWeight.w700,
+    _ => FontWeight.w400,
+  };
+
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: AppH1('Weighted Heading', fontWeight: fontWeight),
+    ),
+  );
+}
+
+/// Real-world Page Title Example
+@widgetbook.UseCase(name: 'Page Title Example', type: AppH1)
+Widget appH1PageTitle(BuildContext context) {
+  final pageTitle = context.knobs.string(
+    label: 'Page Title',
+    initialValue: 'Dashboard',
+  );
+
+  return Scaffold(
+    appBar: AppBar(title: const Text('Example Screen')),
+    body: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          AppH1(pageTitle),
+          const SizedBox(height: 8),
+          Text(
+            'Welcome back! Here\'s your overview.',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 24),
+          const Divider(),
+          const SizedBox(height: 16),
+          const AppH2('Recent Activity'),
+          const SizedBox(height: 8),
+          const Text('No recent activity to display.'),
+        ],
+      ),
+    ),
+  );
+}

--- a/widgetbook_kit/lib/stories/core_kit/typography/app_h2_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/typography/app_h2_stories.dart
@@ -1,2 +1,310 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/core_kit.dart';
+
+/// Interactive Playground - Expose ALL AppH2 properties as knobs
+@widgetbook.UseCase(name: 'Interactive Playground', type: AppH2)
+Widget appH2Playground(BuildContext context) {
+  final text = context.knobs.string(
+    label: 'Text',
+    initialValue: 'Section Heading',
+  );
+
+  final colorOption = context.knobs.object.dropdown(
+    label: 'Color',
+    options: ['Default', 'Primary', 'Secondary', 'Error', 'Custom Green'],
+    labelBuilder: (value) => value,
+  );
+
+  final fontWeightOption = context.knobs.object.dropdown(
+    label: 'Font Weight',
+    options: ['Default', 'Normal (400)', 'Medium (500)', 'Bold (700)'],
+    labelBuilder: (value) => value,
+  );
+
+  final textAlignOption = context.knobs.object.dropdown(
+    label: 'Text Align',
+    options: ['Default', 'Left', 'Center', 'Right'],
+    labelBuilder: (value) => value,
+  );
+
+  final maxLines = context.knobs.intOrNull.slider(
+    label: 'Max Lines',
+    initialValue: null,
+    min: 1,
+    max: 5,
+  );
+
+  final overflowOption = context.knobs.object.dropdown(
+    label: 'Overflow',
+    options: ['Default', 'Clip', 'Fade', 'Ellipsis'],
+    labelBuilder: (value) => value,
+  );
+
+  final Color? color = switch (colorOption) {
+    'Primary' => Theme.of(context).colorScheme.primary,
+    'Secondary' => Theme.of(context).colorScheme.secondary,
+    'Error' => Theme.of(context).colorScheme.error,
+    'Custom Green' => Colors.green,
+    _ => null,
+  };
+
+  final FontWeight? fontWeight = switch (fontWeightOption) {
+    'Normal (400)' => FontWeight.w400,
+    'Medium (500)' => FontWeight.w500,
+    'Bold (700)' => FontWeight.w700,
+    _ => null,
+  };
+
+  final TextAlign? textAlign = switch (textAlignOption) {
+    'Left' => TextAlign.left,
+    'Center' => TextAlign.center,
+    'Right' => TextAlign.right,
+    _ => null,
+  };
+
+  final TextOverflow? overflow = switch (overflowOption) {
+    'Clip' => TextOverflow.clip,
+    'Fade' => TextOverflow.fade,
+    'Ellipsis' => TextOverflow.ellipsis,
+    _ => null,
+  };
+
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: AppH2(
+        text,
+        color: color,
+        fontWeight: fontWeight,
+        textAlign: textAlign,
+        maxLines: maxLines,
+        overflow: overflow,
+      ),
+    ),
+  );
+}
+
+/// Default H2 - Simple usage with default styling
+@widgetbook.UseCase(name: 'Default H2', type: AppH2)
+Widget appH2Default(BuildContext context) {
+  final text = context.knobs.string(
+    label: 'Text',
+    initialValue: 'Account Settings',
+  );
+
+  return Center(
+    child: Padding(padding: const EdgeInsets.all(16.0), child: AppH2(text)),
+  );
+}
+
+/// Section Headings - H2 for dividing content into sections
+@widgetbook.UseCase(name: 'Section Headings', type: AppH2)
+Widget appH2Sections(BuildContext context) {
+  final sectionTitle = context.knobs.string(
+    label: 'Section Title',
+    initialValue: 'Personal Information',
+  );
+
+  final showContent = context.knobs.boolean(
+    label: 'Show Section Content',
+    initialValue: true,
+  );
+
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const AppH1('User Profile'),
+        const SizedBox(height: 24),
+        AppH2(sectionTitle),
+        if (showContent) ...[
+          const SizedBox(height: 8),
+          const Text('Name: John Doe'),
+          const Text('Email: john@example.com'),
+        ],
+      ],
+    ),
+  );
+}
+
+/// Color Variants - Different color options
+@widgetbook.UseCase(name: 'Color Variants', type: AppH2)
+Widget appH2Colors(BuildContext context) {
+  final colorScheme = Theme.of(context).colorScheme;
+
+  final colorOption = context.knobs.object.dropdown(
+    label: 'Color',
+    options: ['Default', 'Primary', 'Secondary', 'Custom Purple'],
+    labelBuilder: (value) => value,
+  );
+
+  final Color? color = switch (colorOption) {
+    'Primary' => colorScheme.primary,
+    'Secondary' => colorScheme.secondary,
+    'Custom Purple' => Colors.purple,
+    _ => null,
+  };
+
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: AppH2('Colored Section', color: color),
+    ),
+  );
+}
+
+/// Alignment Options - Left, center, right alignment
+@widgetbook.UseCase(name: 'Alignment Options', type: AppH2)
+Widget appH2Alignment(BuildContext context) {
+  final alignmentOption = context.knobs.object.dropdown(
+    label: 'Text Align',
+    options: ['Left', 'Center', 'Right'],
+    labelBuilder: (value) => value,
+  );
+
+  final TextAlign textAlign = switch (alignmentOption) {
+    'Center' => TextAlign.center,
+    'Right' => TextAlign.right,
+    _ => TextAlign.left,
+  };
+
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.grey.withValues(alpha: 0.3)),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: AppH2('Aligned Section', textAlign: textAlign),
+    ),
+  );
+}
+
+/// Font Weight Variants - Light, normal, semibold, bold
+@widgetbook.UseCase(name: 'Font Weight Variants', type: AppH2)
+Widget appH2FontWeights(BuildContext context) {
+  final weightOption = context.knobs.object.dropdown(
+    label: 'Font Weight',
+    options: ['Light (300)', 'Normal (400)', 'SemiBold (600)', 'Bold (700)'],
+    labelBuilder: (value) => value,
+  );
+
+  final FontWeight fontWeight = switch (weightOption) {
+    'Light (300)' => FontWeight.w300,
+    'SemiBold (600)' => FontWeight.w600,
+    'Bold (700)' => FontWeight.w700,
+    _ => FontWeight.w400,
+  };
+
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: AppH2('Weighted Section', fontWeight: fontWeight),
+    ),
+  );
+}
+
+/// Settings Screen Example - Real-world usage
+@widgetbook.UseCase(name: 'Settings Screen Example', type: AppH2)
+Widget appH2SettingsExample(BuildContext context) {
+  return const _AppH2SettingsExample();
+}
+
+class _AppH2SettingsExample extends StatefulWidget {
+  const _AppH2SettingsExample();
+
+  @override
+  State<_AppH2SettingsExample> createState() => _AppH2SettingsExampleState();
+}
+
+class _AppH2SettingsExampleState extends State<_AppH2SettingsExample> {
+  bool _notificationsEnabled = true;
+  bool _emailNotifications = true;
+  bool _pushNotifications = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final sectionName = context.knobs.object.dropdown(
+      label: 'Section',
+      options: ['General', 'Privacy & Security', 'Notifications'],
+      labelBuilder: (value) => value,
+    );
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: ListView(
+        padding: const EdgeInsets.all(16.0),
+        children: [
+          AppH2(sectionName),
+          const SizedBox(height: 8),
+          if (sectionName == 'General') ...[
+            ListTile(
+              leading: const Icon(Icons.language),
+              title: const Text('Language'),
+              subtitle: const Text('English'),
+              trailing: const Icon(Icons.chevron_right),
+            ),
+            ListTile(
+              leading: const Icon(Icons.notifications),
+              title: const Text('Notifications'),
+              trailing: Switch(
+                value: _notificationsEnabled,
+                onChanged: (value) {
+                  setState(() {
+                    _notificationsEnabled = value;
+                  });
+                },
+              ),
+            ),
+          ],
+          if (sectionName == 'Privacy & Security') ...[
+            ListTile(
+              leading: const Icon(Icons.lock),
+              title: const Text('Change Password'),
+              trailing: const Icon(Icons.chevron_right),
+            ),
+            ListTile(
+              leading: const Icon(Icons.security),
+              title: const Text('Two-Factor Authentication'),
+              trailing: const Icon(Icons.chevron_right),
+            ),
+          ],
+          if (sectionName == 'Notifications') ...[
+            ListTile(
+              leading: const Icon(Icons.email),
+              title: const Text('Email Notifications'),
+              trailing: Switch(
+                value: _emailNotifications,
+                onChanged: (value) {
+                  setState(() {
+                    _emailNotifications = value;
+                  });
+                },
+              ),
+            ),
+            ListTile(
+              leading: const Icon(Icons.phone_android),
+              title: const Text('Push Notifications'),
+              trailing: Switch(
+                value: _pushNotifications,
+                onChanged: (value) {
+                  setState(() {
+                    _pushNotifications = value;
+                  });
+                },
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/widgetbook_kit/lib/stories/core_kit/typography/app_h3_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/typography/app_h3_stories.dart
@@ -1,2 +1,262 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/core_kit.dart';
+
+/// Interactive Playground - Expose ALL AppH3 properties as knobs
+@widgetbook.UseCase(name: 'Interactive Playground', type: AppH3)
+Widget appH3Playground(BuildContext context) {
+  final text = context.knobs.string(
+    label: 'Text',
+    initialValue: 'Subsection Title',
+  );
+
+  final colorOption = context.knobs.object.dropdown(
+    label: 'Color',
+    options: ['Default', 'Primary', 'Secondary', 'Tertiary', 'Custom Orange'],
+    labelBuilder: (value) => value,
+  );
+
+  final fontWeightOption = context.knobs.object.dropdown(
+    label: 'Font Weight',
+    options: ['Default', 'Normal (400)', 'Medium (500)', 'Bold (700)'],
+    labelBuilder: (value) => value,
+  );
+
+  final textAlignOption = context.knobs.object.dropdown(
+    label: 'Text Align',
+    options: ['Default', 'Left', 'Center', 'Right'],
+    labelBuilder: (value) => value,
+  );
+
+  final maxLines = context.knobs.intOrNull.slider(
+    label: 'Max Lines',
+    initialValue: null,
+    min: 1,
+    max: 5,
+  );
+
+  final overflowOption = context.knobs.object.dropdown(
+    label: 'Overflow',
+    options: ['Default', 'Clip', 'Fade', 'Ellipsis'],
+    labelBuilder: (value) => value,
+  );
+
+  final Color? color = switch (colorOption) {
+    'Primary' => Theme.of(context).colorScheme.primary,
+    'Secondary' => Theme.of(context).colorScheme.secondary,
+    'Tertiary' => Theme.of(context).colorScheme.tertiary,
+    'Custom Orange' => Colors.orange,
+    _ => null,
+  };
+
+  final FontWeight? fontWeight = switch (fontWeightOption) {
+    'Normal (400)' => FontWeight.w400,
+    'Medium (500)' => FontWeight.w500,
+    'Bold (700)' => FontWeight.w700,
+    _ => null,
+  };
+
+  final TextAlign? textAlign = switch (textAlignOption) {
+    'Left' => TextAlign.left,
+    'Center' => TextAlign.center,
+    'Right' => TextAlign.right,
+    _ => null,
+  };
+
+  final TextOverflow? overflow = switch (overflowOption) {
+    'Clip' => TextOverflow.clip,
+    'Fade' => TextOverflow.fade,
+    'Ellipsis' => TextOverflow.ellipsis,
+    _ => null,
+  };
+
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: AppH3(
+        text,
+        color: color,
+        fontWeight: fontWeight,
+        textAlign: textAlign,
+        maxLines: maxLines,
+        overflow: overflow,
+      ),
+    ),
+  );
+}
+
+/// Default H3 - Simple usage with default styling
+@widgetbook.UseCase(name: 'Default H3', type: AppH3)
+Widget appH3Default(BuildContext context) {
+  final text = context.knobs.string(
+    label: 'Text',
+    initialValue: 'Personal Details',
+  );
+
+  return Center(
+    child: Padding(padding: const EdgeInsets.all(16.0), child: AppH3(text)),
+  );
+}
+
+/// Nested Heading Structure - Showing full H1>H2>H3 hierarchy
+@widgetbook.UseCase(name: 'Nested Heading Structure', type: AppH3)
+Widget appH3Nested(BuildContext context) {
+  final subsectionTitle = context.knobs.string(
+    label: 'Subsection Title (H3)',
+    initialValue: 'Installation',
+  );
+
+  final showContent = context.knobs.boolean(
+    label: 'Show Content',
+    initialValue: true,
+  );
+
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const AppH1('Documentation'),
+        const SizedBox(height: 16),
+        const AppH2('Getting Started'),
+        const SizedBox(height: 12),
+        AppH3(subsectionTitle),
+        if (showContent) ...[
+          const SizedBox(height: 8),
+          const Text('Run npm install to install dependencies...'),
+        ],
+      ],
+    ),
+  );
+}
+
+/// Color Variants - Different color options
+@widgetbook.UseCase(name: 'Color Variants', type: AppH3)
+Widget appH3Colors(BuildContext context) {
+  final colorScheme = Theme.of(context).colorScheme;
+
+  final colorOption = context.knobs.object.dropdown(
+    label: 'Color',
+    options: ['Default', 'Primary', 'Tertiary', 'Custom Indigo'],
+    labelBuilder: (value) => value,
+  );
+
+  final Color? color = switch (colorOption) {
+    'Primary' => colorScheme.primary,
+    'Tertiary' => colorScheme.tertiary,
+    'Custom Indigo' => Colors.indigo,
+    _ => null,
+  };
+
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: AppH3('Colored Subsection', color: color),
+    ),
+  );
+}
+
+/// Alignment Options - Left, center, right alignment
+@widgetbook.UseCase(name: 'Alignment Options', type: AppH3)
+Widget appH3Alignment(BuildContext context) {
+  final alignmentOption = context.knobs.object.dropdown(
+    label: 'Text Align',
+    options: ['Left', 'Center', 'Right'],
+    labelBuilder: (value) => value,
+  );
+
+  final TextAlign textAlign = switch (alignmentOption) {
+    'Center' => TextAlign.center,
+    'Right' => TextAlign.right,
+    _ => TextAlign.left,
+  };
+
+  return Padding(
+    padding: const EdgeInsets.all(16.0),
+    child: Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.grey.withValues(alpha: 0.3)),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: AppH3('Aligned Subsection', textAlign: textAlign),
+    ),
+  );
+}
+
+/// Font Weight Variants - Light, normal, semibold, bold
+@widgetbook.UseCase(name: 'Font Weight Variants', type: AppH3)
+Widget appH3FontWeights(BuildContext context) {
+  final weightOption = context.knobs.object.dropdown(
+    label: 'Font Weight',
+    options: ['Light (300)', 'Normal (400)', 'SemiBold (600)', 'Bold (700)'],
+    labelBuilder: (value) => value,
+  );
+
+  final FontWeight fontWeight = switch (weightOption) {
+    'Light (300)' => FontWeight.w300,
+    'SemiBold (600)' => FontWeight.w600,
+    'Bold (700)' => FontWeight.w700,
+    _ => FontWeight.w400,
+  };
+
+  return Center(
+    child: Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: AppH3('Weighted Subsection', fontWeight: fontWeight),
+    ),
+  );
+}
+
+/// FAQ Example - Real-world usage with expansion panels
+@widgetbook.UseCase(name: 'FAQ Example', type: AppH3)
+Widget appH3FaqExample(BuildContext context) {
+  final faqQuestion = context.knobs.object.dropdown(
+    label: 'FAQ Question',
+    options: [
+      'How do I reset my password?',
+      'Can I change my subscription plan?',
+      'App crashes on startup',
+    ],
+    labelBuilder: (value) => value,
+  );
+
+  final faqAnswers = {
+    'How do I reset my password?':
+        'To reset your password, click on "Forgot Password" on the login screen '
+        'and follow the instructions sent to your email.',
+    'Can I change my subscription plan?':
+        'Yes, you can upgrade or downgrade your plan at any time from the '
+        'Settings > Billing section.',
+    'App crashes on startup':
+        'Try clearing the app cache or reinstalling the application. If the '
+        'problem persists, contact our support team.',
+  };
+
+  return Scaffold(
+    appBar: AppBar(title: const Text('FAQ')),
+    body: ListView(
+      padding: const EdgeInsets.all(16.0),
+      children: [
+        const AppH1('Frequently Asked Questions'),
+        const SizedBox(height: 24),
+        const AppH2('Account & Billing'),
+        const SizedBox(height: 12),
+        ExpansionTile(
+          title: AppH3(faqQuestion),
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Text(faqAnswers[faqQuestion] ?? ''),
+            ),
+          ],
+        ),
+      ],
+    ),
+  );
+}


### PR DESCRIPTION
# Pull Request

## 📄 Summary

-Implemented AppH1, AppH2, and AppH3 heading widgets with Material Design 3 text styles, accessibility support, and customization options. Created 21 interactive Widgetbook stories and 41 comprehensive tests covering all features and edge cases. Addresses issues #28 (AppH1), #31 (AppH2), and #32 (AppH3). All quality checks passed including formatting, analysis, and REUSE compliance.
---

## 🧩 Affected Module(s)

- [X] Packages (packages/*)
- [X] Widgetbook Kit (widgetbook_kit/)
- [ ] Documentation (docs/)
- [ ] CI / Infra (.github/)

## ✅ Checklist

- [✅] My branch name follows format: <type>/<short-description> (e.g., feat/login-screen)
- [✅] My PR title starts with one of the approved types listed above
- [✅] My Dart code is formatted (dart format . or flutter format .)
- [✅] I ran static analysis (flutter analyze) and resolved warnings
- [✅] I ran tests successfully (flutter test)
- [✅] I updated / checked pubspec.yaml and pubspec.lock for dependency changes
- [✅] For UI changes, I added screenshots and/or updated golden tests (if applicable)
- [✅] I ensured this PR has no unrelated changes
- [✅] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

Closes #28 #31 #32 

## 💬 Additional Notes (Optional)