### PR TITLE
feat(core_kit): add responsive layout utilities and breakpoints 

### DIFF
--- a/packages/core_kit/lib/core_kit.dart
+++ b/packages/core_kit/lib/core_kit.dart
@@ -15,6 +15,7 @@ export 'typography/app_text_styles.dart';
 // Layout exports
 export 'layout/gap.dart';
 export 'layout/responsive_padding.dart';
+export 'layout/responsive_layout.dart';
 export 'layout/core_scaffold.dart';
 export 'layout/page_container.dart';
 export 'layout/app_scroll_view.dart';

--- a/packages/core_kit/lib/layout/responsive_layout.dart
+++ b/packages/core_kit/lib/layout/responsive_layout.dart
@@ -1,0 +1,1306 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../theme/app_spacing.dart';
+
+// =============================================================================
+// 1. M3 Layout Grid Data — Margins, Gutters, and Columns
+// =============================================================================
+
+/// Material Design 3 layout grid specifications.
+///
+/// Provides centralized access to M3-compliant margins, gutters, and
+/// column counts based on [WindowSizeClass].
+class AppLayoutGrid {
+  const AppLayoutGrid._();
+
+  /// Returns the M3 recommended outer margin for the given [sizeClass].
+  static double margin(WindowSizeClass sizeClass) {
+    switch (sizeClass) {
+      case WindowSizeClass.compact:
+        return 16.0;
+      default:
+        return 24.0;
+    }
+  }
+
+  /// Returns the M3 recommended gutter (spacing between columns)
+  /// for the given [sizeClass].
+  static double gutter(WindowSizeClass sizeClass) {
+    switch (sizeClass) {
+      case WindowSizeClass.compact:
+        return 16.0;
+      default:
+        return 24.0;
+    }
+  }
+
+  /// Returns the M3 recommended column count for the given [sizeClass].
+  static int columns(WindowSizeClass sizeClass) {
+    switch (sizeClass) {
+      case WindowSizeClass.compact:
+        return 4;
+      default:
+        return 12;
+    }
+  }
+}
+
+// =============================================================================
+// 2. WindowSizeClass — Material Design 3 Window Size Classes
+// =============================================================================
+
+/// Material Design 3 window size classes for responsive layout adaptation.
+///
+/// These classes define how layouts should adapt based on the available
+/// window width, following the [M3 Layout Guidelines](https://m3.material.io/foundations/layout).
+///
+/// | Class       | Width Range  | Layout Pattern         | Navigation   |
+/// |-------------|-------------|------------------------|--------------|
+/// | compact     | 0–599dp     | Single pane            | Bottom bar   |
+/// | medium      | 600–839dp   | List-detail possible   | Rail         |
+/// | expanded    | 840–1199dp  | List-detail            | Drawer       |
+/// | large       | 1200–1599dp | Multi-pane             | Drawer       |
+/// | extraLarge  | 1600dp+     | Multi-pane             | Drawer       |
+///
+/// Example:
+/// ```dart
+/// final sizeClass = AppBreakpoints.fromWidth(screenWidth);
+/// switch (sizeClass) {
+///   case WindowSizeClass.compact:
+///     return MobileLayout();
+///   case WindowSizeClass.medium:
+///     return TabletLayout();
+///   default:
+///     return DesktopLayout();
+/// }
+/// ```
+enum WindowSizeClass {
+  /// Small phones in portrait mode (0–599dp).
+  compact,
+
+  /// Large phones in landscape, small tablets in portrait (600–839dp).
+  medium,
+
+  /// Tablets in landscape, small desktops (840–1199dp).
+  expanded,
+
+  /// Standard desktops (1200–1599dp).
+  large,
+
+  /// Large desktops and ultra-wide screens (1600dp+).
+  extraLarge,
+}
+
+// =============================================================================
+// 3. AppBreakpoints — Material Design 3 Breakpoint Constants
+// =============================================================================
+
+/// Material Design 3 breakpoint constants and utilities.
+///
+/// Provides a single source of truth for all responsive breakpoint values
+/// in the application. All breakpoints follow the official M3 specifications.
+///
+/// Use [fromWidth] to determine the [WindowSizeClass] for a given width,
+/// or use the convenience helpers [isMobile], [isTablet], [isDesktop]
+/// for simplified 3-tier detection.
+///
+/// Example:
+/// ```dart
+/// // 5-tier detection
+/// final sizeClass = AppBreakpoints.fromWidth(screenWidth);
+///
+/// // 3-tier convenience
+/// if (AppBreakpoints.isMobile(screenWidth)) {
+///   // Mobile layout
+/// }
+/// ```
+class AppBreakpoints {
+  const AppBreakpoints._();
+
+  /// Compact breakpoint start (0dp).
+  ///
+  /// Applies to: small phones in portrait mode.
+  static const double compact = 0;
+
+  /// Medium breakpoint start (600dp).
+  ///
+  /// Applies to: large phones in landscape, small tablets in portrait.
+  static const double medium = 600;
+
+  /// Expanded breakpoint start (840dp).
+  ///
+  /// Applies to: tablets in landscape, small desktops.
+  static const double expanded = 840;
+
+  /// Large breakpoint start (1200dp).
+  ///
+  /// Applies to: standard desktops.
+  static const double large = 1200;
+
+  /// Extra large breakpoint start (1600dp).
+  ///
+  /// Applies to: large desktops and ultra-wide screens.
+  static const double extraLarge = 1600;
+
+  /// M3 recommended max content width for medium screens.
+  static const double maxContentMedium = 600;
+
+  /// M3 recommended max content width for expanded+ screens.
+  static const double maxContentExpanded = 840;
+
+  /// Resolves the [WindowSizeClass] for the given screen [width].
+  ///
+  /// Returns the appropriate M3 window size class based on the width
+  /// in density-independent pixels (dp).
+  ///
+  /// Example:
+  /// ```dart
+  /// final sizeClass = AppBreakpoints.fromWidth(
+  ///   MediaQuery.sizeOf(context).width,
+  /// );
+  /// ```
+  static WindowSizeClass fromWidth(double width) {
+    if (width >= extraLarge) return WindowSizeClass.extraLarge;
+    if (width >= large) return WindowSizeClass.large;
+    if (width >= expanded) return WindowSizeClass.expanded;
+    if (width >= medium) return WindowSizeClass.medium;
+    return WindowSizeClass.compact;
+  }
+
+  /// Returns `true` if [width] falls in the compact range (< 600dp).
+  ///
+  /// Convenience helper for simplified 3-tier responsive logic.
+  static bool isMobile(double width) => width < medium;
+
+  /// Returns `true` if [width] falls in the medium range (600dp–839dp).
+  ///
+  /// Convenience helper for simplified 3-tier responsive logic.
+  static bool isTablet(double width) => width >= medium && width < expanded;
+
+  /// Returns `true` if [width] falls in the expanded+ range (>= 840dp).
+  ///
+  /// Convenience helper for simplified 3-tier responsive logic.
+  static bool isDesktop(double width) => width >= expanded;
+}
+
+// =============================================================================
+// 4. CustomBreakpoints — User-Defined Breakpoints
+// =============================================================================
+
+/// Custom breakpoint definitions for non-standard responsive layouts.
+///
+/// Use this when the default M3 breakpoints in [AppBreakpoints] don't fit
+/// your layout requirements.
+///
+/// Example:
+/// ```dart
+/// const gameBreakpoints = CustomBreakpoints(
+///   medium: 480,
+///   expanded: 768,
+///   large: 1024,
+///   extraLarge: 1440,
+/// );
+///
+/// final sizeClass = gameBreakpoints.fromWidth(screenWidth);
+/// ```
+class CustomBreakpoints {
+  /// Creates custom breakpoint definitions.
+  ///
+  /// All values are in density-independent pixels (dp).
+  /// Values must satisfy: [medium] < [expanded] < [large] < [extraLarge].
+  const CustomBreakpoints({
+    this.medium = AppBreakpoints.medium,
+    this.expanded = AppBreakpoints.expanded,
+    this.large = AppBreakpoints.large,
+    this.extraLarge = AppBreakpoints.extraLarge,
+  }) : assert(medium > 0, 'medium must be > 0'),
+       assert(expanded > medium, 'expanded must be > medium'),
+       assert(large > expanded, 'large must be > expanded'),
+       assert(extraLarge > large, 'extraLarge must be > large');
+
+  /// Width threshold for medium window size class.
+  final double medium;
+
+  /// Width threshold for expanded window size class.
+  final double expanded;
+
+  /// Width threshold for large window size class.
+  final double large;
+
+  /// Width threshold for extra large window size class.
+  final double extraLarge;
+
+  /// Resolves the [WindowSizeClass] for the given [width]
+  /// using these custom breakpoints.
+  WindowSizeClass fromWidth(double width) {
+    if (width >= extraLarge) return WindowSizeClass.extraLarge;
+    if (width >= large) return WindowSizeClass.large;
+    if (width >= expanded) return WindowSizeClass.expanded;
+    if (width >= medium) return WindowSizeClass.medium;
+    return WindowSizeClass.compact;
+  }
+}
+
+// =============================================================================
+// 5. ResponsiveBuilder — Different Widgets Per Breakpoint
+// =============================================================================
+
+/// Renders different widget trees based on the current M3 breakpoint.
+///
+/// Provides two usage patterns:
+/// 1. **Builder callback** — full control with [builder] function.
+/// 2. **Named slots** — supply separate widgets per breakpoint.
+///
+/// When using named slots, the widget falls back to the nearest smaller
+/// variant if a specific breakpoint widget is not provided.
+///
+/// Example (builder):
+/// ```dart
+/// ResponsiveBuilder(
+///   builder: (context, sizeClass) {
+///     return Text('Current: $sizeClass');
+///   },
+/// )
+/// ```
+///
+/// Example (named slots):
+/// ```dart
+/// ResponsiveBuilder(
+///   compact: MobileLayout(),
+///   medium: TabletLayout(),
+///   expanded: DesktopLayout(),
+/// )
+/// ```
+class ResponsiveBuilder extends StatelessWidget {
+  /// Creates a responsive builder.
+  ///
+  /// Either [builder] or at least [compact] must be provided.
+  const ResponsiveBuilder({
+    super.key,
+    this.builder,
+    this.compact,
+    this.medium,
+    this.expanded,
+    this.large,
+    this.extraLarge,
+  }) : assert(
+         builder != null || compact != null,
+         'Either builder or compact widget must be provided',
+       );
+
+  /// Builder function receiving the current [WindowSizeClass].
+  ///
+  /// When provided, this takes priority over named slot widgets.
+  final Widget Function(BuildContext, WindowSizeClass)? builder;
+
+  /// Widget for compact screens (0–599dp).
+  final Widget? compact;
+
+  /// Widget for medium screens (600–839dp).
+  /// Falls back to [compact] if not provided.
+  final Widget? medium;
+
+  /// Widget for expanded screens (840–1199dp).
+  /// Falls back to [medium] → [compact] if not provided.
+  final Widget? expanded;
+
+  /// Widget for large screens (1200–1599dp).
+  /// Falls back to [expanded] → [medium] → [compact] if not provided.
+  final Widget? large;
+
+  /// Widget for extra large screens (1600dp+).
+  /// Falls back to [large] → [expanded] → [medium] → [compact].
+  final Widget? extraLarge;
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.sizeOf(context).width;
+    final sizeClass = AppBreakpoints.fromWidth(width);
+
+    if (builder != null) {
+      return builder!(context, sizeClass);
+    }
+
+    return _resolveWidget(sizeClass);
+  }
+
+  /// Resolves the widget for the given [sizeClass] with cascade fallback.
+  Widget _resolveWidget(WindowSizeClass sizeClass) {
+    switch (sizeClass) {
+      case WindowSizeClass.extraLarge:
+        return extraLarge ?? large ?? expanded ?? medium ?? compact!;
+      case WindowSizeClass.large:
+        return large ?? expanded ?? medium ?? compact!;
+      case WindowSizeClass.expanded:
+        return expanded ?? medium ?? compact!;
+      case WindowSizeClass.medium:
+        return medium ?? compact!;
+      case WindowSizeClass.compact:
+        return compact!;
+    }
+  }
+}
+
+// =============================================================================
+// 6. ResponsiveValue<T> — Generic Value Resolver Per Breakpoint
+// =============================================================================
+
+/// Returns different values based on the current M3 breakpoint.
+///
+/// Generic utility for resolving any type of value (numbers, strings,
+/// EdgeInsets, colors, etc.) per breakpoint with cascade fallback.
+///
+/// When a value for a specific breakpoint is not provided, it falls back
+/// to the nearest smaller breakpoint's value.
+///
+/// Example:
+/// ```dart
+/// final columns = const ResponsiveValue<int>(
+///   compact: 1,
+///   medium: 2,
+///   expanded: 3,
+/// ).resolve(context);
+///
+/// final padding = const ResponsiveValue<double>(
+///   compact: AppSpacing.sm,
+///   medium: AppSpacing.md,
+///   expanded: AppSpacing.lg,
+/// ).resolve(context);
+/// ```
+class ResponsiveValue<T> {
+  /// Creates a responsive value resolver.
+  ///
+  /// [compact] is required and serves as the base fallback value.
+  const ResponsiveValue({
+    required this.compact,
+    this.medium,
+    this.expanded,
+    this.large,
+    this.extraLarge,
+  });
+
+  /// Value for compact screens (0–599dp). Always required as fallback.
+  final T compact;
+
+  /// Value for medium screens (600–839dp). Falls back to [compact].
+  final T? medium;
+
+  /// Value for expanded screens (840–1199dp). Falls back to [medium].
+  final T? expanded;
+
+  /// Value for large screens (1200–1599dp). Falls back to [expanded].
+  final T? large;
+
+  /// Value for extra large screens (1600dp+). Falls back to [large].
+  final T? extraLarge;
+
+  /// Resolves the value for the current screen size.
+  ///
+  /// Uses [MediaQuery] to determine the current width and returns
+  /// the appropriate value with cascade fallback.
+  T resolve(BuildContext context) {
+    final width = MediaQuery.sizeOf(context).width;
+    final sizeClass = AppBreakpoints.fromWidth(width);
+    return resolveForClass(sizeClass);
+  }
+
+  /// Resolves the value for a specific [WindowSizeClass].
+  ///
+  /// Useful when you already have the size class and want to avoid
+  /// repeated [MediaQuery] lookups.
+  T resolveForClass(WindowSizeClass sizeClass) {
+    switch (sizeClass) {
+      case WindowSizeClass.extraLarge:
+        return extraLarge ?? large ?? expanded ?? medium ?? compact;
+      case WindowSizeClass.large:
+        return large ?? expanded ?? medium ?? compact;
+      case WindowSizeClass.expanded:
+        return expanded ?? medium ?? compact;
+      case WindowSizeClass.medium:
+        return medium ?? compact;
+      case WindowSizeClass.compact:
+        return compact;
+    }
+  }
+}
+
+// =============================================================================
+// 7. ResponsiveGridView — Adaptive Column Count Grid
+// =============================================================================
+
+/// A responsive grid that adapts its column count based on screen size.
+///
+/// Uses [AppSpacing] defaults for consistent grid spacing. The column count
+/// changes at M3 breakpoints for optimal content display.
+///
+/// M3 recommended column counts:
+/// - Compact: 2 columns (default)
+/// - Medium: 3 columns (default)
+/// - Expanded: 4 columns (default)
+/// - Large/Extra Large: follows expanded count
+///
+/// Example:
+/// ```dart
+/// ResponsiveGridView(
+///   children: items.map((item) => ItemCard(item: item)).toList(),
+/// )
+/// ```
+class ResponsiveGridView extends StatelessWidget {
+  /// Creates a responsive grid view.
+  const ResponsiveGridView({
+    super.key,
+    required this.children,
+    this.compactColumns = 2,
+    this.mediumColumns = 3,
+    this.expandedColumns = 4,
+    this.largeColumns,
+    this.extraLargeColumns,
+    this.spacing,
+    this.runSpacing,
+    this.padding,
+    this.shrinkWrap = false,
+    this.physics,
+    this.childAspectRatio = 1.0,
+  });
+
+  /// The grid items to display.
+  final List<Widget> children;
+
+  /// Number of columns on compact screens (default: 2).
+  final int compactColumns;
+
+  /// Number of columns on medium screens (default: 3).
+  final int mediumColumns;
+
+  /// Number of columns on expanded screens (default: 4).
+  final int expandedColumns;
+
+  /// Number of columns on large screens. Falls back to [expandedColumns].
+  final int? largeColumns;
+
+  /// Number of columns on extra large screens. Falls back to [largeColumns].
+  final int? extraLargeColumns;
+
+  /// Spacing between grid items.
+  ///
+  /// Defaults to [AppLayoutGrid.gutter] based on current size class.
+  final double? spacing;
+
+  /// Vertical spacing between rows. Falls back to [spacing] or
+  /// [AppLayoutGrid.gutter].
+  final double? runSpacing;
+
+  /// Optional padding around the grid.
+  ///
+  /// Defaults to [AppLayoutGrid.margin] for outer padding if not provided.
+  final EdgeInsetsGeometry? padding;
+
+  /// Whether the grid should shrink-wrap its content.
+  final bool shrinkWrap;
+
+  /// Scroll physics for the grid.
+  final ScrollPhysics? physics;
+
+  /// Aspect ratio of each grid child (default: 1.0).
+  final double childAspectRatio;
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.sizeOf(context).width;
+    final sizeClass = AppBreakpoints.fromWidth(width);
+    final columns = _resolveColumns(sizeClass);
+    final gutter = spacing ?? AppLayoutGrid.gutter(sizeClass);
+    final margin = padding ?? EdgeInsets.all(AppLayoutGrid.margin(sizeClass));
+
+    return GridView.count(
+      crossAxisCount: columns,
+      crossAxisSpacing: gutter,
+      mainAxisSpacing: runSpacing ?? gutter,
+      padding: margin,
+      shrinkWrap: shrinkWrap,
+      physics: physics,
+      childAspectRatio: childAspectRatio,
+      children: children,
+    );
+  }
+
+  /// Resolves column count with cascade fallback.
+  int _resolveColumns(WindowSizeClass sizeClass) {
+    switch (sizeClass) {
+      case WindowSizeClass.extraLarge:
+        return extraLargeColumns ?? largeColumns ?? expandedColumns;
+      case WindowSizeClass.large:
+        return largeColumns ?? expandedColumns;
+      case WindowSizeClass.expanded:
+        return expandedColumns;
+      case WindowSizeClass.medium:
+        return mediumColumns;
+      case WindowSizeClass.compact:
+        return compactColumns;
+    }
+  }
+}
+
+// =============================================================================
+// 8. AppLayoutGridContainer — M3 Adaptive Grid Layout Wrapper
+// =============================================================================
+
+/// A wrapper widget that provides M3-compliant margins and gutters.
+///
+/// Automatically applies the correct padding (margins) based on the
+/// current [WindowSizeClass].
+class AppLayoutGridContainer extends StatelessWidget {
+  /// Creates an adaptive layout grid container.
+  const AppLayoutGridContainer({
+    super.key,
+    required this.child,
+    this.padding,
+    this.maxWidth,
+  });
+
+  /// The widget to display within the grid.
+  final Widget child;
+
+  /// Optional custom padding. If provided, replaces M3 margins.
+  final EdgeInsetsGeometry? padding;
+
+  /// Optional max width constraint.
+  final double? maxWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final sizeClass = context.windowSizeClass;
+    final margin = padding ?? EdgeInsets.all(AppLayoutGrid.margin(sizeClass));
+
+    Widget content = Padding(padding: margin, child: child);
+
+    if (maxWidth != null) {
+      content = MaxWidthContainer(maxWidth: maxWidth!, child: content);
+    }
+
+    return content;
+  }
+}
+
+// =============================================================================
+// 10. ResponsiveLayout — Switch Entire Layouts By Breakpoint
+// =============================================================================
+
+/// Switches entire layout structures based on the current M3 breakpoint.
+///
+/// Unlike [ResponsiveBuilder], this widget is specifically designed for
+/// switching between fundamentally different layout structures
+/// (e.g., bottom navigation on mobile vs side navigation on desktop).
+///
+/// Falls back to the nearest smaller variant when a specific breakpoint
+/// layout is not provided.
+///
+/// M3 Layout Patterns:
+/// - **Compact:** Single pane with bottom navigation
+/// - **Medium:** List-detail with navigation rail
+/// - **Expanded:** List-detail with navigation drawer
+///
+/// Example:
+/// ```dart
+/// ResponsiveLayout(
+///   compact: Scaffold(
+///     body: ContentList(),
+///     bottomNavigationBar: AppBottomNavigationBar(...),
+///   ),
+///   medium: Row(
+///     children: [
+///       NavigationRail(...),
+///       Expanded(child: ContentList()),
+///     ],
+///   ),
+///   expanded: Row(
+///     children: [
+///       AppDrawer(...),
+///       Expanded(child: ContentList()),
+///       Expanded(child: DetailView()),
+///     ],
+///   ),
+/// )
+/// ```
+class ResponsiveLayout extends StatelessWidget {
+  /// Creates a responsive layout.
+  ///
+  /// [compact] is required and serves as the base layout.
+  const ResponsiveLayout({
+    super.key,
+    required this.compact,
+    this.medium,
+    this.expanded,
+    this.large,
+    this.extraLarge,
+  });
+
+  /// Layout for compact screens (0–599dp). Always required.
+  final Widget compact;
+
+  /// Layout for medium screens (600–839dp). Falls back to [compact].
+  final Widget? medium;
+
+  /// Layout for expanded screens (840–1199dp). Falls back to [medium].
+  final Widget? expanded;
+
+  /// Layout for large screens (1200–1599dp). Falls back to [expanded].
+  final Widget? large;
+
+  /// Layout for extra large screens (1600dp+). Falls back to [large].
+  final Widget? extraLarge;
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.sizeOf(context).width;
+    final sizeClass = AppBreakpoints.fromWidth(width);
+
+    switch (sizeClass) {
+      case WindowSizeClass.extraLarge:
+        return extraLarge ?? large ?? expanded ?? medium ?? compact;
+      case WindowSizeClass.large:
+        return large ?? expanded ?? medium ?? compact;
+      case WindowSizeClass.expanded:
+        return expanded ?? medium ?? compact;
+      case WindowSizeClass.medium:
+        return medium ?? compact;
+      case WindowSizeClass.compact:
+        return compact;
+    }
+  }
+}
+
+// =============================================================================
+// 10. ScreenMetrics — Screen Measurement Data
+// =============================================================================
+
+/// Immutable screen measurement data including dimensions, orientation,
+/// and M3 window size class.
+///
+/// Created by [ScreenSizeProvider] and accessible via
+/// `ScreenSizeProvider.of(context)` or `context.screenMetrics`.
+///
+/// Example:
+/// ```dart
+/// final metrics = ScreenSizeProvider.of(context);
+/// print('Width: ${metrics.width}');
+/// print('Size class: ${metrics.windowSizeClass}');
+/// print('Diagonal: ${metrics.diagonal}');
+/// ```
+class ScreenMetrics {
+  /// Creates screen metrics from the given dimensions.
+  const ScreenMetrics({
+    required this.width,
+    required this.height,
+    required this.orientation,
+    required this.windowSizeClass,
+  });
+
+  /// Screen width in density-independent pixels.
+  final double width;
+
+  /// Screen height in density-independent pixels.
+  final double height;
+
+  /// Current device orientation.
+  final Orientation orientation;
+
+  /// M3 window size class based on [width].
+  final WindowSizeClass windowSizeClass;
+
+  /// Screen diagonal in density-independent pixels.
+  double get diagonal => math.sqrt(width * width + height * height);
+
+  /// Returns `true` if the screen is in portrait orientation.
+  bool get isPortrait => orientation == Orientation.portrait;
+
+  /// Returns `true` if the screen is in landscape orientation.
+  bool get isLandscape => orientation == Orientation.landscape;
+
+  /// Returns `true` if the screen width is in the compact range.
+  bool get isMobile => AppBreakpoints.isMobile(width);
+
+  /// Returns `true` if the screen width is in the medium/expanded range.
+  bool get isTablet => AppBreakpoints.isTablet(width);
+
+  /// Returns `true` if the screen width is in the large+ range.
+  bool get isDesktop => AppBreakpoints.isDesktop(width);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ScreenMetrics &&
+        other.width == width &&
+        other.height == height &&
+        other.orientation == orientation &&
+        other.windowSizeClass == windowSizeClass;
+  }
+
+  @override
+  int get hashCode => Object.hash(width, height, orientation, windowSizeClass);
+
+  @override
+  String toString() =>
+      'ScreenMetrics(${width.toStringAsFixed(0)}x'
+      '${height.toStringAsFixed(0)}, '
+      '$windowSizeClass, $orientation)';
+}
+
+// =============================================================================
+// 11. ScreenSizeProvider — InheritedWidget for Screen Metrics
+// =============================================================================
+
+/// An [InheritedWidget] that provides [ScreenMetrics] to its descendants.
+///
+/// Wraps the widget tree and exposes screen dimensions, orientation,
+/// and M3 window size class via [ScreenSizeProvider.of] or
+/// `context.screenMetrics`.
+///
+/// Example:
+/// ```dart
+/// // Wrap your app or a subtree
+/// ScreenSizeProvider(
+///   child: MyApp(),
+/// )
+///
+/// // Access metrics anywhere below
+/// final metrics = ScreenSizeProvider.of(context);
+/// if (metrics.isMobile) {
+///   // Mobile-specific logic
+/// }
+/// ```
+class ScreenSizeProvider extends StatelessWidget {
+  /// Creates a screen size provider.
+  const ScreenSizeProvider({super.key, required this.child});
+
+  /// The widget below this provider in the tree.
+  final Widget child;
+
+  /// Retrieves the [ScreenMetrics] from the nearest ancestor provider.
+  ///
+  /// Throws if no [ScreenSizeProvider] is found in the widget tree.
+  /// Use [maybeOf] for a nullable version.
+  static ScreenMetrics of(BuildContext context) {
+    final data = context
+        .dependOnInheritedWidgetOfExactType<_ScreenMetricsScope>();
+    assert(
+      data != null,
+      'ScreenSizeProvider.of() called without a ScreenSizeProvider ancestor.',
+    );
+    return data!.metrics;
+  }
+
+  /// Retrieves the [ScreenMetrics] from the nearest ancestor provider,
+  /// or `null` if no provider exists.
+  static ScreenMetrics? maybeOf(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<_ScreenMetricsScope>()
+        ?.metrics;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final size = mediaQuery.size;
+    final orientation = mediaQuery.orientation;
+
+    final metrics = ScreenMetrics(
+      width: size.width,
+      height: size.height,
+      orientation: orientation,
+      windowSizeClass: AppBreakpoints.fromWidth(size.width),
+    );
+
+    return _ScreenMetricsScope(metrics: metrics, child: child);
+  }
+}
+
+/// Internal inherited widget holding [ScreenMetrics].
+class _ScreenMetricsScope extends InheritedWidget {
+  const _ScreenMetricsScope({required this.metrics, required super.child});
+
+  final ScreenMetrics metrics;
+
+  @override
+  bool updateShouldNotify(_ScreenMetricsScope oldWidget) =>
+      metrics != oldWidget.metrics;
+}
+
+// =============================================================================
+// 12. AppOrientationBuilder — Orientation + Responsive Integration
+// =============================================================================
+
+/// Builds widgets based on both device orientation and M3 window size class.
+///
+/// Provides two usage patterns:
+/// 1. **Builder callback** — full control with orientation and size class.
+/// 2. **Named slots** — supply separate widgets for portrait/landscape.
+///
+/// Example (builder):
+/// ```dart
+/// AppOrientationBuilder(
+///   builder: (context, orientation, sizeClass) {
+///     if (orientation == Orientation.landscape &&
+///         sizeClass == WindowSizeClass.compact) {
+///       return CompactLandscapeLayout();
+///     }
+///     return DefaultLayout();
+///   },
+/// )
+/// ```
+///
+/// Example (named slots):
+/// ```dart
+/// AppOrientationBuilder(
+///   portrait: PortraitLayout(),
+///   landscape: LandscapeLayout(),
+/// )
+/// ```
+class AppOrientationBuilder extends StatelessWidget {
+  /// Creates an orientation-aware builder.
+  ///
+  /// Either [builder] or at least [portrait] must be provided.
+  const AppOrientationBuilder({
+    super.key,
+    this.builder,
+    this.portrait,
+    this.landscape,
+  }) : assert(
+         builder != null || portrait != null,
+         'Either builder or portrait widget must be provided',
+       );
+
+  /// Builder receiving orientation and window size class.
+  final Widget Function(BuildContext, Orientation, WindowSizeClass)? builder;
+
+  /// Widget for portrait orientation. Falls back when [landscape] is null.
+  final Widget? portrait;
+
+  /// Widget for landscape orientation. Falls back to [portrait].
+  final Widget? landscape;
+
+  @override
+  Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final orientation = mediaQuery.orientation;
+    final sizeClass = AppBreakpoints.fromWidth(mediaQuery.size.width);
+
+    if (builder != null) {
+      return builder!(context, orientation, sizeClass);
+    }
+
+    if (orientation == Orientation.landscape) {
+      return landscape ?? portrait!;
+    }
+    return portrait!;
+  }
+}
+
+// =============================================================================
+// 13. MaxWidthContainer — Constrained Width Wrapper
+// =============================================================================
+
+/// A lightweight container that constrains its child to a maximum width.
+///
+/// Unlike [PageContainer], this widget provides only width constraint
+/// and optional centering without padding or SafeArea logic.
+///
+/// Useful for preventing content from stretching too wide on large screens
+/// while maintaining a clean, focused layout.
+///
+/// Example:
+/// ```dart
+/// MaxWidthContainer(
+///   maxWidth: 800,
+///   child: Column(
+///     children: [
+///       Text('Constrained content'),
+///     ],
+///   ),
+/// )
+///
+/// // Full-width on mobile, constrained on desktop
+/// MaxWidthContainer(
+///   child: ArticleContent(),
+/// )
+/// ```
+class MaxWidthContainer extends StatelessWidget {
+  /// Creates a max-width constrained container.
+  const MaxWidthContainer({
+    super.key,
+    required this.child,
+    this.maxWidth = AppBreakpoints.large,
+    this.center = true,
+  });
+
+  /// The widget to constrain.
+  final Widget child;
+
+  /// Maximum width in density-independent pixels.
+  ///
+  /// Defaults to [AppBreakpoints.large] (1200dp).
+  final double maxWidth;
+
+  /// Whether to center the child when the screen is wider than [maxWidth].
+  ///
+  /// Defaults to `true`.
+  final bool center;
+
+  /// Named constructor for narrow content (max 600dp).
+  ///
+  /// Follows M3 recommendation for medium screen content width.
+  const MaxWidthContainer.narrow({
+    super.key,
+    required this.child,
+    this.center = true,
+  }) : maxWidth = AppBreakpoints.maxContentMedium;
+
+  /// Named constructor for standard content (max 840dp).
+  ///
+  /// Follows M3 recommendation for expanded screen content width.
+  const MaxWidthContainer.standard({
+    super.key,
+    required this.child,
+    this.center = true,
+  }) : maxWidth = AppBreakpoints.maxContentExpanded;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: center ? Alignment.topCenter : Alignment.topLeft,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: maxWidth),
+        child: child,
+      ),
+    );
+  }
+}
+
+// =============================================================================
+// 14. ResponsiveIconSize — Adaptive Icon Sizing
+// =============================================================================
+
+/// Provides adaptive icon sizing based on M3 breakpoints.
+///
+/// Returns different icon sizes for different screen sizes, ensuring
+/// icons remain visually balanced across devices.
+///
+/// Example:
+/// ```dart
+/// Icon(
+///   Icons.home,
+///   size: ResponsiveIconSize.resolve(context),
+/// )
+///
+/// // Custom sizes
+/// Icon(
+///   Icons.settings,
+///   size: ResponsiveIconSize.resolve(
+///     context,
+///     compact: 20,
+///     medium: 24,
+///     expanded: 28,
+///   ),
+/// )
+/// ```
+class ResponsiveIconSize {
+  const ResponsiveIconSize._();
+
+  /// M3 default icon size for compact screens.
+  static const double defaultCompact = 20;
+
+  /// M3 default icon size for medium screens.
+  static const double defaultMedium = 24;
+
+  /// M3 default icon size for expanded+ screens.
+  static const double defaultExpanded = 28;
+
+  /// Resolves the appropriate icon size for the current screen size.
+  ///
+  /// Falls back to the nearest smaller value when not specified.
+  static double resolve(
+    BuildContext context, {
+    double compact = defaultCompact,
+    double medium = defaultMedium,
+    double expanded = defaultExpanded,
+    double? large,
+    double? extraLarge,
+  }) {
+    final width = MediaQuery.sizeOf(context).width;
+    final sizeClass = AppBreakpoints.fromWidth(width);
+
+    switch (sizeClass) {
+      case WindowSizeClass.extraLarge:
+        return extraLarge ?? large ?? expanded;
+      case WindowSizeClass.large:
+        return large ?? expanded;
+      case WindowSizeClass.expanded:
+        return expanded;
+      case WindowSizeClass.medium:
+        return medium;
+      case WindowSizeClass.compact:
+        return compact;
+    }
+  }
+}
+
+// =============================================================================
+// 15. ViewportHelpers — Device Form-Factor Detection
+// =============================================================================
+
+/// Utility class for detecting device form factors and viewport properties.
+///
+/// Provides simple boolean checks for common responsive layout decisions.
+/// Uses [AppBreakpoints] and [MediaQuery] internally.
+///
+/// Example:
+/// ```dart
+/// if (ViewportHelpers.isPhone(context)) {
+///   // Phone-specific logic
+/// }
+///
+/// if (ViewportHelpers.isLandscape(context)) {
+///   // Landscape-specific layout
+/// }
+/// ```
+class ViewportHelpers {
+  const ViewportHelpers._();
+
+  /// Returns `true` if the device is a phone (compact window size).
+  static bool isPhone(BuildContext context) {
+    return AppBreakpoints.isMobile(MediaQuery.sizeOf(context).width);
+  }
+
+  /// Returns `true` if the device is a tablet (medium/expanded window size).
+  static bool isTablet(BuildContext context) {
+    final width = MediaQuery.sizeOf(context).width;
+    return width >= AppBreakpoints.medium && width < AppBreakpoints.large;
+  }
+
+  /// Returns `true` if the device is a desktop (large+ window size).
+  static bool isDesktop(BuildContext context) {
+    return AppBreakpoints.isDesktop(MediaQuery.sizeOf(context).width);
+  }
+
+  /// Returns `true` if the device is in landscape orientation.
+  static bool isLandscape(BuildContext context) {
+    return MediaQuery.orientationOf(context) == Orientation.landscape;
+  }
+
+  /// Returns `true` if the device is in portrait orientation.
+  static bool isPortrait(BuildContext context) {
+    return MediaQuery.orientationOf(context) == Orientation.portrait;
+  }
+
+  /// Returns `true` if the device may be a foldable.
+  ///
+  /// Uses a heuristic: medium-width device in landscape orientation
+  /// suggests a foldable in unfolded state.
+  static bool isFoldable(BuildContext context) {
+    final size = MediaQuery.sizeOf(context);
+    final width = size.width;
+    final height = size.height;
+    // Heuristic: aspect ratio close to square with medium width
+    final aspectRatio = width / height;
+    return width >= AppBreakpoints.medium &&
+        width < AppBreakpoints.expanded &&
+        aspectRatio > 0.7 &&
+        aspectRatio < 1.5;
+  }
+}
+
+// =============================================================================
+// 16. ResponsiveExtension — BuildContext Extension Methods
+// =============================================================================
+
+/// Extension methods on [BuildContext] for convenient responsive access.
+///
+/// Provides quick access to screen metrics, window size class, and
+/// responsive value resolution without boilerplate.
+///
+/// Example:
+/// ```dart
+/// Widget build(BuildContext context) {
+///   if (context.isMobile) {
+///     return MobileLayout();
+///   }
+///
+///   final columns = context.responsiveValue<int>(
+///     compact: 1,
+///     medium: 2,
+///     expanded: 3,
+///   );
+///
+///   print('Screen: ${context.screenWidth}x${context.screenHeight}');
+///   print('Size class: ${context.windowSizeClass}');
+/// }
+/// ```
+extension ResponsiveExtension on BuildContext {
+  /// The current M3 [WindowSizeClass] based on screen width.
+  WindowSizeClass get windowSizeClass =>
+      AppBreakpoints.fromWidth(MediaQuery.sizeOf(this).width);
+
+  /// The current [ScreenMetrics] from the nearest [ScreenSizeProvider].
+  ///
+  /// Falls back to creating metrics from [MediaQuery] if no provider exists.
+  ScreenMetrics get screenMetrics {
+    final provided = ScreenSizeProvider.maybeOf(this);
+    if (provided != null) return provided;
+
+    final mediaQuery = MediaQuery.of(this);
+    return ScreenMetrics(
+      width: mediaQuery.size.width,
+      height: mediaQuery.size.height,
+      orientation: mediaQuery.orientation,
+      windowSizeClass: AppBreakpoints.fromWidth(mediaQuery.size.width),
+    );
+  }
+
+  /// Returns `true` if the screen is in the compact range (< 600dp).
+  bool get isMobile => AppBreakpoints.isMobile(MediaQuery.sizeOf(this).width);
+
+  /// Returns `true` if the screen is in the medium/expanded range.
+  bool get isTablet => AppBreakpoints.isTablet(MediaQuery.sizeOf(this).width);
+
+  /// Returns `true` if the screen is in the large+ range (>= 1200dp).
+  bool get isDesktop => AppBreakpoints.isDesktop(MediaQuery.sizeOf(this).width);
+
+  /// The current screen width in density-independent pixels.
+  double get screenWidth => MediaQuery.sizeOf(this).width;
+
+  /// The current screen height in density-independent pixels.
+  double get screenHeight => MediaQuery.sizeOf(this).height;
+
+  /// The current device orientation.
+  Orientation get orientation => MediaQuery.orientationOf(this);
+
+  /// Resolves a value based on the current M3 breakpoint.
+  ///
+  /// Shorthand for creating a [ResponsiveValue] and resolving it.
+  ///
+  /// Example:
+  /// ```dart
+  /// final padding = context.responsiveValue<double>(
+  ///   compact: AppSpacing.sm,
+  ///   medium: AppSpacing.md,
+  ///   expanded: AppSpacing.lg,
+  /// );
+  /// ```
+  T responsiveValue<T>({
+    required T compact,
+    T? medium,
+    T? expanded,
+    T? large,
+    T? extraLarge,
+  }) {
+    return ResponsiveValue<T>(
+      compact: compact,
+      medium: medium,
+      expanded: expanded,
+      large: large,
+      extraLarge: extraLarge,
+    ).resolve(this);
+  }
+
+  /// Returns a text style with font size scaled by breakpoint.
+  TextStyle? responsiveTextStyle(TextStyle? style) {
+    return Theme.of(this).responsiveTextStyle(this, style);
+  }
+
+  /// Returns spacing scaled by the current breakpoint.
+  double responsiveSpacing(double base) {
+    return Theme.of(this).responsiveSpacing(this, base);
+  }
+
+  /// Returns an icon size scaled by the current breakpoint.
+  double responsiveIconSize({double base = 24.0}) {
+    return Theme.of(this).responsiveIconSize(this, base: base);
+  }
+}
+
+// =============================================================================
+// 17. ResponsiveThemeExtension — Theme Integration
+// =============================================================================
+
+/// Extension on [ThemeData] for responsive theme values.
+///
+/// Provides convenience methods to scale theme-related values
+/// (spacing, text styles, icon sizes) based on the current breakpoint.
+///
+/// Example:
+/// ```dart
+/// final theme = Theme.of(context);
+/// final spacing = theme.responsiveSpacing(context, AppSpacing.md);
+/// final textStyle = theme.responsiveTextStyle(
+///   context,
+///   theme.textTheme.bodyLarge,
+/// );
+/// ```
+extension ResponsiveThemeExtension on ThemeData {
+  /// Returns spacing scaled by the current breakpoint.
+  ///
+  /// Scale factors:
+  /// - Compact: 1.0x
+  /// - Medium: 1.0x
+  /// - Expanded: 1.25x
+  /// - Large: 1.5x
+  /// - Extra Large: 1.5x
+  double responsiveSpacing(BuildContext context, double base) {
+    final sizeClass = AppBreakpoints.fromWidth(
+      MediaQuery.sizeOf(context).width,
+    );
+
+    final scaleFactor = switch (sizeClass) {
+      WindowSizeClass.compact => 1.0,
+      WindowSizeClass.medium => 1.0,
+      WindowSizeClass.expanded => 1.25,
+      WindowSizeClass.large => 1.5,
+      WindowSizeClass.extraLarge => 1.5,
+    };
+
+    // Round to nearest 4dp to maintain grid alignment
+    final scaledValue = base * scaleFactor;
+    return (scaledValue / 4).round() * 4.0;
+  }
+
+  /// Returns a text style with font size scaled by breakpoint.
+  ///
+  /// Scale factors:
+  /// - Compact: 0.9x
+  /// - Medium: 1.0x
+  /// - Expanded: 1.0x
+  /// - Large: 1.1x
+  /// - Extra Large: 1.1x
+  TextStyle? responsiveTextStyle(BuildContext context, TextStyle? style) {
+    if (style == null) return null;
+
+    final sizeClass = AppBreakpoints.fromWidth(
+      MediaQuery.sizeOf(context).width,
+    );
+
+    final scaleFactor = switch (sizeClass) {
+      WindowSizeClass.compact => 0.9,
+      WindowSizeClass.medium => 1.0,
+      WindowSizeClass.expanded => 1.0,
+      WindowSizeClass.large => 1.1,
+      WindowSizeClass.extraLarge => 1.1,
+    };
+
+    return style.copyWith(fontSize: (style.fontSize ?? 14.0) * scaleFactor);
+  }
+
+  /// Returns an icon size scaled by the current breakpoint.
+  double responsiveIconSize(BuildContext context, {double base = 24.0}) {
+    return ResponsiveIconSize.resolve(
+      context,
+      compact: base * 0.83,
+      medium: base,
+      expanded: base * 1.17,
+    );
+  }
+}

