### PR TITLE
feat(core-kit): implement ResponsivePadding layout widget with Widgetbook stories

### DIFF
--- a/packages/core_kit/lib/core_kit.dart
+++ b/packages/core_kit/lib/core_kit.dart
@@ -9,6 +9,10 @@ export 'theme/app_spacing.dart';
 export 'theme/app_radius.dart';
 export 'theme/app_shadows.dart';
 
+// Layout exports
+export 'layout/gap.dart';
+export 'layout/responsive_padding.dart';
+
 // Widget exports
 
 // Buttons

--- a/packages/core_kit/lib/layout/responsive_padding.dart
+++ b/packages/core_kit/lib/layout/responsive_padding.dart
@@ -1,6 +1,316 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
-class ResponsivePadding {
-  const ResponsivePadding();
+import 'package:flutter/widgets.dart';
+
+import '../theme/app_spacing.dart';
+
+/// Breakpoint values for responsive design following Material Design 3.
+///
+/// These values correspond to Material Design 3 window size classes:
+/// - Compact: < 600dp (mobile)
+/// - Medium: 600-839dp (tablet portrait, small tablet)
+/// - Expanded: >= 840dp (tablet landscape, desktop)
+///
+/// We use slightly different values as specified in Issue #39:
+/// - Mobile: < 600dp
+/// - Tablet: 600-1023dp
+/// - Desktop: >= 1024dp
+class ResponsiveBreakpoints {
+  const ResponsiveBreakpoints._();
+
+  /// Default mobile breakpoint width (< 600dp)
+  static const double mobile = 600.0;
+
+  /// Default tablet breakpoint width (< 1024dp)
+  static const double tablet = 1024.0;
+}
+
+/// A widget that provides adaptive padding based on screen size breakpoints.
+///
+/// [ResponsivePadding] automatically adjusts padding values based on the
+/// current screen width, using breakpoints for mobile, tablet, and desktop.
+///
+/// This widget is useful for:
+/// - Page edge padding that adapts to screen size
+/// - Card content padding that varies by device
+/// - Section spacing that respects device form factor
+/// - Form field margins that scale appropriately
+///
+/// ## Breakpoint Detection
+///
+/// The widget uses the following default breakpoints:
+/// - **Mobile**: width < 600dp
+/// - **Tablet**: 600dp <= width < 1024dp
+/// - **Desktop**: width >= 1024dp
+///
+/// You can customize these breakpoints using [mobileBreakpoint] and
+/// [tabletBreakpoint] parameters.
+///
+/// ## Example
+///
+/// ```dart
+/// ResponsivePadding(
+///   mobilePadding: EdgeInsets.all(AppSpacing.sm),
+///   tabletPadding: EdgeInsets.all(AppSpacing.md),
+///   desktopPadding: EdgeInsets.all(AppSpacing.lg),
+///   child: MyContent(),
+/// )
+/// ```
+///
+/// ## Named Constructors
+///
+/// For convenience, several named constructors are provided:
+/// - [ResponsivePadding.all] - Same padding for all sides per breakpoint
+/// - [ResponsivePadding.symmetric] - Horizontal/vertical padding per breakpoint
+/// - [ResponsivePadding.horizontal] - Only horizontal padding per breakpoint
+/// - [ResponsivePadding.vertical] - Only vertical padding per breakpoint
+class ResponsivePadding extends StatelessWidget {
+  /// Creates a responsive padding widget.
+  ///
+  /// The [child] parameter is required.
+  ///
+  /// Padding values are applied based on the current screen breakpoint:
+  /// - [mobilePadding] for screens smaller than [mobileBreakpoint]
+  /// - [tabletPadding] for screens between [mobileBreakpoint] and [tabletBreakpoint]
+  /// - [desktopPadding] for screens larger than or equal to [tabletBreakpoint]
+  ///
+  /// If a specific breakpoint padding is null, [padding] is used as fallback.
+  /// If [padding] is also null, [EdgeInsets.zero] is used.
+  const ResponsivePadding({
+    required this.child,
+    this.padding,
+    this.mobilePadding,
+    this.tabletPadding,
+    this.desktopPadding,
+    this.mobileBreakpoint = ResponsiveBreakpoints.mobile,
+    this.tabletBreakpoint = ResponsiveBreakpoints.tablet,
+    super.key,
+  });
+
+  /// Creates responsive padding with the same value for all sides.
+  ///
+  /// Uses [AppSpacing] values for consistent Material Design 3 spacing.
+  ///
+  /// Example:
+  /// ```dart
+  /// ResponsivePadding.all(
+  ///   mobile: AppSpacing.sm,
+  ///   tablet: AppSpacing.md,
+  ///   desktop: AppSpacing.lg,
+  ///   child: Content(),
+  /// )
+  /// ```
+  factory ResponsivePadding.all({
+    required Widget child,
+    double mobile = AppSpacing.sm,
+    double tablet = AppSpacing.md,
+    double desktop = AppSpacing.lg,
+    double mobileBreakpoint = ResponsiveBreakpoints.mobile,
+    double tabletBreakpoint = ResponsiveBreakpoints.tablet,
+    Key? key,
+  }) {
+    return ResponsivePadding(
+      key: key,
+      mobilePadding: EdgeInsets.all(mobile),
+      tabletPadding: EdgeInsets.all(tablet),
+      desktopPadding: EdgeInsets.all(desktop),
+      mobileBreakpoint: mobileBreakpoint,
+      tabletBreakpoint: tabletBreakpoint,
+      child: child,
+    );
+  }
+
+  /// Creates responsive padding with symmetric horizontal and vertical values.
+  ///
+  /// Example:
+  /// ```dart
+  /// ResponsivePadding.symmetric(
+  ///   mobileHorizontal: AppSpacing.sm,
+  ///   mobileVertical: AppSpacing.xs,
+  ///   tabletHorizontal: AppSpacing.md,
+  ///   tabletVertical: AppSpacing.sm,
+  ///   desktopHorizontal: AppSpacing.lg,
+  ///   desktopVertical: AppSpacing.md,
+  ///   child: Content(),
+  /// )
+  /// ```
+  factory ResponsivePadding.symmetric({
+    required Widget child,
+    double mobileHorizontal = AppSpacing.sm,
+    double mobileVertical = AppSpacing.xs,
+    double tabletHorizontal = AppSpacing.md,
+    double tabletVertical = AppSpacing.sm,
+    double desktopHorizontal = AppSpacing.lg,
+    double desktopVertical = AppSpacing.md,
+    double mobileBreakpoint = ResponsiveBreakpoints.mobile,
+    double tabletBreakpoint = ResponsiveBreakpoints.tablet,
+    Key? key,
+  }) {
+    return ResponsivePadding(
+      key: key,
+      mobilePadding: EdgeInsets.symmetric(
+        horizontal: mobileHorizontal,
+        vertical: mobileVertical,
+      ),
+      tabletPadding: EdgeInsets.symmetric(
+        horizontal: tabletHorizontal,
+        vertical: tabletVertical,
+      ),
+      desktopPadding: EdgeInsets.symmetric(
+        horizontal: desktopHorizontal,
+        vertical: desktopVertical,
+      ),
+      mobileBreakpoint: mobileBreakpoint,
+      tabletBreakpoint: tabletBreakpoint,
+      child: child,
+    );
+  }
+
+  /// Creates responsive padding for horizontal sides only.
+  ///
+  /// Useful for page edge padding that only applies to left and right.
+  ///
+  /// Example:
+  /// ```dart
+  /// ResponsivePadding.horizontal(
+  ///   mobile: AppSpacing.md,
+  ///   tablet: AppSpacing.lg,
+  ///   desktop: AppSpacing.xl,
+  ///   child: PageContent(),
+  /// )
+  /// ```
+  factory ResponsivePadding.horizontal({
+    required Widget child,
+    double mobile = AppSpacing.md,
+    double tablet = AppSpacing.lg,
+    double desktop = AppSpacing.xl,
+    double mobileBreakpoint = ResponsiveBreakpoints.mobile,
+    double tabletBreakpoint = ResponsiveBreakpoints.tablet,
+    Key? key,
+  }) {
+    return ResponsivePadding(
+      key: key,
+      mobilePadding: EdgeInsets.symmetric(horizontal: mobile),
+      tabletPadding: EdgeInsets.symmetric(horizontal: tablet),
+      desktopPadding: EdgeInsets.symmetric(horizontal: desktop),
+      mobileBreakpoint: mobileBreakpoint,
+      tabletBreakpoint: tabletBreakpoint,
+      child: child,
+    );
+  }
+
+  /// Creates responsive padding for vertical sides only.
+  ///
+  /// Useful for content spacing that only applies to top and bottom.
+  ///
+  /// Example:
+  /// ```dart
+  /// ResponsivePadding.vertical(
+  ///   mobile: AppSpacing.sm,
+  ///   tablet: AppSpacing.md,
+  ///   desktop: AppSpacing.lg,
+  ///   child: SectionContent(),
+  /// )
+  /// ```
+  factory ResponsivePadding.vertical({
+    required Widget child,
+    double mobile = AppSpacing.sm,
+    double tablet = AppSpacing.md,
+    double desktop = AppSpacing.lg,
+    double mobileBreakpoint = ResponsiveBreakpoints.mobile,
+    double tabletBreakpoint = ResponsiveBreakpoints.tablet,
+    Key? key,
+  }) {
+    return ResponsivePadding(
+      key: key,
+      mobilePadding: EdgeInsets.symmetric(vertical: mobile),
+      tabletPadding: EdgeInsets.symmetric(vertical: tablet),
+      desktopPadding: EdgeInsets.symmetric(vertical: desktop),
+      mobileBreakpoint: mobileBreakpoint,
+      tabletBreakpoint: tabletBreakpoint,
+      child: child,
+    );
+  }
+
+  /// The widget to wrap with responsive padding.
+  final Widget child;
+
+  /// Fallback padding when specific breakpoint padding is not provided.
+  ///
+  /// If null and no breakpoint-specific padding is set, [EdgeInsets.zero]
+  /// is used.
+  final EdgeInsetsGeometry? padding;
+
+  /// Padding to apply on mobile screens (width < [mobileBreakpoint]).
+  ///
+  /// If null, falls back to [padding].
+  final EdgeInsetsGeometry? mobilePadding;
+
+  /// Padding to apply on tablet screens
+  /// ([mobileBreakpoint] <= width < [tabletBreakpoint]).
+  ///
+  /// If null, falls back to [padding].
+  final EdgeInsetsGeometry? tabletPadding;
+
+  /// Padding to apply on desktop screens (width >= [tabletBreakpoint]).
+  ///
+  /// If null, falls back to [padding].
+  final EdgeInsetsGeometry? desktopPadding;
+
+  /// The width threshold for mobile devices.
+  ///
+  /// Screens with width less than this value are considered mobile.
+  /// Defaults to [ResponsiveBreakpoints.mobile] (600dp).
+  final double mobileBreakpoint;
+
+  /// The width threshold for tablet devices.
+  ///
+  /// Screens with width greater than or equal to this value are considered
+  /// desktop. Screens between [mobileBreakpoint] and this value are tablet.
+  /// Defaults to [ResponsiveBreakpoints.tablet] (1024dp).
+  final double tabletBreakpoint;
+
+  /// Determines the current device type based on screen width.
+  DeviceType _getDeviceType(double width) {
+    if (width < mobileBreakpoint) {
+      return DeviceType.mobile;
+    } else if (width < tabletBreakpoint) {
+      return DeviceType.tablet;
+    } else {
+      return DeviceType.desktop;
+    }
+  }
+
+  /// Gets the appropriate padding for the given device type.
+  EdgeInsetsGeometry _getPaddingForDevice(DeviceType deviceType) {
+    final EdgeInsetsGeometry? specificPadding = switch (deviceType) {
+      DeviceType.mobile => mobilePadding,
+      DeviceType.tablet => tabletPadding,
+      DeviceType.desktop => desktopPadding,
+    };
+
+    return specificPadding ?? padding ?? EdgeInsets.zero;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.sizeOf(context).width;
+    final deviceType = _getDeviceType(width);
+    final effectivePadding = _getPaddingForDevice(deviceType);
+
+    return Padding(padding: effectivePadding, child: child);
+  }
+}
+
+/// Represents the device type based on screen width breakpoints.
+enum DeviceType {
+  /// Mobile device (width < 600dp by default)
+  mobile,
+
+  /// Tablet device (600dp <= width < 1024dp by default)
+  tablet,
+
+  /// Desktop device (width >= 1024dp by default)
+  desktop,
 }

--- a/packages/core_kit/test/layout/responsive_padding_test.dart
+++ b/packages/core_kit/test/layout/responsive_padding_test.dart
@@ -1,0 +1,301 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:core_kit/core_kit.dart';
+
+void main() {
+  group('ResponsivePadding', () {
+    Widget buildTestWidget({
+      required double screenWidth,
+      EdgeInsetsGeometry? padding,
+      EdgeInsetsGeometry? mobilePadding,
+      EdgeInsetsGeometry? tabletPadding,
+      EdgeInsetsGeometry? desktopPadding,
+      double mobileBreakpoint = ResponsiveBreakpoints.mobile,
+      double tabletBreakpoint = ResponsiveBreakpoints.tablet,
+    }) {
+      return MaterialApp(
+        home: MediaQuery(
+          data: MediaQueryData(size: Size(screenWidth, 800)),
+          child: ResponsivePadding(
+            padding: padding,
+            mobilePadding: mobilePadding,
+            tabletPadding: tabletPadding,
+            desktopPadding: desktopPadding,
+            mobileBreakpoint: mobileBreakpoint,
+            tabletBreakpoint: tabletBreakpoint,
+            child: const Text('Test Content'),
+          ),
+        ),
+      );
+    }
+
+    group('Breakpoint Detection', () {
+      testWidgets('applies mobile padding for width < 600', (tester) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            screenWidth: 400,
+            mobilePadding: const EdgeInsets.all(8),
+            tabletPadding: const EdgeInsets.all(16),
+            desktopPadding: const EdgeInsets.all(24),
+          ),
+        );
+
+        final padding = tester.widget<Padding>(find.byType(Padding).first);
+        expect(padding.padding, const EdgeInsets.all(8));
+      });
+
+      testWidgets('applies tablet padding for 600 <= width < 1024', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            screenWidth: 800,
+            mobilePadding: const EdgeInsets.all(8),
+            tabletPadding: const EdgeInsets.all(16),
+            desktopPadding: const EdgeInsets.all(24),
+          ),
+        );
+
+        final padding = tester.widget<Padding>(find.byType(Padding).first);
+        expect(padding.padding, const EdgeInsets.all(16));
+      });
+
+      testWidgets('applies desktop padding for width >= 1024', (tester) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            screenWidth: 1200,
+            mobilePadding: const EdgeInsets.all(8),
+            tabletPadding: const EdgeInsets.all(16),
+            desktopPadding: const EdgeInsets.all(24),
+          ),
+        );
+
+        final padding = tester.widget<Padding>(find.byType(Padding).first);
+        expect(padding.padding, const EdgeInsets.all(24));
+      });
+
+      testWidgets('applies tablet padding at exactly 600 width', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            screenWidth: 600,
+            mobilePadding: const EdgeInsets.all(8),
+            tabletPadding: const EdgeInsets.all(16),
+            desktopPadding: const EdgeInsets.all(24),
+          ),
+        );
+
+        final padding = tester.widget<Padding>(find.byType(Padding).first);
+        expect(padding.padding, const EdgeInsets.all(16));
+      });
+
+      testWidgets('applies desktop padding at exactly 1024 width', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            screenWidth: 1024,
+            mobilePadding: const EdgeInsets.all(8),
+            tabletPadding: const EdgeInsets.all(16),
+            desktopPadding: const EdgeInsets.all(24),
+          ),
+        );
+
+        final padding = tester.widget<Padding>(find.byType(Padding).first);
+        expect(padding.padding, const EdgeInsets.all(24));
+      });
+    });
+
+    group('Custom Breakpoints', () {
+      testWidgets('respects custom mobile breakpoint', (tester) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            screenWidth: 500,
+            mobileBreakpoint: 400, // Custom: < 400 is mobile
+            mobilePadding: const EdgeInsets.all(8),
+            tabletPadding: const EdgeInsets.all(16),
+            desktopPadding: const EdgeInsets.all(24),
+          ),
+        );
+
+        // 500 >= 400, so it should be tablet
+        final padding = tester.widget<Padding>(find.byType(Padding).first);
+        expect(padding.padding, const EdgeInsets.all(16));
+      });
+
+      testWidgets('respects custom tablet breakpoint', (tester) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            screenWidth: 900,
+            tabletBreakpoint: 800, // Custom: >= 800 is desktop
+            mobilePadding: const EdgeInsets.all(8),
+            tabletPadding: const EdgeInsets.all(16),
+            desktopPadding: const EdgeInsets.all(24),
+          ),
+        );
+
+        // 900 >= 800, so it should be desktop
+        final padding = tester.widget<Padding>(find.byType(Padding).first);
+        expect(padding.padding, const EdgeInsets.all(24));
+      });
+    });
+
+    group('Fallback Behavior', () {
+      testWidgets('falls back to padding when breakpoint padding is null', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            screenWidth: 400,
+            padding: const EdgeInsets.all(12),
+            mobilePadding: null,
+          ),
+        );
+
+        final padding = tester.widget<Padding>(find.byType(Padding).first);
+        expect(padding.padding, const EdgeInsets.all(12));
+      });
+
+      testWidgets('uses EdgeInsets.zero when no padding is provided', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(screenWidth: 400, padding: null, mobilePadding: null),
+        );
+
+        final padding = tester.widget<Padding>(find.byType(Padding).first);
+        expect(padding.padding, EdgeInsets.zero);
+      });
+    });
+
+    group('Named Constructors', () {
+      testWidgets('ResponsivePadding.all applies same padding all sides', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: MediaQuery(
+              data: const MediaQueryData(size: Size(400, 800)),
+              child: ResponsivePadding.all(
+                mobile: 8,
+                tablet: 16,
+                desktop: 24,
+                child: const Text('Test'),
+              ),
+            ),
+          ),
+        );
+
+        final padding = tester.widget<Padding>(find.byType(Padding).first);
+        expect(padding.padding, const EdgeInsets.all(8));
+      });
+
+      testWidgets('ResponsivePadding.symmetric applies h/v padding', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: MediaQuery(
+              data: const MediaQueryData(size: Size(800, 800)),
+              child: ResponsivePadding.symmetric(
+                mobileHorizontal: 8,
+                mobileVertical: 4,
+                tabletHorizontal: 16,
+                tabletVertical: 8,
+                desktopHorizontal: 24,
+                desktopVertical: 12,
+                child: const Text('Test'),
+              ),
+            ),
+          ),
+        );
+
+        final padding = tester.widget<Padding>(find.byType(Padding).first);
+        expect(
+          padding.padding,
+          const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        );
+      });
+
+      testWidgets('ResponsivePadding.horizontal applies only h padding', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: MediaQuery(
+              data: const MediaQueryData(size: Size(1200, 800)),
+              child: ResponsivePadding.horizontal(
+                mobile: 8,
+                tablet: 16,
+                desktop: 24,
+                child: const Text('Test'),
+              ),
+            ),
+          ),
+        );
+
+        final padding = tester.widget<Padding>(find.byType(Padding).first);
+        expect(padding.padding, const EdgeInsets.symmetric(horizontal: 24));
+      });
+
+      testWidgets('ResponsivePadding.vertical applies only v padding', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: MediaQuery(
+              data: const MediaQueryData(size: Size(400, 800)),
+              child: ResponsivePadding.vertical(
+                mobile: 8,
+                tablet: 16,
+                desktop: 24,
+                child: const Text('Test'),
+              ),
+            ),
+          ),
+        );
+
+        final padding = tester.widget<Padding>(find.byType(Padding).first);
+        expect(padding.padding, const EdgeInsets.symmetric(vertical: 8));
+      });
+    });
+
+    group('Child Rendering', () {
+      testWidgets('renders child widget correctly', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: MediaQuery(
+              data: const MediaQueryData(size: Size(400, 800)),
+              child: ResponsivePadding(
+                mobilePadding: const EdgeInsets.all(8),
+                child: const Text('Test Content'),
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Test Content'), findsOneWidget);
+      });
+    });
+
+    group('DeviceType enum', () {
+      test('DeviceType has correct values', () {
+        expect(DeviceType.values, contains(DeviceType.mobile));
+        expect(DeviceType.values, contains(DeviceType.tablet));
+        expect(DeviceType.values, contains(DeviceType.desktop));
+        expect(DeviceType.values.length, 3);
+      });
+    });
+
+    group('ResponsiveBreakpoints', () {
+      test('has correct default values', () {
+        expect(ResponsiveBreakpoints.mobile, 600.0);
+        expect(ResponsiveBreakpoints.tablet, 1024.0);
+      });
+    });
+  });
+}

