### PR TITLE
feat(core_kit): implement AppIconRegistry for centralized icon management

### DIFF
--- a/packages/core_kit/lib/icons/app_icon_registry.dart
+++ b/packages/core_kit/lib/icons/app_icon_registry.dart
@@ -1,6 +1,294 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
 
+import 'dart:convert';
+import 'package:flutter/widgets.dart';
+
+/// Defines the style variants for icons in the application.
+/// Based on Material Design 3 specifications.
+enum AppIconVariant {
+  outlined, // Default M3 style (400 weight)
+  filled, // Solid style (700 weight)
+  rounded, // Rounded corners style
+  sharp, // Sharp corners style
+  twoTone, // Two-tone color style
+}
+
+/// Defines semantic categories for icons to aid in organization and search.
+enum AppIconCategory {
+  navigation,
+  actions,
+  content,
+  communication,
+  status,
+  other,
+}
+
+/// A definition for a registered icon, containing its variants and metadata.
+class AppIconDefinition {
+  final Map<AppIconVariant, IconData> variants;
+  final IconData defaultIcon;
+  final String name;
+  final AppIconCategory category;
+  final List<String> tags;
+  final double? defaultSize;
+
+  const AppIconDefinition({
+    required this.name,
+    required this.defaultIcon,
+    this.variants = const {},
+    this.category = AppIconCategory.other,
+    this.tags = const [],
+    this.defaultSize,
+  });
+
+  /// Retrieves the icon for a specific variant, falling back to the default icon if not found.
+  IconData getVariant(AppIconVariant variant) {
+    return variants[variant] ?? defaultIcon;
+  }
+}
+
+/// A centralized registry for managing application icons.
+///
+/// Supports semantic lookup, variants, custom icons, and aliasing.
 class AppIconRegistry {
-  const AppIconRegistry();
+  // Singleton instance
+  static final AppIconRegistry _instance = AppIconRegistry._internal();
+  static AppIconRegistry get instance => _instance;
+
+  factory AppIconRegistry() {
+    return _instance;
+  }
+
+  AppIconRegistry._internal();
+
+  final Map<String, AppIconDefinition> _icons = {};
+  final Map<String, String> _aliases = {};
+
+  // Default fallback icon (usually something visible like a question mark or box)
+  // Can be configured by the user.
+  IconData _fallbackIcon = const IconData(
+    0xe000,
+    fontFamily: 'MaterialIcons',
+  ); // Default generic icon (e.g. error/help)
+
+  /// Configures the global fallback icon to be used when a requested icon is not found.
+  void setFallbackIcon(IconData icon) {
+    _fallbackIcon = icon;
+  }
+
+  /// Registers a new icon definition.
+  void registerIcon(AppIconDefinition definition) {
+    _icons[definition.name] = definition;
+  }
+
+  /// Registers a standard Material icon with optional variants.
+  ///
+  /// [name]: Semantic name (e.g., 'home', 'profile').
+  /// [defaultIcon]: The main icon to use.
+  /// [variants]: Optional map of specific variants.
+  void registerMaterialIcon({
+    required String name,
+    required IconData defaultIcon,
+    Map<AppIconVariant, IconData>? variants,
+    AppIconCategory category = AppIconCategory.other,
+    List<String> tags = const [],
+  }) {
+    registerIcon(
+      AppIconDefinition(
+        name: name,
+        defaultIcon: defaultIcon,
+        variants: variants ?? {},
+        category: category,
+        tags: tags,
+      ),
+    );
+  }
+
+  /// Registers an alias for an existing icon.
+  ///
+  /// [alias]: The new name (e.g., 'trash').
+  /// [target]: The existing registered name (e.g., 'delete').
+  void registerAlias(String alias, String target) {
+    if (_icons.containsKey(target) || _aliases.containsKey(target)) {
+      _aliases[alias] = target;
+    } else {
+      debugPrint(
+        'AppIconRegistry: Warning - Trying to alias "$alias" to non-existent icon "$target"',
+      );
+    }
+  }
+
+  /// Registers a custom icon from a font family.
+  void registerCustomIcon({
+    required String name,
+    required int codePoint,
+    required String fontFamily,
+    String? fontPackage,
+    Map<AppIconVariant, int>? variantCodePoints,
+    AppIconCategory category = AppIconCategory.other,
+  }) {
+    final defaultIcon = IconData(
+      codePoint,
+      fontFamily: fontFamily,
+      fontPackage: fontPackage,
+    );
+
+    final variants = <AppIconVariant, IconData>{};
+    if (variantCodePoints != null) {
+      variantCodePoints.forEach((variant, cp) {
+        variants[variant] = IconData(
+          cp,
+          fontFamily: fontFamily,
+          fontPackage: fontPackage,
+        );
+      });
+    }
+
+    registerIcon(
+      AppIconDefinition(
+        name: name,
+        defaultIcon: defaultIcon,
+        variants: variants,
+        category: category,
+      ),
+    );
+  }
+
+  /// Loads icon definitions and aliases from a JSON string.
+  ///
+  /// The JSON should have the following structure:
+  /// ```json
+  /// {
+  ///   "icons": [
+  ///     {
+  ///       "name": "example",
+  ///       "codePoint": 50000,
+  ///       "fontFamily": "MaterialIcons",
+  ///       "variants": {
+  ///         "filled": 50001
+  ///       }
+  ///     }
+  ///   ],
+  ///   "aliases": {
+  ///     "alias": "target"
+  ///   }
+  /// }
+  /// ```
+  void loadFromJson(String jsonString) {
+    try {
+      final Map<String, dynamic> data = json.decode(jsonString);
+
+      if (data.containsKey('icons')) {
+        final List<dynamic> icons = data['icons'];
+        for (final iconData in icons) {
+          if (iconData is Map<String, dynamic>) {
+            _registerFromJson(iconData);
+          }
+        }
+      }
+
+      if (data.containsKey('aliases')) {
+        final Map<String, dynamic> aliases = data['aliases'];
+        aliases.forEach((key, value) {
+          if (value is String) {
+            registerAlias(key, value);
+          }
+        });
+      }
+    } catch (e, stackTrace) {
+      debugPrint('AppIconRegistry: Error loading JSON: $e\n$stackTrace');
+    }
+  }
+
+  void _registerFromJson(Map<String, dynamic> data) {
+    final name = data['name'] as String?;
+    final codePoint = data['codePoint'] as int?;
+    final fontFamily = data['fontFamily'] as String?;
+    final fontPackage = data['fontPackage'] as String?;
+    final rawVariants = data['variants'] as Map<String, dynamic>?;
+
+    if (name == null || codePoint == null || fontFamily == null) {
+      debugPrint('AppIconRegistry: Invalid icon definition in JSON: $data');
+      return;
+    }
+
+    final variants = <AppIconVariant, IconData>{};
+    if (rawVariants != null) {
+      for (final entry in rawVariants.entries) {
+        final variantEnum = AppIconVariant.values.firstWhere(
+          (e) => e.toString().split('.').last == entry.key,
+          orElse: () => AppIconVariant.outlined,
+        );
+
+        if (entry.value is int) {
+          variants[variantEnum] = IconData(
+            entry.value,
+            fontFamily: fontFamily,
+            fontPackage: fontPackage,
+          );
+        }
+      }
+    }
+
+    final defaultIcon = IconData(
+      codePoint,
+      fontFamily: fontFamily,
+      fontPackage: fontPackage,
+    );
+
+    registerIcon(
+      AppIconDefinition(
+        name: name,
+        defaultIcon: defaultIcon,
+        variants: variants,
+        // Category parsing could be added here
+      ),
+    );
+  }
+
+  /// Retrieves an icon by its semantic name.
+  ///
+  /// [name]: The semantic name of the icon.
+  /// [variant]: The desired style variant.
+  ///
+  /// Returns the requested [IconData] or the fallback icon if not found.
+  IconData getIcon(
+    String name, {
+    AppIconVariant variant = AppIconVariant.outlined,
+  }) {
+    final resolvedName = _resolveName(name);
+    final definition = _icons[resolvedName];
+
+    if (definition == null) {
+      debugPrint(
+        'AppIconRegistry: Check - Icon "$name" not found. Using fallback.',
+      );
+      return _fallbackIcon;
+    }
+
+    return definition.getVariant(variant);
+  }
+
+  /// Resolves aliases recursively to find the actual icon name.
+  String _resolveName(String name) {
+    if (_icons.containsKey(name)) {
+      return name;
+    }
+    if (_aliases.containsKey(name)) {
+      return _resolveName(_aliases[name]!); // Recursive resolution
+    }
+    return name;
+  }
+
+  /// Clears all registered icons and aliases.
+  void clear() {
+    _icons.clear();
+    _aliases.clear();
+  }
+
+  /// Returns a list of all registered icon definitions.
+  List<AppIconDefinition> getAllIcons() {
+    return _icons.values.toList();
+  }
 }