--- a/packages/core_kit/test/layout/responsive_layout_test.dart
+++ b/packages/core_kit/test/layout/responsive_layout_test.dart
@@ -1,0 +1,1428 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:core_kit/core_kit.dart';
+
+void main() {
+  // ===========================================================================
+  // Helper: wraps a widget with MaterialApp + MediaQuery at the given size
+  // ===========================================================================
+  Widget buildTestWidget({
+    required double screenWidth,
+    double screenHeight = 800,
+    required Widget child,
+  }) {
+    return MaterialApp(
+      home: MediaQuery(
+        data: MediaQueryData(size: Size(screenWidth, screenHeight)),
+        child: Scaffold(body: child),
+      ),
+    );
+  }
+
+  // ===========================================================================
+  // AppBreakpoints
+  // ===========================================================================
+  group('AppBreakpoints', () {
+    group('fromWidth', () {
+      test('returns compact for width 0', () {
+        expect(AppBreakpoints.fromWidth(0), WindowSizeClass.compact);
+      });
+
+      test('returns compact for width 599', () {
+        expect(AppBreakpoints.fromWidth(599), WindowSizeClass.compact);
+      });
+
+      test('returns medium for width 600', () {
+        expect(AppBreakpoints.fromWidth(600), WindowSizeClass.medium);
+      });
+
+      test('returns medium for width 839', () {
+        expect(AppBreakpoints.fromWidth(839), WindowSizeClass.medium);
+      });
+
+      test('returns expanded for width 840', () {
+        expect(AppBreakpoints.fromWidth(840), WindowSizeClass.expanded);
+      });
+
+      test('returns expanded for width 1199', () {
+        expect(AppBreakpoints.fromWidth(1199), WindowSizeClass.expanded);
+      });
+
+      test('returns large for width 1200', () {
+        expect(AppBreakpoints.fromWidth(1200), WindowSizeClass.large);
+      });
+
+      test('returns large for width 1599', () {
+        expect(AppBreakpoints.fromWidth(1599), WindowSizeClass.large);
+      });
+
+      test('returns extraLarge for width 1600', () {
+        expect(AppBreakpoints.fromWidth(1600), WindowSizeClass.extraLarge);
+      });
+
+      test('returns extraLarge for width 2560', () {
+        expect(AppBreakpoints.fromWidth(2560), WindowSizeClass.extraLarge);
+      });
+    });
+
+    group('convenience helpers', () {
+      test('isMobile returns true for width < 600', () {
+        expect(AppBreakpoints.isMobile(599), isTrue);
+        expect(AppBreakpoints.isMobile(0), isTrue);
+      });
+
+      test('isMobile returns false for width >= 600', () {
+        expect(AppBreakpoints.isMobile(600), isFalse);
+        expect(AppBreakpoints.isMobile(1200), isFalse);
+      });
+
+      test('isTablet returns true for 600 <= width < 840', () {
+        expect(AppBreakpoints.isTablet(600), isTrue);
+        expect(AppBreakpoints.isTablet(839), isTrue);
+      });
+
+      test('isTablet returns false outside range', () {
+        expect(AppBreakpoints.isTablet(599), isFalse);
+        expect(AppBreakpoints.isTablet(840), isFalse);
+      });
+
+      test('isDesktop returns true for width >= 840', () {
+        expect(AppBreakpoints.isDesktop(840), isTrue);
+        expect(AppBreakpoints.isDesktop(1200), isTrue);
+        expect(AppBreakpoints.isDesktop(1600), isTrue);
+        expect(AppBreakpoints.isDesktop(2560), isTrue);
+      });
+
+      test('isDesktop returns false for width < 840', () {
+        expect(AppBreakpoints.isDesktop(839), isFalse);
+        expect(AppBreakpoints.isDesktop(600), isFalse);
+      });
+    });
+
+    test('breakpoint constants match M3 spec', () {
+      expect(AppBreakpoints.compact, 0);
+      expect(AppBreakpoints.medium, 600);
+      expect(AppBreakpoints.expanded, 840);
+      expect(AppBreakpoints.large, 1200);
+      expect(AppBreakpoints.extraLarge, 1600);
+    });
+
+    test('content width constants match M3 spec', () {
+      expect(AppBreakpoints.maxContentMedium, 600);
+      expect(AppBreakpoints.maxContentExpanded, 840);
+    });
+
+    group('AppLayoutGrid', () {
+      test('margin returns 16 for compact, 24 otherwise', () {
+        expect(AppLayoutGrid.margin(WindowSizeClass.compact), 16.0);
+        expect(AppLayoutGrid.margin(WindowSizeClass.medium), 24.0);
+        expect(AppLayoutGrid.margin(WindowSizeClass.expanded), 24.0);
+      });
+
+      test('gutter returns 16 for compact, 24 otherwise', () {
+        expect(AppLayoutGrid.gutter(WindowSizeClass.compact), 16.0);
+        expect(AppLayoutGrid.gutter(WindowSizeClass.medium), 24.0);
+        expect(AppLayoutGrid.gutter(WindowSizeClass.expanded), 24.0);
+      });
+
+      test('columns returns 4 for compact, 12 otherwise', () {
+        expect(AppLayoutGrid.columns(WindowSizeClass.compact), 4);
+        expect(AppLayoutGrid.columns(WindowSizeClass.medium), 12);
+        expect(AppLayoutGrid.columns(WindowSizeClass.expanded), 12);
+      });
+    });
+  });
+
+  // ===========================================================================
+  // WindowSizeClass
+  // ===========================================================================
+  group('WindowSizeClass', () {
+    test('has 5 values matching M3 spec', () {
+      expect(WindowSizeClass.values.length, 5);
+    });
+
+    test('values are in order from smallest to largest', () {
+      expect(
+        WindowSizeClass.compact.index < WindowSizeClass.medium.index,
+        isTrue,
+      );
+      expect(
+        WindowSizeClass.medium.index < WindowSizeClass.expanded.index,
+        isTrue,
+      );
+      expect(
+        WindowSizeClass.expanded.index < WindowSizeClass.large.index,
+        isTrue,
+      );
+      expect(
+        WindowSizeClass.large.index < WindowSizeClass.extraLarge.index,
+        isTrue,
+      );
+    });
+  });
+
+  // ===========================================================================
+  // CustomBreakpoints
+  // ===========================================================================
+  group('CustomBreakpoints', () {
+    test('uses default M3 breakpoints when no args provided', () {
+      const custom = CustomBreakpoints();
+      expect(custom.medium, AppBreakpoints.medium);
+      expect(custom.expanded, AppBreakpoints.expanded);
+      expect(custom.large, AppBreakpoints.large);
+      expect(custom.extraLarge, AppBreakpoints.extraLarge);
+    });
+
+    test('resolves from custom breakpoints', () {
+      const custom = CustomBreakpoints(
+        medium: 480,
+        expanded: 768,
+        large: 1024,
+        extraLarge: 1440,
+      );
+
+      expect(custom.fromWidth(400), WindowSizeClass.compact);
+      expect(custom.fromWidth(480), WindowSizeClass.medium);
+      expect(custom.fromWidth(768), WindowSizeClass.expanded);
+      expect(custom.fromWidth(1024), WindowSizeClass.large);
+      expect(custom.fromWidth(1440), WindowSizeClass.extraLarge);
+    });
+  });
+
+  // ===========================================================================
+  // ResponsiveBuilder
+  // ===========================================================================
+  group('ResponsiveBuilder', () {
+    testWidgets('renders compact widget on small screen', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 400,
+          child: const ResponsiveBuilder(
+            compact: Text('compact'),
+            medium: Text('medium'),
+            expanded: Text('expanded'),
+          ),
+        ),
+      );
+
+      expect(find.text('compact'), findsOneWidget);
+      expect(find.text('medium'), findsNothing);
+    });
+
+    testWidgets('renders medium widget on medium screen', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 700,
+          child: const ResponsiveBuilder(
+            compact: Text('compact'),
+            medium: Text('medium'),
+            expanded: Text('expanded'),
+          ),
+        ),
+      );
+
+      expect(find.text('medium'), findsOneWidget);
+      expect(find.text('compact'), findsNothing);
+    });
+
+    testWidgets('renders expanded widget on expanded screen', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 900,
+          child: const ResponsiveBuilder(
+            compact: Text('compact'),
+            medium: Text('medium'),
+            expanded: Text('expanded'),
+          ),
+        ),
+      );
+
+      expect(find.text('expanded'), findsOneWidget);
+    });
+
+    testWidgets('falls back to compact when medium not provided', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 700,
+          child: const ResponsiveBuilder(compact: Text('compact')),
+        ),
+      );
+
+      expect(find.text('compact'), findsOneWidget);
+    });
+
+    testWidgets('falls back to medium when expanded not provided', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 900,
+          child: const ResponsiveBuilder(
+            compact: Text('compact'),
+            medium: Text('medium'),
+          ),
+        ),
+      );
+
+      expect(find.text('medium'), findsOneWidget);
+    });
+
+    testWidgets('uses builder callback when provided', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 400,
+          child: ResponsiveBuilder(
+            builder: (context, sizeClass) {
+              return Text('class: $sizeClass');
+            },
+          ),
+        ),
+      );
+
+      expect(find.text('class: WindowSizeClass.compact'), findsOneWidget);
+    });
+
+    testWidgets('builder takes priority over named slots', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 400,
+          child: ResponsiveBuilder(
+            builder: (context, sizeClass) => const Text('builder'),
+            compact: const Text('compact'),
+          ),
+        ),
+      );
+
+      expect(find.text('builder'), findsOneWidget);
+      expect(find.text('compact'), findsNothing);
+    });
+
+    testWidgets('renders large widget on large screen', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 1300,
+          child: const ResponsiveBuilder(
+            compact: Text('compact'),
+            large: Text('large'),
+          ),
+        ),
+      );
+
+      expect(find.text('large'), findsOneWidget);
+    });
+
+    testWidgets('renders extraLarge widget on extra large screen', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 1700,
+          child: const ResponsiveBuilder(
+            compact: Text('compact'),
+            extraLarge: Text('extraLarge'),
+          ),
+        ),
+      );
+
+      expect(find.text('extraLarge'), findsOneWidget);
+    });
+  });
+
+  // ===========================================================================
+  // ResponsiveValue
+  // ===========================================================================
+  group('ResponsiveValue', () {
+    testWidgets('resolves compact value on small screen', (tester) async {
+      int? resolved;
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 400,
+          child: Builder(
+            builder: (context) {
+              resolved = const ResponsiveValue<int>(
+                compact: 1,
+                medium: 2,
+                expanded: 3,
+              ).resolve(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(resolved, 1);
+    });
+
+    testWidgets('resolves medium value on medium screen', (tester) async {
+      int? resolved;
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 700,
+          child: Builder(
+            builder: (context) {
+              resolved = const ResponsiveValue<int>(
+                compact: 1,
+                medium: 2,
+                expanded: 3,
+              ).resolve(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(resolved, 2);
+    });
+
+    testWidgets('cascades to compact when medium not provided', (tester) async {
+      int? resolved;
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 700,
+          child: Builder(
+            builder: (context) {
+              resolved = const ResponsiveValue<int>(
+                compact: 1,
+              ).resolve(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(resolved, 1);
+    });
+
+    test('resolveForClass works without context', () {
+      const value = ResponsiveValue<String>(
+        compact: 'small',
+        medium: 'medium',
+        expanded: 'big',
+      );
+
+      expect(value.resolveForClass(WindowSizeClass.compact), 'small');
+      expect(value.resolveForClass(WindowSizeClass.medium), 'medium');
+      expect(value.resolveForClass(WindowSizeClass.expanded), 'big');
+      expect(value.resolveForClass(WindowSizeClass.large), 'big');
+      expect(value.resolveForClass(WindowSizeClass.extraLarge), 'big');
+    });
+
+    test('cascade fallback works correctly', () {
+      const value = ResponsiveValue<int>(compact: 1, expanded: 3);
+
+      expect(value.resolveForClass(WindowSizeClass.compact), 1);
+      expect(value.resolveForClass(WindowSizeClass.medium), 1);
+      expect(value.resolveForClass(WindowSizeClass.expanded), 3);
+      expect(value.resolveForClass(WindowSizeClass.large), 3);
+      expect(value.resolveForClass(WindowSizeClass.extraLarge), 3);
+    });
+  });
+
+  // ===========================================================================
+  // ResponsiveGridView
+  // ===========================================================================
+  group('ResponsiveGridView', () {
+    testWidgets('renders with default 2 columns on compact', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 400,
+          child: ResponsiveGridView(
+            children: List.generate(
+              4,
+              (i) => Container(key: ValueKey(i), color: Colors.blue),
+            ),
+          ),
+        ),
+      );
+
+      final gridView = tester.widget<GridView>(find.byType(GridView));
+      final delegate =
+          gridView.gridDelegate as SliverGridDelegateWithFixedCrossAxisCount;
+      expect(delegate.crossAxisCount, 2);
+    });
+
+    testWidgets('renders with 3 columns on medium', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 700,
+          child: ResponsiveGridView(
+            children: List.generate(
+              6,
+              (i) => Container(key: ValueKey(i), color: Colors.blue),
+            ),
+          ),
+        ),
+      );
+
+      final gridView = tester.widget<GridView>(find.byType(GridView));
+      final delegate =
+          gridView.gridDelegate as SliverGridDelegateWithFixedCrossAxisCount;
+      expect(delegate.crossAxisCount, 3);
+    });
+
+    testWidgets('renders with 4 columns on expanded', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 900,
+          child: ResponsiveGridView(
+            children: List.generate(
+              8,
+              (i) => Container(key: ValueKey(i), color: Colors.blue),
+            ),
+          ),
+        ),
+      );
+
+      final gridView = tester.widget<GridView>(find.byType(GridView));
+      final delegate =
+          gridView.gridDelegate as SliverGridDelegateWithFixedCrossAxisCount;
+      expect(delegate.crossAxisCount, 4);
+    });
+
+    testWidgets('uses AppSpacing.md as default spacing', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 400,
+          child: ResponsiveGridView(children: [Container(color: Colors.blue)]),
+        ),
+      );
+
+      final gridView = tester.widget<GridView>(find.byType(GridView));
+      final delegate =
+          gridView.gridDelegate as SliverGridDelegateWithFixedCrossAxisCount;
+      expect(delegate.crossAxisSpacing, AppSpacing.md);
+      expect(delegate.mainAxisSpacing, AppSpacing.md);
+    });
+
+    testWidgets('supports custom spacing', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 400,
+          child: ResponsiveGridView(
+            spacing: AppSpacing.lg,
+            runSpacing: AppSpacing.sm,
+            children: [Container(color: Colors.blue)],
+          ),
+        ),
+      );
+
+      final gridView = tester.widget<GridView>(find.byType(GridView));
+      final delegate =
+          gridView.gridDelegate as SliverGridDelegateWithFixedCrossAxisCount;
+      expect(delegate.crossAxisSpacing, AppSpacing.lg);
+      expect(delegate.mainAxisSpacing, AppSpacing.sm);
+    });
+
+    testWidgets('supports custom column counts', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 400,
+          child: ResponsiveGridView(
+            compactColumns: 1,
+            children: [Container(color: Colors.blue)],
+          ),
+        ),
+      );
+
+      final gridView = tester.widget<GridView>(find.byType(GridView));
+      final delegate =
+          gridView.gridDelegate as SliverGridDelegateWithFixedCrossAxisCount;
+      expect(delegate.crossAxisCount, 1);
+    });
+  });
+
+  // ===========================================================================
+  // ResponsiveLayout
+  // ===========================================================================
+  group('ResponsiveLayout', () {
+    testWidgets('renders compact layout on small screen', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 400,
+          child: ResponsiveLayout(
+            compact: const Text('compact'),
+            medium: const Text('medium'),
+            expanded: const Text('expanded'),
+          ),
+        ),
+      );
+
+      expect(find.text('compact'), findsOneWidget);
+    });
+
+    testWidgets('renders medium layout on medium screen', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 700,
+          child: ResponsiveLayout(
+            compact: const Text('compact'),
+            medium: const Text('medium'),
+          ),
+        ),
+      );
+
+      expect(find.text('medium'), findsOneWidget);
+    });
+
+    testWidgets('falls back to compact when medium not provided', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 700,
+          child: const ResponsiveLayout(compact: Text('compact')),
+        ),
+      );
+
+      expect(find.text('compact'), findsOneWidget);
+    });
+
+    testWidgets('renders expanded layout on large screen', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 1300,
+          child: ResponsiveLayout(
+            compact: const Text('compact'),
+            expanded: const Text('expanded'),
+          ),
+        ),
+      );
+
+      expect(find.text('expanded'), findsOneWidget);
+    });
+  });
+
+  // ===========================================================================
+  // ScreenMetrics
+  // ===========================================================================
+  group('ScreenMetrics', () {
+    test('calculates diagonal correctly', () {
+      const metrics = ScreenMetrics(
+        width: 300,
+        height: 400,
+        orientation: Orientation.portrait,
+        windowSizeClass: WindowSizeClass.compact,
+      );
+
+      expect(metrics.diagonal, 500);
+    });
+
+    test('isPortrait returns true for portrait orientation', () {
+      const metrics = ScreenMetrics(
+        width: 400,
+        height: 800,
+        orientation: Orientation.portrait,
+        windowSizeClass: WindowSizeClass.compact,
+      );
+
+      expect(metrics.isPortrait, isTrue);
+      expect(metrics.isLandscape, isFalse);
+    });
+
+    test('isLandscape returns true for landscape orientation', () {
+      const metrics = ScreenMetrics(
+        width: 800,
+        height: 400,
+        orientation: Orientation.landscape,
+        windowSizeClass: WindowSizeClass.medium,
+      );
+
+      expect(metrics.isLandscape, isTrue);
+      expect(metrics.isPortrait, isFalse);
+    });
+
+    test('isMobile/isTablet/isDesktop delegate to AppBreakpoints', () {
+      const mobile = ScreenMetrics(
+        width: 400,
+        height: 800,
+        orientation: Orientation.portrait,
+        windowSizeClass: WindowSizeClass.compact,
+      );
+      expect(mobile.isMobile, isTrue);
+      expect(mobile.isTablet, isFalse);
+      expect(mobile.isDesktop, isFalse);
+
+      const tablet = ScreenMetrics(
+        width: 800,
+        height: 1200,
+        orientation: Orientation.portrait,
+        windowSizeClass: WindowSizeClass.expanded,
+      );
+      expect(tablet.isMobile, isFalse);
+      expect(tablet.isTablet, isTrue);
+      expect(tablet.isDesktop, isFalse);
+
+      const desktop = ScreenMetrics(
+        width: 1400,
+        height: 900,
+        orientation: Orientation.landscape,
+        windowSizeClass: WindowSizeClass.large,
+      );
+      expect(desktop.isMobile, isFalse);
+      expect(desktop.isTablet, isFalse);
+      expect(desktop.isDesktop, isTrue);
+    });
+
+    test('equality works correctly', () {
+      const a = ScreenMetrics(
+        width: 400,
+        height: 800,
+        orientation: Orientation.portrait,
+        windowSizeClass: WindowSizeClass.compact,
+      );
+      const b = ScreenMetrics(
+        width: 400,
+        height: 800,
+        orientation: Orientation.portrait,
+        windowSizeClass: WindowSizeClass.compact,
+      );
+      const c = ScreenMetrics(
+        width: 500,
+        height: 800,
+        orientation: Orientation.portrait,
+        windowSizeClass: WindowSizeClass.compact,
+      );
+
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('toString includes dimensions and class', () {
+      const metrics = ScreenMetrics(
+        width: 400,
+        height: 800,
+        orientation: Orientation.portrait,
+        windowSizeClass: WindowSizeClass.compact,
+      );
+
+      final str = metrics.toString();
+      expect(str, contains('400'));
+      expect(str, contains('800'));
+      expect(str, contains('compact'));
+    });
+  });
+
+  // ===========================================================================
+  // ScreenSizeProvider
+  // ===========================================================================
+  group('ScreenSizeProvider', () {
+    testWidgets('provides correct metrics to descendants', (tester) async {
+      ScreenMetrics? result;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(size: Size(400, 800)),
+            child: ScreenSizeProvider(
+              child: Builder(
+                builder: (context) {
+                  result = ScreenSizeProvider.of(context);
+                  return const SizedBox.shrink();
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(result, isNotNull);
+      expect(result!.width, 400);
+      expect(result!.height, 800);
+      expect(result!.windowSizeClass, WindowSizeClass.compact);
+    });
+
+    testWidgets('maybeOf returns null without provider', (tester) async {
+      ScreenMetrics? result;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              result = ScreenSizeProvider.maybeOf(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(result, isNull);
+    });
+
+    testWidgets('updates when screen size changes', (tester) async {
+      ScreenMetrics? result;
+
+      Widget buildWithWidth(double width) {
+        return MaterialApp(
+          home: MediaQuery(
+            data: MediaQueryData(size: Size(width, 800)),
+            child: ScreenSizeProvider(
+              child: Builder(
+                builder: (context) {
+                  result = ScreenSizeProvider.of(context);
+                  return const SizedBox.shrink();
+                },
+              ),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(buildWithWidth(400));
+      expect(result!.windowSizeClass, WindowSizeClass.compact);
+
+      await tester.pumpWidget(buildWithWidth(700));
+      expect(result!.windowSizeClass, WindowSizeClass.medium);
+
+      await tester.pumpWidget(buildWithWidth(900));
+      expect(result!.windowSizeClass, WindowSizeClass.expanded);
+    });
+  });
+
+  // ===========================================================================
+  // AppOrientationBuilder
+  // ===========================================================================
+  group('AppOrientationBuilder', () {
+    testWidgets('renders portrait widget in portrait mode', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(size: Size(400, 800)),
+            child: const AppOrientationBuilder(
+              portrait: Text('portrait'),
+              landscape: Text('landscape'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('portrait'), findsOneWidget);
+      expect(find.text('landscape'), findsNothing);
+    });
+
+    testWidgets('renders landscape widget in landscape mode', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(size: Size(800, 400)),
+            child: const AppOrientationBuilder(
+              portrait: Text('portrait'),
+              landscape: Text('landscape'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('landscape'), findsOneWidget);
+      expect(find.text('portrait'), findsNothing);
+    });
+
+    testWidgets('falls back to portrait when landscape not provided', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(size: Size(800, 400)),
+            child: const AppOrientationBuilder(portrait: Text('portrait')),
+          ),
+        ),
+      );
+
+      expect(find.text('portrait'), findsOneWidget);
+    });
+
+    testWidgets('builder provides orientation and sizeClass', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(size: Size(400, 800)),
+            child: AppOrientationBuilder(
+              builder: (context, orientation, sizeClass) {
+                return Text('$orientation $sizeClass');
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        find.text('Orientation.portrait WindowSizeClass.compact'),
+        findsOneWidget,
+      );
+    });
+  });
+
+  // ===========================================================================
+  // MaxWidthContainer
+  // ===========================================================================
+  group('MaxWidthContainer', () {
+    testWidgets('constrains child width', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 1600,
+          child: const MaxWidthContainer(maxWidth: 800, child: Placeholder()),
+        ),
+      );
+
+      final constrainedBox = tester.widget<ConstrainedBox>(
+        find.descendant(
+          of: find.byType(MaxWidthContainer),
+          matching: find.byType(ConstrainedBox),
+        ),
+      );
+      expect(constrainedBox.constraints.maxWidth, 800);
+    });
+
+    testWidgets('centers child by default', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 1600,
+          child: const MaxWidthContainer(maxWidth: 800, child: Placeholder()),
+        ),
+      );
+
+      final align = tester.widget<Align>(find.byType(Align));
+      expect(align.alignment, Alignment.topCenter);
+    });
+
+    testWidgets('aligns left when center is false', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 1600,
+          child: const MaxWidthContainer(
+            maxWidth: 800,
+            center: false,
+            child: Placeholder(),
+          ),
+        ),
+      );
+
+      final align = tester.widget<Align>(find.byType(Align));
+      expect(align.alignment, Alignment.topLeft);
+    });
+
+    testWidgets('narrow constructor uses 600dp max', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 1600,
+          child: const MaxWidthContainer.narrow(child: Placeholder()),
+        ),
+      );
+
+      final constrainedBox = tester.widget<ConstrainedBox>(
+        find.descendant(
+          of: find.byType(MaxWidthContainer),
+          matching: find.byType(ConstrainedBox),
+        ),
+      );
+      expect(constrainedBox.constraints.maxWidth, 600);
+    });
+
+    testWidgets('standard constructor uses 840dp max', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 1600,
+          child: const MaxWidthContainer.standard(child: Placeholder()),
+        ),
+      );
+
+      final constrainedBox = tester.widget<ConstrainedBox>(
+        find.descendant(
+          of: find.byType(MaxWidthContainer),
+          matching: find.byType(ConstrainedBox),
+        ),
+      );
+      expect(constrainedBox.constraints.maxWidth, 840);
+    });
+  });
+
+  // ===========================================================================
+  // ViewportHelpers
+  // ===========================================================================
+  group('ViewportHelpers', () {
+    testWidgets('isPhone returns true for compact width', (tester) async {
+      bool? result;
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 400,
+          child: Builder(
+            builder: (context) {
+              result = ViewportHelpers.isPhone(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(result, isTrue);
+    });
+
+    testWidgets('isPhone returns false for medium width', (tester) async {
+      bool? result;
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 700,
+          child: Builder(
+            builder: (context) {
+              result = ViewportHelpers.isPhone(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(result, isFalse);
+    });
+
+    testWidgets('isTablet returns true for medium/expanded width', (
+      tester,
+    ) async {
+      bool? result;
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 900,
+          child: Builder(
+            builder: (context) {
+              result = ViewportHelpers.isTablet(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(result, isTrue);
+    });
+
+    testWidgets('isDesktop returns true for expanded+ width', (tester) async {
+      bool? result;
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 900,
+          child: Builder(
+            builder: (context) {
+              result = ViewportHelpers.isDesktop(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(result, isTrue);
+    });
+
+    testWidgets('isLandscape returns true for landscape', (tester) async {
+      bool? result;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(size: Size(800, 400)),
+            child: Scaffold(
+              body: Builder(
+                builder: (context) {
+                  result = ViewportHelpers.isLandscape(context);
+                  return const SizedBox.shrink();
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(result, isTrue);
+    });
+
+    testWidgets('isPortrait returns true for portrait', (tester) async {
+      bool? result;
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 400,
+          screenHeight: 800,
+          child: Builder(
+            builder: (context) {
+              result = ViewportHelpers.isPortrait(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(result, isTrue);
+    });
+  });
+
+  // ===========================================================================
+  // ResponsiveExtension
+  // ===========================================================================
+  group('ResponsiveExtension', () {
+    testWidgets('windowSizeClass returns correct class', (tester) async {
+      WindowSizeClass? result;
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 700,
+          child: Builder(
+            builder: (context) {
+              result = context.windowSizeClass;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(result, WindowSizeClass.medium);
+    });
+
+    testWidgets('isMobile/isTablet/isDesktop work correctly', (tester) async {
+      bool? mobile;
+      bool? tablet;
+      bool? desktop;
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 700,
+          child: Builder(
+            builder: (context) {
+              mobile = context.isMobile;
+              tablet = context.isTablet;
+              desktop = context.isDesktop;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      // 700 is Tablet (600-839)
+      expect(mobile, isFalse);
+      expect(tablet, isTrue);
+      expect(desktop, isFalse);
+    });
+
+    testWidgets('screenWidth and screenHeight return correct values', (
+      tester,
+    ) async {
+      double? width;
+      double? height;
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 375,
+          screenHeight: 812,
+          child: Builder(
+            builder: (context) {
+              width = context.screenWidth;
+              height = context.screenHeight;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(width, 375);
+      expect(height, 812);
+    });
+
+    testWidgets('responsiveValue resolves correctly', (tester) async {
+      int? result;
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 700,
+          child: Builder(
+            builder: (context) {
+              result = context.responsiveValue<int>(
+                compact: 1,
+                medium: 2,
+                expanded: 3,
+              );
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(result, 2);
+    });
+
+    testWidgets('screenMetrics works without ScreenSizeProvider', (
+      tester,
+    ) async {
+      ScreenMetrics? metrics;
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 400,
+          screenHeight: 800,
+          child: Builder(
+            builder: (context) {
+              metrics = context.screenMetrics;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(metrics, isNotNull);
+      expect(metrics!.width, 400);
+      expect(metrics!.height, 800);
+      expect(metrics!.windowSizeClass, WindowSizeClass.compact);
+    });
+
+    testWidgets('screenMetrics uses ScreenSizeProvider when available', (
+      tester,
+    ) async {
+      ScreenMetrics? metrics;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(size: Size(700, 1000)),
+            child: ScreenSizeProvider(
+              child: Scaffold(
+                body: Builder(
+                  builder: (context) {
+                    metrics = context.screenMetrics;
+                    return const SizedBox.shrink();
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(metrics, isNotNull);
+      expect(metrics!.width, 700);
+      expect(metrics!.windowSizeClass, WindowSizeClass.medium);
+    });
+  });
+
+  // ===========================================================================
+  // ResponsiveThemeExtension
+  // ===========================================================================
+  group('ResponsiveThemeExtension', () {
+    testWidgets('responsiveSpacing scales for compact', (tester) async {
+      double? result;
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 400,
+          child: Builder(
+            builder: (context) {
+              result = Theme.of(context).responsiveSpacing(context, 16);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      // Compact: 1.0x, 16 * 1.0 = 16, rounded to 4dp = 16
+      expect(result, 16);
+    });
+
+    testWidgets('responsiveSpacing scales for expanded', (tester) async {
+      double? result;
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 900,
+          child: Builder(
+            builder: (context) {
+              result = Theme.of(context).responsiveSpacing(context, 16);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      // Expanded: 1.25x, 16 * 1.25 = 20, rounded to 4dp = 20
+      expect(result, 20);
+    });
+
+    testWidgets('responsiveSpacing scales for large', (tester) async {
+      double? result;
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 1300,
+          child: Builder(
+            builder: (context) {
+              result = Theme.of(context).responsiveSpacing(context, 16);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      // Large: 1.5x, 16 * 1.5 = 24, rounded to 4dp = 24
+      expect(result, 24);
+    });
+
+    testWidgets('responsiveTextStyle scales font size', (tester) async {
+      TextStyle? result;
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 400,
+          child: Builder(
+            builder: (context) {
+              const baseStyle = TextStyle(fontSize: 16);
+              result = Theme.of(
+                context,
+              ).responsiveTextStyle(context, baseStyle);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      // Compact: 0.9x, 16 * 0.9 = 14.4
+      expect(result!.fontSize, closeTo(14.4, 0.01));
+    });
+
+    testWidgets('responsiveTextStyle returns null for null input', (
+      tester,
+    ) async {
+      TextStyle? result;
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 400,
+          child: Builder(
+            builder: (context) {
+              result = Theme.of(context).responsiveTextStyle(context, null);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(result, isNull);
+    });
+
+    testWidgets('responsiveIconSize delegates to ResponsiveIconSize', (
+      tester,
+    ) async {
+      double? result;
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 400,
+          child: Builder(
+            builder: (context) {
+              result = Theme.of(context).responsiveIconSize(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      // base=24, compact factor=0.83, 24*0.83 ≈ 19.92
+      expect(result, closeTo(19.92, 0.1));
+    });
+  });
+
+  // ===========================================================================
+  // ResponsiveIconSize
+  // ===========================================================================
+  group('ResponsiveIconSize', () {
+    testWidgets('returns compact size on small screen', (tester) async {
+      double? result;
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 400,
+          child: Builder(
+            builder: (context) {
+              result = ResponsiveIconSize.resolve(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(result, ResponsiveIconSize.defaultCompact);
+    });
+
+    testWidgets('returns medium size on medium screen', (tester) async {
+      double? result;
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 700,
+          child: Builder(
+            builder: (context) {
+              result = ResponsiveIconSize.resolve(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(result, ResponsiveIconSize.defaultMedium);
+    });
+
+    testWidgets('returns expanded size on expanded screen', (tester) async {
+      double? result;
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 900,
+          child: Builder(
+            builder: (context) {
+              result = ResponsiveIconSize.resolve(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(result, ResponsiveIconSize.defaultExpanded);
+    });
+
+    testWidgets('supports custom sizes', (tester) async {
+      double? result;
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 400,
+          child: Builder(
+            builder: (context) {
+              result = ResponsiveIconSize.resolve(
+                context,
+                compact: 16,
+                medium: 20,
+                expanded: 24,
+              );
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      expect(result, 16);
+    });
+  });
+  // ===========================================================================
+  // AppLayoutGridContainer
+  // ===========================================================================
+  group('AppLayoutGridContainer', () {
+    testWidgets('applies M3 margins by default', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 400,
+          child: const AppLayoutGridContainer(child: Placeholder()),
+        ),
+      );
+
+      final padding = tester.widget<Padding>(find.byType(Padding));
+      expect(padding.padding, const EdgeInsets.all(16.0));
+    });
+
+    testWidgets('applies standard M3 margins for expanded', (tester) async {
+      await tester.pumpWidget(
+        buildTestWidget(
+          screenWidth: 900,
+          child: const AppLayoutGridContainer(child: Placeholder()),
+        ),
+      );
+
+      final padding = tester.widget<Padding>(find.byType(Padding));
+      expect(padding.padding, const EdgeInsets.all(24.0));
+    });
+  });
+}

--- a/widgetbook_kit/lib/stories/core_kit/layout/responsive_layout_stories.dart
+++ b/widgetbook_kit/lib/stories/core_kit/layout/responsive_layout_stories.dart
@@ -1,0 +1,968 @@
+// SPDX-FileCopyrightText: 2025 hexaTune LLC
+// SPDX-License-Identifier: MIT
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:core_kit/core_kit.dart';
+
+/// Widgetbook stories for the Responsive Layout system.
+///
+/// Demonstrates Material Design 3 responsive breakpoints, adaptive layouts,
+/// and responsive utilities following the project requirements.
+
+// =============================================================================
+@widgetbook.UseCase(name: 'Interactive Playground', type: ResponsiveLayout)
+Widget responsiveLayoutPlayground(BuildContext context) {
+  final title = context.knobs.string(
+    label: 'Dashboard Title',
+    initialValue: 'Dashboard',
+  );
+
+  final baseSpacing = context.knobs.double.slider(
+    label: 'Base Spacing',
+    initialValue: AppSpacing.md,
+    min: 8,
+    max: 32,
+  );
+
+  final limitWidth = context.knobs.boolean(
+    label: 'Limit Desktop Width',
+    initialValue: true,
+  );
+
+  return ResponsiveBuilder(
+    builder: (ctx, sizeClass) {
+      final isCompact = sizeClass == WindowSizeClass.compact;
+      final spacing = ctx.responsiveSpacing(baseSpacing);
+
+      Widget content = SingleChildScrollView(
+        padding: EdgeInsets.symmetric(
+          horizontal: AppLayoutGrid.margin(sizeClass),
+          vertical: ctx.responsiveSpacing(AppSpacing.lg),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                AppH1(title),
+                if (!isCompact)
+                  AppChip.assist(
+                    label: sizeClass.name.toUpperCase(),
+                    icon: _sizeClassIcon(sizeClass),
+                  ),
+              ],
+            ),
+            VGap(spacing),
+            // Adaptive Stats Grid
+            ResponsiveGridView(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              compactColumns: 1,
+              mediumColumns: 2,
+              expandedColumns: 4,
+              spacing: spacing,
+              padding: EdgeInsets.zero,
+              children: [
+                _buildStatCard(ctx, 'Total Users', '1,284', Icons.people),
+                _buildStatCard(ctx, 'Active Now', '542', Icons.bolt),
+                _buildStatCard(ctx, 'Revenue', '\$12,4k', Icons.payments),
+                _buildStatCard(ctx, 'Growth', '+12%', Icons.trending_up),
+              ],
+            ),
+            VGap(spacing),
+            // Multi-Value Demo Card
+            AppCard(
+              color: ctx.responsiveValue(
+                compact: Theme.of(
+                  ctx,
+                ).colorScheme.primaryContainer.withValues(alpha: 0.2),
+                medium: Theme.of(
+                  ctx,
+                ).colorScheme.secondaryContainer.withValues(alpha: 0.2),
+                expanded: Theme.of(
+                  ctx,
+                ).colorScheme.tertiaryContainer.withValues(alpha: 0.2),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const AppLabel.large('System Intelligence'),
+                  const VGap.xs(),
+                  AppBodyText(
+                    'This container uses context.responsiveValue to change its '
+                    'color and context.responsiveSpacing (currently ${spacing.toStringAsFixed(1)}dp) '
+                    'to manage its internal and external gaps.',
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      );
+
+      if (limitWidth) {
+        content = MaxWidthContainer.standard(child: content);
+      }
+
+      return content;
+    },
+  );
+}
+
+Widget _buildStatCard(
+  BuildContext ctx,
+  String label,
+  String val,
+  IconData icon,
+) {
+  return AppCard(
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            AppLabel.small(
+              label,
+              color: Theme.of(ctx).colorScheme.onSurfaceVariant,
+            ),
+            Container(
+              padding: const EdgeInsets.all(6),
+              decoration: BoxDecoration(
+                color: Theme.of(ctx).colorScheme.primary.withValues(alpha: 0.1),
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                icon,
+                color: Theme.of(ctx).colorScheme.primary,
+                size: ctx.responsiveValue(
+                  compact: 16,
+                  medium: 18,
+                  expanded: 20,
+                ),
+              ),
+            ),
+          ],
+        ),
+        const VGap.xs(),
+        AppH3(val),
+      ],
+    ),
+  );
+}
+
+// =============================================================================
+// Breakpoint System Demo
+// =============================================================================
+
+/// Breakpoint System — shows sizes, margins, gutters, and columns
+@widgetbook.UseCase(name: 'Breakpoint System', type: ResponsiveLayout)
+Widget responsiveLayoutM3Grid(BuildContext context) {
+  final showOverlay = context.knobs.boolean(
+    label: 'Show Grid Overlay',
+    initialValue: true,
+  );
+
+  // Fixed values to strictly demonstrate the MD3 system
+  return _ResponsiveGridLayout(
+    showOverlay: showOverlay,
+    compactItems: 2,
+    mediumItems: 3,
+    expandedItems: 4,
+  );
+}
+
+class _ResponsiveGridLayout extends StatelessWidget {
+  final bool showOverlay;
+  final int compactItems;
+  final int mediumItems;
+  final int expandedItems;
+
+  const _ResponsiveGridLayout({
+    required this.showOverlay,
+    required this.compactItems,
+    required this.mediumItems,
+    required this.expandedItems,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final sizeClass = context.windowSizeClass;
+    final margin = AppLayoutGrid.margin(sizeClass);
+    final gutter = AppLayoutGrid.gutter(sizeClass);
+    final columns = AppLayoutGrid.columns(sizeClass);
+
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        // Content Layer
+        SingleChildScrollView(
+          padding: EdgeInsets.symmetric(
+            vertical: context.responsiveSpacing(AppSpacing.md),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: EdgeInsets.symmetric(horizontal: margin),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const AppH3('M3 Breakpoint System'),
+                    const VGap.md(),
+                    _GridInfoCard(),
+                  ],
+                ),
+              ),
+              const VGap.lg(),
+              ResponsiveGridView(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                compactColumns: compactItems,
+                mediumColumns: mediumItems,
+                expandedColumns: expandedItems,
+                spacing: gutter,
+                padding: EdgeInsets.symmetric(horizontal: margin),
+                children: List.generate(
+                  12,
+                  (index) => _GridDemoItem(index: index),
+                ),
+              ),
+              const Gap.xxl(),
+            ],
+          ),
+        ),
+
+        // Grid Overlay Layer (In-file implementation for DRY/Project Rules)
+        if (showOverlay)
+          IgnorePointer(
+            child: Padding(
+              padding: EdgeInsets.symmetric(horizontal: margin),
+              child: Row(
+                children: List.generate(columns * 2 - 1, (index) {
+                  if (index.isEven) {
+                    return Expanded(
+                      child: Container(
+                        color: Colors.red.withValues(alpha: 0.08),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Container(
+                              width: 1,
+                              color: Colors.blue.withValues(alpha: 0.1),
+                            ),
+                            Container(
+                              width: 1,
+                              color: Colors.blue.withValues(alpha: 0.1),
+                            ),
+                          ],
+                        ),
+                      ),
+                    );
+                  } else {
+                    return Container(
+                      width: gutter,
+                      color: Colors.blue.withValues(alpha: 0.05),
+                    );
+                  }
+                }),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _GridInfoCard extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final sizeClass = context.windowSizeClass;
+    final margin = AppLayoutGrid.margin(sizeClass);
+    final gutter = AppLayoutGrid.gutter(sizeClass);
+    final columns = AppLayoutGrid.columns(sizeClass);
+
+    return AppCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                _sizeClassIcon(sizeClass),
+                color: Theme.of(context).colorScheme.primary,
+              ),
+              const HGap.md(),
+              AppLabel.large('Size Class: ${sizeClass.name.toUpperCase()}'),
+            ],
+          ),
+          const VGap.sm(),
+          AppCaption(
+            text:
+                'Columns: $columns | Margin: ${margin}dp | Gutter: ${gutter}dp',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GridDemoItem extends StatelessWidget {
+  final int index;
+
+  const _GridDemoItem({required this.index});
+
+  @override
+  Widget build(BuildContext context) {
+    return AppCard(
+      elevation: 0,
+      color: Theme.of(
+        context,
+      ).colorScheme.primaryContainer.withValues(alpha: 0.7),
+      shape: AppRadius.smShape.copyWith(
+        side: BorderSide(
+          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
+        ),
+      ),
+      child: SizedBox(
+        height: 120,
+        child: Center(
+          child: AppLabel.large(
+            'Item ${index + 1}',
+            color: Theme.of(context).colorScheme.onPrimaryContainer,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// =============================================================================
+// Adaptive Navigation
+// =============================================================================
+
+/// Responsive Navigation — bottom nav (compact) → rail (medium) → drawer
+/// (expanded)
+@widgetbook.UseCase(name: 'Adaptive Navigation', type: ResponsiveLayout)
+Widget responsiveLayoutNavigation(BuildContext context) {
+  final selectedIndex = context.knobs.int.slider(
+    label: 'Selected Tab',
+    initialValue: 0,
+    min: 0,
+    max: 3,
+  );
+
+  final destinations = [
+    const AppBottomNavigationDestination(icon: Icon(Icons.home), label: 'Home'),
+    const AppBottomNavigationDestination(
+      icon: Icon(Icons.search),
+      label: 'Search',
+    ),
+    const AppBottomNavigationDestination(
+      icon: Icon(Icons.notifications),
+      label: 'Alerts',
+    ),
+    const AppBottomNavigationDestination(
+      icon: Icon(Icons.person),
+      label: 'Profile',
+    ),
+  ];
+
+  final drawerDestinations = [
+    const AppDrawerDestination(icon: Icons.home, label: 'Home'),
+    const AppDrawerDestination(icon: Icons.search, label: 'Search'),
+    const AppDrawerDestination(icon: Icons.notifications, label: 'Alerts'),
+    const AppDrawerDestination(icon: Icons.person, label: 'Profile'),
+  ];
+
+  final railDestinations = destinations
+      .map((d) => NavigationRailDestination(icon: d.icon, label: Text(d.label)))
+      .toList();
+
+  // (Drawer items used directly in AppDrawer via destinations)
+
+  Widget content(String label) {
+    return Center(
+      child: AppCard(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            AppH2(label),
+            const VGap.sm(),
+            ResponsiveBuilder(
+              builder: (ctx, sizeClass) =>
+                  AppBodyText('Navigation: ${_navType(sizeClass)}'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  return ResponsiveLayout(
+    // Compact: bottom navigation bar
+    compact: CoreScaffold(
+      body: content('Bottom Navigation (Compact)'),
+      bottomNavigationBar: AppBottomNavigationBar(
+        selectedIndex: selectedIndex,
+        onDestinationSelected: (idx) => {},
+        destinations: destinations,
+      ),
+    ),
+    // Medium: navigation rail
+    medium: CoreScaffold(
+      body: Row(
+        children: [
+          NavigationRail(
+            selectedIndex: selectedIndex,
+            destinations: railDestinations,
+          ),
+          const VerticalDivider(thickness: 1, width: 1),
+          Expanded(child: content('Navigation Rail (Medium)')),
+        ],
+      ),
+    ),
+    // Expanded: navigation drawer
+    expanded: CoreScaffold(
+      body: Row(
+        children: [
+          AppDrawer(
+            selectedIndex: selectedIndex,
+            destinations: drawerDestinations,
+            onDestinationSelected: (idx) => {},
+            header: const AppDrawerHeader(
+              name: 'Menu',
+              email: 'MD3 Navigation',
+            ),
+          ),
+          Expanded(child: content('Navigation Drawer (Expanded)')),
+        ],
+      ),
+    ),
+  );
+}
+
+// =============================================================================
+// Adaptive Column Layout
+// =============================================================================
+
+/// Adaptive Column Layout — 1/2/3 columns switching
+@widgetbook.UseCase(name: 'Adaptive Column Layout', type: ResponsiveLayout)
+Widget responsiveLayoutColumns(BuildContext context) {
+  final itemCount = context.knobs.int.slider(
+    label: 'Item Count',
+    initialValue: 6,
+    min: 1,
+    max: 12,
+  );
+
+  Widget buildItem(int index) {
+    return AppCard(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          AppCard(
+            elevation: 0,
+            color: Colors.primaries[index % Colors.primaries.length].withValues(
+              alpha: 0.3,
+            ),
+            shape: AppRadius.xsShape,
+            child: SizedBox(
+              height: 80,
+              child: Center(child: AppLabel.large('Item ${index + 1}')),
+            ),
+          ),
+          const VGap.sm(),
+          AppCaption(text: 'Content card ${index + 1}'),
+        ],
+      ),
+    );
+  }
+
+  final items = List.generate(itemCount, buildItem);
+
+  return SingleChildScrollView(
+    padding: EdgeInsets.all(AppSpacing.md),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ResponsiveBuilder(
+          builder: (ctx, sizeClass) {
+            final columns = switch (sizeClass) {
+              WindowSizeClass.compact => 1,
+              WindowSizeClass.medium => 2,
+              _ => 3,
+            };
+            return AppCard(
+              child: AppBodyText(
+                'Layout: $columns column(s) | '
+                '${sizeClass.name.toUpperCase()}',
+              ),
+            );
+          },
+        ),
+        const VGap.md(),
+        ResponsiveLayout(
+          // 1 column on compact
+          compact: Column(
+            children: items
+                .map(
+                  (item) => Padding(
+                    padding: EdgeInsets.only(bottom: AppSpacing.sm),
+                    child: item,
+                  ),
+                )
+                .toList(),
+          ),
+          // 2 columns on medium
+          medium: Wrap(
+            spacing: AppSpacing.md,
+            runSpacing: AppSpacing.md,
+            children: items
+                .map(
+                  (item) => SizedBox(
+                    width:
+                        (MediaQuery.sizeOf(context).width - AppSpacing.md * 3) /
+                        2,
+                    child: item,
+                  ),
+                )
+                .toList(),
+          ),
+          // 3 columns on expanded
+          expanded: Wrap(
+            spacing: AppSpacing.md,
+            runSpacing: AppSpacing.md,
+            children: items
+                .map(
+                  (item) => SizedBox(
+                    width:
+                        (MediaQuery.sizeOf(context).width - AppSpacing.md * 4) /
+                        3,
+                    child: item,
+                  ),
+                )
+                .toList(),
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+// =============================================================================
+// Responsive Grid
+// =============================================================================
+
+/// Responsive Grid — ResponsiveGridView 2/3/4 columns with knobs
+@widgetbook.UseCase(name: 'Responsive Grid', type: ResponsiveLayout)
+Widget responsiveLayoutGrid(BuildContext context) {
+  final compactCols = context.knobs.int.slider(
+    label: 'Compact Columns',
+    initialValue: 2,
+    min: 1,
+    max: 4,
+  );
+
+  final mediumCols = context.knobs.int.slider(
+    label: 'Medium Columns',
+    initialValue: 3,
+    min: 1,
+    max: 6,
+  );
+
+  final expandedCols = context.knobs.int.slider(
+    label: 'Expanded Columns',
+    initialValue: 4,
+    min: 1,
+    max: 8,
+  );
+
+  final itemCount = context.knobs.int.slider(
+    label: 'Item Count',
+    initialValue: 12,
+    min: 1,
+    max: 24,
+  );
+
+  final spacingValue = context.knobs.double.slider(
+    label: 'Spacing',
+    initialValue: AppSpacing.md,
+    min: 0,
+    max: 32,
+  );
+
+  return Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Padding(
+        padding: EdgeInsets.all(AppSpacing.md),
+        child: ResponsiveBuilder(
+          builder: (ctx, sizeClass) {
+            final columns = switch (sizeClass) {
+              WindowSizeClass.compact => compactCols,
+              WindowSizeClass.medium => mediumCols,
+              _ => expandedCols,
+            };
+            return AppCard(
+              child: AppBodyText(
+                'Grid: $columns columns | '
+                'Spacing: ${spacingValue.toStringAsFixed(0)}dp | '
+                '${sizeClass.name}',
+              ),
+            );
+          },
+        ),
+      ),
+      Expanded(
+        child: ResponsiveGridView(
+          compactColumns: compactCols,
+          mediumColumns: mediumCols,
+          expandedColumns: expandedCols,
+          spacing: spacingValue,
+          padding: EdgeInsets.all(AppSpacing.md),
+          children: List.generate(
+            itemCount,
+            (i) => AppCard(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.grid_view,
+                    size: ResponsiveIconSize.resolve(context),
+                    color: Colors.primaries[i % Colors.primaries.length],
+                  ),
+                  const VGap.xs(),
+                  AppCaption(text: 'Item ${i + 1}'),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    ],
+  );
+}
+
+// =============================================================================
+// Orientation-Aware Layout
+// =============================================================================
+
+/// Orientation-Aware Layout — portrait vs landscape switching
+@widgetbook.UseCase(name: 'Orientation Awareness', type: ResponsiveLayout)
+Widget responsiveLayoutOrientation(BuildContext context) {
+  return AppOrientationBuilder(
+    builder: (ctx, orientation, sizeClass) {
+      final isLand = orientation == Orientation.landscape;
+
+      return SingleChildScrollView(
+        padding: EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            AppCard(
+              child: Row(
+                children: [
+                  Icon(
+                    isLand
+                        ? Icons.stay_current_landscape
+                        : Icons.stay_current_portrait,
+                    size: ResponsiveIconSize.resolve(ctx),
+                  ),
+                  const HGap.md(),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      AppLabel.large(isLand ? 'Landscape' : 'Portrait'),
+                      AppCaption(
+                        text:
+                            'Window: ${sizeClass.name} | '
+                            '${MediaQuery.sizeOf(ctx).width.toStringAsFixed(0)}x'
+                            '${MediaQuery.sizeOf(ctx).height.toStringAsFixed(0)}',
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            const VGap.lg(),
+            if (isLand)
+              // Landscape: side-by-side layout
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: AppCard(
+                      child: Column(
+                        children: [
+                          const AppLabel.large('Left Panel'),
+                          const VGap.sm(),
+                          const AppCaption(
+                            text: 'Landscape mode uses side-by-side panels',
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const HGap.md(),
+                  Expanded(
+                    child: AppCard(
+                      child: Column(
+                        children: [
+                          const AppLabel.large('Right Panel'),
+                          const VGap.sm(),
+                          const AppCaption(
+                            text: 'Content spreads horizontally',
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              )
+            else
+              // Portrait: stacked layout
+              Column(
+                children: [
+                  AppCard(
+                    child: Column(
+                      children: [
+                        const AppLabel.large('Top Section'),
+                        const VGap.sm(),
+                        const AppCaption(
+                          text: 'Portrait mode stacks content vertically',
+                        ),
+                      ],
+                    ),
+                  ),
+                  const VGap.md(),
+                  AppCard(
+                    child: Column(
+                      children: [
+                        const AppLabel.large('Bottom Section'),
+                        const VGap.sm(),
+                        AppCaption(
+                          text: 'Content stacks vertically for readability',
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+          ],
+        ),
+      );
+    },
+  );
+}
+
+// =============================================================================
+// Constrained Width Layout
+// =============================================================================
+
+/// Constrained Width Layout — MaxWidthContainer + PageContainer
+@widgetbook.UseCase(name: 'Content Constraint', type: ResponsiveLayout)
+Widget responsiveLayoutConstrained(BuildContext context) {
+  final containerType = context.knobs.object.dropdown(
+    label: 'Container Type',
+    options: const ['default', 'narrow', 'standard', 'custom'],
+    labelBuilder: (value) => value,
+  );
+
+  final customMaxWidth = context.knobs.double.slider(
+    label: 'Custom Max Width',
+    initialValue: 1000,
+    min: 300,
+    max: 1600,
+  );
+
+  final centerContent = context.knobs.boolean(
+    label: 'Center Content',
+    initialValue: true,
+  );
+
+  Widget content = Builder(
+    builder: (ctx) {
+      final width = MediaQuery.sizeOf(ctx).width;
+      return SingleChildScrollView(
+        padding: EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            AppCard(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const AppLabel.large('Constrained Content'),
+                  const VGap.sm(),
+                  AppCaption(
+                    text: 'Screen width: ${width.toStringAsFixed(0)}dp',
+                  ),
+                  AppCaption(
+                    text:
+                        'Container: $containerType | '
+                        'Centered: $centerContent',
+                  ),
+                ],
+              ),
+            ),
+            const VGap.md(),
+            AppCard(
+              color: Theme.of(
+                ctx,
+              ).colorScheme.primaryContainer.withValues(alpha: 0.5),
+              elevation: 0,
+              shape: AppRadius.smShape,
+              child: const SizedBox(
+                height: 100,
+                child: Center(child: AppBodyText('Fills container width')),
+              ),
+            ),
+            const VGap.md(),
+            Row(
+              children: List.generate(
+                3,
+                (i) => Expanded(
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+                    child: AppCard(
+                      child: Center(child: AppBodyText('Column ${i + 1}')),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+    },
+  );
+
+  switch (containerType) {
+    case 'narrow':
+      return MaxWidthContainer.narrow(center: centerContent, child: content);
+    case 'standard':
+      return MaxWidthContainer.standard(center: centerContent, child: content);
+    case 'custom':
+      return MaxWidthContainer(
+        maxWidth: customMaxWidth,
+        center: centerContent,
+        child: content,
+      );
+    default:
+      return MaxWidthContainer(center: centerContent, child: content);
+  }
+}
+
+// =============================================================================
+// Responsive Typography
+// =============================================================================
+
+/// Responsive Typography — text scaling demo
+@widgetbook.UseCase(name: 'Responsive Typography', type: ResponsiveLayout)
+Widget responsiveLayoutTypography(BuildContext context) {
+  return ResponsiveBuilder(
+    builder: (ctx, sizeClass) {
+      final theme = Theme.of(ctx);
+
+      return SingleChildScrollView(
+        padding: EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            AppCard(
+              child: AppBodyText(
+                'Window: ${sizeClass.name} | '
+                'Width: ${MediaQuery.sizeOf(ctx).width.toStringAsFixed(0)}dp',
+              ),
+            ),
+            const VGap.lg(),
+            Text(
+              'Display Large',
+              style: theme.responsiveTextStyle(
+                ctx,
+                theme.textTheme.displayLarge,
+              ),
+            ),
+            const VGap.md(),
+            Text(
+              'Headline Medium',
+              style: theme.responsiveTextStyle(
+                ctx,
+                theme.textTheme.headlineMedium,
+              ),
+            ),
+            const VGap.md(),
+            Text(
+              'Title Large',
+              style: theme.responsiveTextStyle(ctx, theme.textTheme.titleLarge),
+            ),
+            const VGap.md(),
+            Text(
+              'Body Large — Lorem ipsum dolor sit amet, consectetur '
+              'adipiscing elit. Sed do eiusmod tempor incididunt.',
+              style: theme.responsiveTextStyle(ctx, theme.textTheme.bodyLarge),
+            ),
+            const VGap.md(),
+            Text(
+              'Body Medium — Lorem ipsum dolor sit amet, consectetur '
+              'adipiscing elit.',
+              style: theme.responsiveTextStyle(ctx, theme.textTheme.bodyMedium),
+            ),
+            const VGap.md(),
+            Text(
+              'Label Small',
+              style: theme.responsiveTextStyle(ctx, theme.textTheme.labelSmall),
+            ),
+            const VGap.lg(),
+            // Scale factor info
+            AppCard(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const AppLabel.large('Scale Factors'),
+                  const VGap.sm(),
+                  const AppCaption(
+                    text:
+                        'Compact: 0.9x | Medium: 1.0x | '
+                        'Expanded: 1.0x | Large: 1.1x',
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}
+
+// =============================================================================
+// Helpers (private)
+// =============================================================================
+
+// =============================================================================
+// Helpers (private)
+// =============================================================================
+
+String _navType(WindowSizeClass sizeClass) {
+  return switch (sizeClass) {
+    WindowSizeClass.compact => 'Bottom Bar',
+    WindowSizeClass.medium => 'Navigation Rail',
+    _ => 'Navigation Drawer',
+  };
+}
+
+IconData _sizeClassIcon(WindowSizeClass sizeClass) {
+  return switch (sizeClass) {
+    WindowSizeClass.compact => Icons.smartphone,
+    WindowSizeClass.medium => Icons.tablet,
+    WindowSizeClass.expanded => Icons.tablet_mac,
+    WindowSizeClass.large => Icons.desktop_windows,
+    WindowSizeClass.extraLarge => Icons.tv,
+  };
+}


### PR DESCRIPTION
# Pull Request

## 📄 Summary

Implements responsive layout utilities and M3 breakpoint system for `core_kit`. Adds [ResponsiveLayout](cci:2://file:///c:/Users/USER/hexatune/packages/core_kit/lib/layout/responsive_layout.dart:629:0-675:1), [ResponsiveBuilder](cci:2://file:///c:/Users/USER/hexatune/packages/core_kit/lib/layout/responsive_layout.dart:278:0-346:1), [ResponsiveGridView](cci:2://file:///c:/Users/USER/hexatune/packages/core_kit/lib/layout/responsive_layout.dart:452:0-546:1), [MaxWidthContainer](cci:2://file:///c:/Users/USER/hexatune/packages/core_kit/lib/layout/responsive_layout.dart:931:0-981:1), [AppLayoutGrid](cci:2://file:///c:/Users/USER/hexatune/packages/core_kit/lib/layout/responsive_layout.dart:17:0-50:1), orientation-aware builders, and `BuildContext` extensions. Includes 8 Widgetbook stories and 91 unit tests.

---

## 🧩 Affected Module(s)

- [x] Packages (packages/*)
- [x] Widgetbook Kit (widgetbook_kit/)
- [ ] Documentation (docs/)
- [ ] CI / Infra (.github/)

---

## ✅ Checklist

- [x] My branch name follows format: `feat/responsive-layout-system`
- [x] My PR title starts with one of the approved types listed above
- [x] My Dart code is formatted (dart format . or flutter format .)
- [x] I ran static analysis (flutter analyze) and resolved warnings
- [x] I ran tests successfully (flutter test) — 91 passed
- [x] I updated / checked pubspec.yaml and pubspec.lock for dependency changes
- [x] For UI changes, I added screenshots and/or updated golden tests (if applicable)
- [x] I ensured this PR has no unrelated changes
- [x] This PR is ready for review and does not include unfinished work

---

## 🔗 Related Issues

Closes #152

---

## 💬 Additional Notes 

4 files changed: `core_kit.dart` (export), [responsive_layout.dart](cci:7://file:///c:/Users/USER/hexatune/packages/core_kit/lib/layout/responsive_layout.dart:0:0-0:0) (core system), [responsive_layout_test.dart](cci:7://file:///c:/Users/USER/hexatune/packages/core_kit/test/layout/responsive_layout_test.dart:0:0-0:0) (91 tests), [responsive_layout_stories.dart](cci:7://file:///c:/Users/USER/hexatune/widgetbook_kit/lib/stories/core_kit/layout/responsive_layout_stories.dart:0:0-0:0) (8 Widgetbook stories).