--- a/widgetbook_kit/lib/stories/core_kit/layout/responsive_padding_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/layout/responsive_padding_stories.dart
@@ -1,2 +1,581 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/core_kit.dart';
+
+/// Widgetbook stories for [ResponsivePadding] layout widget.
+///
+/// A layout widget that automatically adjusts padding based on screen size
+/// breakpoints (mobile, tablet, desktop).
+
+/// Interactive Playground - explore all ResponsivePadding properties with knobs
+@widgetbook.UseCase(name: 'Interactive Playground', type: ResponsivePadding)
+Widget responsivePaddingPlayground(BuildContext context) {
+  final paddingType = context.knobs.object.dropdown(
+    label: 'Padding Type',
+    options: const ['all', 'symmetric', 'horizontal', 'vertical', 'custom'],
+    labelBuilder: (value) => value,
+  );
+
+  final mobilePadding = context.knobs.double.slider(
+    label: 'Mobile Padding',
+    initialValue: AppSpacing.sm,
+    min: 0,
+    max: 48,
+  );
+
+  final tabletPadding = context.knobs.double.slider(
+    label: 'Tablet Padding',
+    initialValue: AppSpacing.md,
+    min: 0,
+    max: 64,
+  );
+
+  final desktopPadding = context.knobs.double.slider(
+    label: 'Desktop Padding',
+    initialValue: AppSpacing.lg,
+    min: 0,
+    max: 96,
+  );
+
+  final mobileBreakpoint = context.knobs.double.slider(
+    label: 'Mobile Breakpoint',
+    initialValue: 600,
+    min: 300,
+    max: 800,
+  );
+
+  final tabletBreakpoint = context.knobs.double.slider(
+    label: 'Tablet Breakpoint',
+    initialValue: 1024,
+    min: 600,
+    max: 1400,
+  );
+
+  final showBreakpointInfo = context.knobs.boolean(
+    label: 'Show Breakpoint Info',
+    initialValue: true,
+  );
+
+  Widget buildContent(BuildContext ctx) {
+    final width = MediaQuery.sizeOf(ctx).width;
+    String deviceType;
+    if (width < mobileBreakpoint) {
+      deviceType = 'Mobile';
+    } else if (width < tabletBreakpoint) {
+      deviceType = 'Tablet';
+    } else {
+      deviceType = 'Desktop';
+    }
+
+    return AppCard(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Responsive Content',
+            style: Theme.of(ctx).textTheme.titleMedium,
+          ),
+          if (showBreakpointInfo) ...[
+            const Gap.sm(),
+            Text('Width: ${width.toStringAsFixed(0)}dp'),
+            Text('Device: $deviceType'),
+            Text('Padding Type: $paddingType'),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget child = Builder(builder: buildContent);
+
+  switch (paddingType) {
+    case 'all':
+      return ResponsivePadding.all(
+        mobile: mobilePadding,
+        tablet: tabletPadding,
+        desktop: desktopPadding,
+        mobileBreakpoint: mobileBreakpoint,
+        tabletBreakpoint: tabletBreakpoint,
+        child: child,
+      );
+    case 'symmetric':
+      return ResponsivePadding.symmetric(
+        mobileHorizontal: mobilePadding,
+        mobileVertical: mobilePadding / 2,
+        tabletHorizontal: tabletPadding,
+        tabletVertical: tabletPadding / 2,
+        desktopHorizontal: desktopPadding,
+        desktopVertical: desktopPadding / 2,
+        mobileBreakpoint: mobileBreakpoint,
+        tabletBreakpoint: tabletBreakpoint,
+        child: child,
+      );
+    case 'horizontal':
+      return ResponsivePadding.horizontal(
+        mobile: mobilePadding,
+        tablet: tabletPadding,
+        desktop: desktopPadding,
+        mobileBreakpoint: mobileBreakpoint,
+        tabletBreakpoint: tabletBreakpoint,
+        child: child,
+      );
+    case 'vertical':
+      return ResponsivePadding.vertical(
+        mobile: mobilePadding,
+        tablet: tabletPadding,
+        desktop: desktopPadding,
+        mobileBreakpoint: mobileBreakpoint,
+        tabletBreakpoint: tabletBreakpoint,
+        child: child,
+      );
+    default:
+      return ResponsivePadding(
+        mobilePadding: EdgeInsets.all(mobilePadding),
+        tabletPadding: EdgeInsets.all(tabletPadding),
+        desktopPadding: EdgeInsets.all(desktopPadding),
+        mobileBreakpoint: mobileBreakpoint,
+        tabletBreakpoint: tabletBreakpoint,
+        child: child,
+      );
+  }
+}
+
+/// Default - Basic usage with default breakpoints
+@widgetbook.UseCase(name: 'Default', type: ResponsivePadding)
+Widget responsivePaddingDefault(BuildContext context) {
+  final mobilePadding = context.knobs.double.slider(
+    label: 'Mobile Padding',
+    initialValue: AppSpacing.sm,
+    min: 0,
+    max: 32,
+  );
+
+  final tabletPadding = context.knobs.double.slider(
+    label: 'Tablet Padding',
+    initialValue: AppSpacing.md,
+    min: 0,
+    max: 48,
+  );
+
+  final desktopPadding = context.knobs.double.slider(
+    label: 'Desktop Padding',
+    initialValue: AppSpacing.lg,
+    min: 0,
+    max: 64,
+  );
+
+  return ResponsivePadding.all(
+    mobile: mobilePadding,
+    tablet: tabletPadding,
+    desktop: desktopPadding,
+    child: Builder(
+      builder: (ctx) {
+        final width = MediaQuery.sizeOf(ctx).width;
+        String deviceType;
+        double currentPadding;
+
+        if (width < ResponsiveBreakpoints.mobile) {
+          deviceType = 'Mobile';
+          currentPadding = mobilePadding;
+        } else if (width < ResponsiveBreakpoints.tablet) {
+          deviceType = 'Tablet';
+          currentPadding = tabletPadding;
+        } else {
+          deviceType = 'Desktop';
+          currentPadding = desktopPadding;
+        }
+
+        return AppCard(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Content with responsive padding',
+                style: Theme.of(ctx).textTheme.bodyLarge,
+              ),
+              const Gap.sm(),
+              Text(
+                'Device: $deviceType | Padding: ${currentPadding.toStringAsFixed(0)}dp',
+                style: Theme.of(ctx).textTheme.bodySmall,
+              ),
+            ],
+          ),
+        );
+      },
+    ),
+  );
+}
+
+/// Breakpoint Demo - Shows current breakpoint and applied padding
+@widgetbook.UseCase(name: 'Breakpoint Demo', type: ResponsivePadding)
+Widget responsivePaddingBreakpointDemo(BuildContext context) {
+  final mobilePadding = context.knobs.double.slider(
+    label: 'Mobile Padding',
+    initialValue: 8,
+    min: 0,
+    max: 32,
+  );
+
+  final tabletPadding = context.knobs.double.slider(
+    label: 'Tablet Padding',
+    initialValue: 16,
+    min: 0,
+    max: 48,
+  );
+
+  final desktopPadding = context.knobs.double.slider(
+    label: 'Desktop Padding',
+    initialValue: 24,
+    min: 0,
+    max: 64,
+  );
+
+  return ResponsivePadding.all(
+    mobile: mobilePadding,
+    tablet: tabletPadding,
+    desktop: desktopPadding,
+    child: Builder(
+      builder: (ctx) {
+        final width = MediaQuery.sizeOf(ctx).width;
+        String deviceType;
+        double currentPadding;
+
+        if (width < ResponsiveBreakpoints.mobile) {
+          deviceType = 'MOBILE';
+          currentPadding = mobilePadding;
+        } else if (width < ResponsiveBreakpoints.tablet) {
+          deviceType = 'TABLET';
+          currentPadding = tabletPadding;
+        } else {
+          deviceType = 'DESKTOP';
+          currentPadding = desktopPadding;
+        }
+
+        return AppCard.outlined(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                deviceType == 'MOBILE'
+                    ? Icons.phone_android
+                    : deviceType == 'TABLET'
+                    ? Icons.tablet_android
+                    : Icons.desktop_windows,
+                size: 48,
+                color: Theme.of(ctx).colorScheme.primary,
+              ),
+              const Gap.md(),
+              Text(
+                deviceType,
+                style: Theme.of(ctx).textTheme.headlineSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const Gap.sm(),
+              Text(
+                'Width: ${width.toStringAsFixed(0)}dp',
+                style: Theme.of(ctx).textTheme.bodyMedium,
+              ),
+              Text(
+                'Padding: ${currentPadding.toStringAsFixed(0)}dp',
+                style: Theme.of(ctx).textTheme.bodyMedium?.copyWith(
+                  color: Theme.of(ctx).colorScheme.secondary,
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    ),
+  );
+}
+
+/// All Padding Types - Demonstrates all, symmetric, horizontal, vertical
+@widgetbook.UseCase(name: 'All Padding Types', type: ResponsivePadding)
+Widget responsivePaddingAllTypes(BuildContext context) {
+  final paddingType = context.knobs.object.dropdown(
+    label: 'Padding Type',
+    options: const ['All', 'Symmetric', 'Horizontal', 'Vertical'],
+    labelBuilder: (value) => value,
+  );
+
+  final paddingValue = context.knobs.double.slider(
+    label: 'Padding Value',
+    initialValue: 16,
+    min: 0,
+    max: 48,
+  );
+
+  Widget content = AppCard(
+    child: Text(
+      'Padding Type: $paddingType\nValue: ${paddingValue.toStringAsFixed(0)}dp',
+      style: Theme.of(context).textTheme.bodyLarge,
+    ),
+  );
+
+  switch (paddingType) {
+    case 'All':
+      return ResponsivePadding.all(
+        mobile: paddingValue,
+        tablet: paddingValue,
+        desktop: paddingValue,
+        child: content,
+      );
+    case 'Symmetric':
+      return ResponsivePadding.symmetric(
+        mobileHorizontal: paddingValue,
+        mobileVertical: paddingValue / 2,
+        tabletHorizontal: paddingValue,
+        tabletVertical: paddingValue / 2,
+        desktopHorizontal: paddingValue,
+        desktopVertical: paddingValue / 2,
+        child: content,
+      );
+    case 'Horizontal':
+      return ResponsivePadding.horizontal(
+        mobile: paddingValue,
+        tablet: paddingValue,
+        desktop: paddingValue,
+        child: content,
+      );
+    case 'Vertical':
+      return ResponsivePadding.vertical(
+        mobile: paddingValue,
+        tablet: paddingValue,
+        desktop: paddingValue,
+        child: content,
+      );
+    default:
+      return ResponsivePadding.all(
+        mobile: paddingValue,
+        tablet: paddingValue,
+        desktop: paddingValue,
+        child: content,
+      );
+  }
+}
+
+/// Custom Breakpoints - Custom mobile/tablet threshold values
+@widgetbook.UseCase(name: 'Custom Breakpoints', type: ResponsivePadding)
+Widget responsivePaddingCustomBreakpoints(BuildContext context) {
+  final mobileBreakpoint = context.knobs.double.slider(
+    label: 'Mobile Breakpoint',
+    initialValue: 480,
+    min: 300,
+    max: 800,
+  );
+
+  final tabletBreakpoint = context.knobs.double.slider(
+    label: 'Tablet Breakpoint',
+    initialValue: 900,
+    min: 600,
+    max: 1400,
+  );
+
+  final mobilePadding = context.knobs.double.slider(
+    label: 'Mobile Padding',
+    initialValue: AppSpacing.xs,
+    min: 0,
+    max: 32,
+  );
+
+  final tabletPadding = context.knobs.double.slider(
+    label: 'Tablet Padding',
+    initialValue: AppSpacing.md,
+    min: 0,
+    max: 48,
+  );
+
+  final desktopPadding = context.knobs.double.slider(
+    label: 'Desktop Padding',
+    initialValue: AppSpacing.xl,
+    min: 0,
+    max: 64,
+  );
+
+  return ResponsivePadding.all(
+    mobile: mobilePadding,
+    tablet: tabletPadding,
+    desktop: desktopPadding,
+    mobileBreakpoint: mobileBreakpoint,
+    tabletBreakpoint: tabletBreakpoint,
+    child: Builder(
+      builder: (ctx) {
+        final width = MediaQuery.sizeOf(ctx).width;
+        String deviceType;
+        double currentPadding;
+
+        if (width < mobileBreakpoint) {
+          deviceType = 'Mobile (< ${mobileBreakpoint.toInt()}dp)';
+          currentPadding = mobilePadding;
+        } else if (width < tabletBreakpoint) {
+          deviceType = 'Tablet (< ${tabletBreakpoint.toInt()}dp)';
+          currentPadding = tabletPadding;
+        } else {
+          deviceType = 'Desktop (>= ${tabletBreakpoint.toInt()}dp)';
+          currentPadding = desktopPadding;
+        }
+
+        return AppCard(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                'Custom Breakpoints',
+                style: Theme.of(ctx).textTheme.titleMedium,
+              ),
+              const Gap.sm(),
+              Text('Current Width: ${width.toStringAsFixed(0)}dp'),
+              Text(deviceType),
+              Text('Padding: ${currentPadding.toStringAsFixed(0)}dp'),
+            ],
+          ),
+        );
+      },
+    ),
+  );
+}
+
+/// Page Edge Padding - Real-world page edge padding example
+@widgetbook.UseCase(name: 'Page Edge Padding', type: ResponsivePadding)
+Widget responsivePaddingPageEdge(BuildContext context) {
+  final useLargePadding = context.knobs.boolean(
+    label: 'Use Large Padding',
+    initialValue: false,
+  );
+
+  return Scaffold(
+    appBar: AppBar(title: const Text('Page Edge Padding')),
+    body: ResponsivePadding.horizontal(
+      mobile: useLargePadding ? AppSpacing.md : AppSpacing.sm,
+      tablet: useLargePadding ? AppSpacing.xl : AppSpacing.lg,
+      desktop: useLargePadding ? AppSpacing.xxxl : AppSpacing.xl,
+      child: ListView(
+        children: [
+          const Gap.md(),
+          AppCard(
+            child: Text(
+              'Page Content',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+          ),
+          const Gap.md(),
+          AppCard(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'This content has responsive horizontal padding.',
+                  style: Theme.of(context).textTheme.bodyLarge,
+                ),
+                const Gap.sm(),
+                Text(
+                  'Resize the window to see the padding adjust.',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+/// Card Content Padding - Card content padding real-world example
+@widgetbook.UseCase(name: 'Card Content Padding', type: ResponsivePadding)
+Widget responsivePaddingCardContent(BuildContext context) {
+  final showBorder = context.knobs.boolean(
+    label: 'Show Border',
+    initialValue: true,
+  );
+
+  return Center(
+    child: Container(
+      decoration: showBorder
+          ? BoxDecoration(
+              border: Border.all(color: Theme.of(context).colorScheme.outline),
+              borderRadius: BorderRadius.circular(AppRadius.lg),
+            )
+          : null,
+      child: ResponsivePadding.all(
+        mobile: AppSpacing.sm,
+        tablet: AppSpacing.md,
+        desktop: AppSpacing.lg,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Card Title', style: Theme.of(context).textTheme.titleLarge),
+            const Gap.sm(),
+            Text(
+              'This card has responsive padding that adjusts based on screen '
+              'size. On mobile, the padding is smaller to maximize content '
+              'area. On desktop, larger padding provides visual breathing room.',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const Gap.md(),
+            AppButton.filled(label: 'Action', onPressed: () {}),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+/// Responsive Form - Form with responsive spacing
+@widgetbook.UseCase(name: 'Responsive Form', type: ResponsivePadding)
+Widget responsivePaddingForm(BuildContext context) {
+  final useVerticalPadding = context.knobs.boolean(
+    label: 'Use Vertical Padding',
+    initialValue: true,
+  );
+
+  return Scaffold(
+    appBar: AppBar(title: const Text('Responsive Form')),
+    body: ResponsivePadding.symmetric(
+      mobileHorizontal: AppSpacing.md,
+      mobileVertical: useVerticalPadding ? AppSpacing.sm : 0,
+      tabletHorizontal: AppSpacing.xl,
+      tabletVertical: useVerticalPadding ? AppSpacing.md : 0,
+      desktopHorizontal: AppSpacing.xxxl,
+      desktopVertical: useVerticalPadding ? AppSpacing.lg : 0,
+      child: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Gap.lg(),
+            Text(
+              'Create Account',
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+            const Gap.lg(),
+            const AppTextField(
+              label: 'Full Name',
+              hint: 'Enter your full name',
+            ),
+            const Gap.md(),
+            const AppTextField(label: 'Email', hint: 'Enter your email'),
+            const Gap.md(),
+            const AppPasswordField(
+              label: 'Password',
+              hint: 'Enter your password',
+            ),
+            const Gap.lg(),
+            AppButton.filled(
+              label: 'Create Account',
+              fullWidth: true,
+              onPressed: () {},
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
# Pull Request

## 📄 Summary

-Implemented the ResponsivePadding layout widget that automatically adjusts padding based on screen size breakpoints (mobile < 600dp, tablet < 1024dp, desktop >= 1024dp). The widget includes four named constructors (all, symmetric, horizontal, vertical) for different padding configurations, custom breakpoint override support, and 16 widget tests covering all edge cases. Created 8 interactive Widgetbook stories with full knob support to demonstrate breakpoint detection, padding types, and real-world usage examples.

---

## 🧩 Affected Module(s)

- [X] Packages (packages/*)
- [X] Widgetbook Kit (widgetbook_kit/)
- [ ] Documentation (docs/)
- [ ] CI / Infra (.github/)

---

## ✅ Checklist

- [✅] My branch name follows format: <type>/<short-description> (e.g., feat/login-screen)
- [✅] My PR title starts with one of the approved types listed above
- [✅] My Dart code is formatted (dart format . or flutter format .)
- [✅] I ran static analysis (flutter analyze) and resolved warnings
- [✅] I ran tests successfully (flutter test)
- [✅] I updated / checked pubspec.yaml and pubspec.lock for dependency changes
- [✅] For UI changes, I added screenshots and/or updated golden tests (if applicable)
- [✅] I ensured this PR has no unrelated changes
- [✅] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues


Closes #39 