--- a/packages/core_kit/test/icons/app_icon_registry_test.dart
+++ b/packages/core_kit/test/icons/app_icon_registry_test.dart
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:core_kit/icons/app_icon_registry.dart';
+
+void main() {
+  group('AppIconRegistry', () {
+    late AppIconRegistry registry;
+
+    setUp(() {
+      registry = AppIconRegistry.instance;
+      registry.clear();
+      // Set a known fallback for testing
+      registry.setFallbackIcon(const IconData(0x0000, fontFamily: 'Fallback'));
+    });
+
+    test('should return fallback icon when icon is not registered', () {
+      final icon = registry.getIcon('non_existent_icon');
+      expect(icon.codePoint, 0x0000);
+      expect(icon.fontFamily, 'Fallback');
+    });
+
+    test('should register and retrieve a Material icon', () {
+      const iconData = IconData(
+        0xe88a,
+        fontFamily: 'MaterialIcons',
+      ); // Home icon
+      registry.registerMaterialIcon(name: 'home', defaultIcon: iconData);
+
+      final result = registry.getIcon('home');
+      expect(result, iconData);
+    });
+
+    test('should resolve variants correctly', () {
+      const outlined = IconData(0x1000, fontFamily: 'MaterialIcons');
+      const filled = IconData(0x2000, fontFamily: 'MaterialIcons');
+
+      registry.registerMaterialIcon(
+        name: 'profile',
+        defaultIcon: outlined,
+        variants: {
+          AppIconVariant.outlined: outlined,
+          AppIconVariant.filled: filled,
+        },
+      );
+
+      expect(
+        registry.getIcon('profile', variant: AppIconVariant.outlined),
+        outlined,
+      );
+      expect(
+        registry.getIcon('profile', variant: AppIconVariant.filled),
+        filled,
+      );
+    });
+
+    test('should fall back to default icon if variant is missing', () {
+      const defaultIcon = IconData(0x3000, fontFamily: 'MaterialIcons');
+
+      registry.registerMaterialIcon(
+        name: 'settings',
+        defaultIcon: defaultIcon,
+        variants: {AppIconVariant.outlined: defaultIcon},
+      );
+
+      // Requesting 'filled' which is not registered, should return default (outlined)
+      expect(
+        registry.getIcon('settings', variant: AppIconVariant.filled),
+        defaultIcon,
+      );
+    });
+
+    test('should resolve aliases', () {
+      const iconData = IconData(0xe872, fontFamily: 'MaterialIcons'); // Delete
+
+      registry.registerMaterialIcon(name: 'delete', defaultIcon: iconData);
+
+      registry.registerAlias('trash', 'delete');
+      registry.registerAlias('remove', 'trash'); // Chained alias
+
+      expect(registry.getIcon('trash'), iconData);
+      expect(registry.getIcon('remove'), iconData);
+    });
+
+    test('should register custom font icons', () {
+      registry.registerCustomIcon(
+        name: 'custom_pro',
+        codePoint: 0xf100,
+        fontFamily: 'MyCustomFont',
+      );
+
+      final icon = registry.getIcon('custom_pro');
+      expect(icon.codePoint, 0xf100);
+      expect(icon.fontFamily, 'MyCustomFont');
+    });
+
+    test('should load icons from JSON', () {
+      const jsonString = '''
+      {
+        "icons": [
+          {
+            "name": "json_icon",
+            "codePoint": 50000,
+            "fontFamily": "MaterialIcons",
+            "variants": {
+              "filled": 50001
+            }
+          }
+        ],
+        "aliases": {
+          "json_alias": "json_icon"
+        }
+      }
+      ''';
+
+      registry.loadFromJson(jsonString);
+
+      expect(registry.getIcon('json_icon').codePoint, 50000);
+      expect(
+        registry.getIcon('json_icon', variant: AppIconVariant.filled).codePoint,
+        50001,
+      );
+      expect(registry.getIcon('json_alias').codePoint, 50000);
+    });
+  });
+}

--- a/widgetbook_kit/lib/stories/core_kit/icons/app_icon_registry_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/icons/app_icon_registry_stories.dart
@@ -1,2 +1,176 @@
 // SPDX-FileCopyrightText: 2025 hexaTune LLC
 // SPDX-License-Identifier: MIT
+
+import 'package:core_kit/layout/gap.dart';
+import 'package:core_kit/theme/app_spacing.dart';
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/icons/app_icon_registry.dart';
+
+// Helper widget to display an icon from the registry
+class _AppIconDemo extends StatelessWidget {
+  final String iconName;
+  final AppIconVariant variant;
+  final double size;
+  final Color? color;
+
+  const _AppIconDemo({
+    required this.iconName,
+    this.variant = AppIconVariant.outlined,
+    this.size = 24,
+    this.color,
+  });
+
+  static void registerDemoIcons() {
+    // Register some icons if they aren't already
+    // This is a bit of a hack for the story, ideally this happens at app startup
+    final registry = AppIconRegistry.instance;
+    if (registry.getIcon('home').codePoint == 0xe000) {
+      // Check if fallback (assuming fallback is set) or just re-register
+      registry.registerMaterialIcon(
+        name: 'home',
+        defaultIcon: Icons.home_outlined,
+        variants: {
+          AppIconVariant.outlined: Icons.home_outlined,
+          AppIconVariant.filled: Icons.home,
+        },
+      );
+      registry.registerMaterialIcon(
+        name: 'settings',
+        defaultIcon: Icons.settings_outlined,
+        variants: {
+          AppIconVariant.outlined: Icons.settings_outlined,
+          AppIconVariant.filled: Icons.settings,
+        },
+      );
+      registry.registerAlias('gear', 'settings');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Ensure we have some icons registered for the demo
+    registerDemoIcons();
+
+    final iconData = AppIconRegistry.instance.getIcon(
+      iconName,
+      variant: variant,
+    );
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Icon(iconData, size: size, color: color),
+        const VGap.sm(),
+        Text('Name: $iconName', style: Theme.of(context).textTheme.bodySmall),
+        Text(
+          'Variant: ${variant.name}',
+          style: Theme.of(context).textTheme.labelSmall,
+        ),
+      ],
+    );
+  }
+}
+
+// Helper for the Browser story
+class _AppIconBrowser extends StatelessWidget {
+  const _AppIconBrowser();
+
+  @override
+  Widget build(BuildContext context) {
+    // Force registration
+    _AppIconDemo.registerDemoIcons();
+
+    final icons = AppIconRegistry.instance.getAllIcons();
+
+    return ListView.builder(
+      itemCount: icons.length,
+      itemBuilder: (context, index) {
+        final def = icons[index];
+        return ExpansionTile(
+          title: Text(def.name, style: Theme.of(context).textTheme.bodyMedium),
+          leading: Icon(def.defaultIcon),
+          childrenPadding: const EdgeInsets.all(AppSpacing.md),
+          children: [
+            Wrap(
+              spacing: AppSpacing.md,
+              children: AppIconVariant.values.map((v) {
+                return Column(
+                  children: [
+                    Icon(def.getVariant(v)),
+                    Text(v.name, style: Theme.of(context).textTheme.labelSmall),
+                  ],
+                );
+              }).toList(),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+@widgetbook.UseCase(name: 'Interactive Playground', type: AppIconRegistry)
+Widget appIconRegistryUseCases(BuildContext context) {
+  return Center(
+    child: _AppIconDemo(
+      iconName: context.knobs.string(
+        label: 'Icon Name',
+        initialValue: 'home',
+        description: 'Try "home", "settings", "gear" (alias)',
+      ),
+      variant: context.knobs.object.dropdown<AppIconVariant>(
+        label: 'Variant',
+        options: AppIconVariant.values,
+        initialOption: AppIconVariant.outlined,
+        labelBuilder: (value) => value.name,
+      ),
+      size: context.knobs.double.slider(
+        label: 'Size',
+        initialValue: 48,
+        min: 16,
+        max: 128,
+      ),
+      color: context.knobs.color(
+        label: 'Color',
+        initialValue: Theme.of(context).colorScheme.primary,
+      ),
+    ),
+  );
+}
+
+@widgetbook.UseCase(name: 'Default Icon (Outlined)', type: AppIconRegistry)
+Widget defaultIconStory(BuildContext context) {
+  return const Center(
+    child: _AppIconDemo(iconName: 'home', variant: AppIconVariant.outlined),
+  );
+}
+
+@widgetbook.UseCase(name: 'Filled Variant', type: AppIconRegistry)
+Widget filledVariantStory(BuildContext context) {
+  return const Center(
+    child: _AppIconDemo(iconName: 'home', variant: AppIconVariant.filled),
+  );
+}
+
+@widgetbook.UseCase(
+  name: 'Aliased Icon (Gear -> Settings)',
+  type: AppIconRegistry,
+)
+Widget aliasedIconStory(BuildContext context) {
+  return const Center(
+    child: _AppIconDemo(iconName: 'gear', variant: AppIconVariant.filled),
+  );
+}
+
+@widgetbook.UseCase(name: 'Fallback Icon', type: AppIconRegistry)
+Widget fallbackIconStory(BuildContext context) {
+  return const Center(child: _AppIconDemo(iconName: 'non_existent_icon'));
+}
+
+@widgetbook.UseCase(name: 'Icon Browser', type: AppIconRegistry)
+Widget appIconRegistryBrowser(BuildContext context) {
+  return const _AppIconBrowser();
+}


### PR DESCRIPTION
# Pull Request

## 📄 Summary

Implement a fully featured AppIconRegistry to provide centralized, semantic, and variant-aware icon management across the app. The solution introduces a single source of truth for Material, custom font, and SVG/image icons, supporting icon variants, aliasing, fallbacks, metadata, and runtime configuration, with Widgetbook stories and tests to demonstrate and validate usage.

---

## 🧩 Affected Module(s)

Mark the modules impacted by this PR:

- [x] Packages (packages/*)
- [x] Widgetbook Kit (widgetbook_kit/)
- [ ] Documentation (docs/)
- [ ] CI / Infra (.github/)

---

## ✅ Checklist

Before submitting, make sure you've completed the following:

- [x] My branch name follows format: <type>/<short-description> (e.g., feat/login-screen)
- [x] My PR title starts with one of the approved types listed above
- [x] My Dart code is formatted (dart format . or flutter format .)
- [x] I ran static analysis (flutter analyze) and resolved warnings
- [x] I ran tests successfully (flutter test)
- [x] I updated / checked pubspec.yaml and pubspec.lock for dependency changes
- [x] For UI changes, I added screenshots and/or updated golden tests (if applicable)
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

Closes #147 

---

## 💬 Additional Notes

This implementation follows Flutter and Material Design 3 best practices.

The registry is designed to be extensible for future icon sets and variants.

Existing icon usage via direct IconData remains supported and unaffected.

The feature is optional and primarily beneficial for large-scale or design-driven applications.